### PR TITLE
fix(approval): lower click risk score to auto-approve, fix keyboard t…

### DIFF
--- a/src/core/approval/__tests__/risk-assessors.test.ts
+++ b/src/core/approval/__tests__/risk-assessors.test.ts
@@ -54,14 +54,14 @@ describe('DomToolRiskAssessor', () => {
     expect(result.action).toBe('auto_approve');
   });
 
-  it('should score click as 25 (low)', () => {
+  it('should score click as 10 (none)', () => {
     const result = assessor.assess('dom_tool', { action: 'click', node_id: '42' });
-    expect(result.score).toBe(25);
-    expect(result.level).toBe(RiskLevel.Low);
+    expect(result.score).toBe(10);
+    expect(result.level).toBe(RiskLevel.None);
     expect(result.action).toBe('auto_approve');
   });
 
-  it('should score click with submit/payment params as 25 (base only, semantic boost handled by enhancer)', () => {
+  it('should score click with submit/payment params as 10 (base only, semantic boost handled by enhancer)', () => {
     const result = assessor.assess('dom_tool', {
       action: 'click',
       node_id: '42',
@@ -69,8 +69,8 @@ describe('DomToolRiskAssessor', () => {
     });
     // DomToolRiskAssessor only scores base action type now;
     // SemanticElementEnhancer handles submit/payment boosting to avoid double-counting
-    expect(result.score).toBe(25);
-    expect(result.level).toBe(RiskLevel.Low);
+    expect(result.score).toBe(10);
+    expect(result.level).toBe(RiskLevel.None);
     expect(result.action).toBe('auto_approve');
   });
 
@@ -79,7 +79,7 @@ describe('DomToolRiskAssessor', () => {
       action: 'click',
       aria_label: 'Purchase now',
     });
-    expect(result.score).toBe(25); // base click score only
+    expect(result.score).toBe(10); // base click score only
   });
 
   it('should score type as 40 (medium)', () => {
@@ -202,9 +202,9 @@ describe('McpBrowserRiskAssessor', () => {
     expect(assessor.assess('browser__scroll', {}).score).toBe(0);
   });
 
-  it('should score click as 25', () => {
+  it('should score click as 10', () => {
     const result = assessor.assess('browser__click', { selector: '#btn' });
-    expect(result.score).toBe(25);
+    expect(result.score).toBe(10);
   });
 
   it('should score click on submit/payment as 70', () => {
@@ -237,6 +237,6 @@ describe('McpBrowserRiskAssessor', () => {
 
   it('should handle non-prefixed tool names', () => {
     const result = assessor.assess('click', {});
-    expect(result.score).toBe(25);
+    expect(result.score).toBe(10);
   });
 });

--- a/src/core/approval/assessors/DomToolRiskAssessor.ts
+++ b/src/core/approval/assessors/DomToolRiskAssessor.ts
@@ -34,7 +34,7 @@ export class DomToolRiskAssessor implements IRiskAssessor {
         break;
 
       case 'click':
-        score = 25;
+        score = 10;
         factors.push('Click action on page element');
         break;
 

--- a/src/core/approval/assessors/McpBrowserRiskAssessor.ts
+++ b/src/core/approval/assessors/McpBrowserRiskAssessor.ts
@@ -56,7 +56,7 @@ export class McpBrowserRiskAssessor implements IRiskAssessor {
       score = mapped.score;
       factors.push(mapped.factor);
     } else if (action === 'click') {
-      score = 25;
+      score = 10;
       factors.push('Click action on page element');
 
       // Check for submit/payment indicators in element metadata only

--- a/src/extension/sidepanel/components/event_display/EventDisplay.svelte
+++ b/src/extension/sidepanel/components/event_display/EventDisplay.svelte
@@ -57,6 +57,11 @@
   }
 
   function handleKeyDown(e: KeyboardEvent) {
+    // Don't intercept keys when user is typing in an input/textarea
+    const target = e.target as HTMLElement;
+    if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+      return;
+    }
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       if (event.collapsible) {


### PR DESCRIPTION
…rap in approval input

Lower base click risk score from 25 to 10 in both DomToolRiskAssessor and McpBrowserRiskAssessor so plain clicks auto-approve in balanced mode without prompting. Semantic boosting for submit/payment clicks still handled by SemanticElementEnhancer. Fix EventDisplay keyboard handler intercepting Enter/Space when user is typing in the approval alternative text input.