### PR TITLE
fix: resolve release workflow failures for all platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,12 +181,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
             librsvg2-dev \
             patchelf \
             libssl-dev \
             libgtk-3-dev \
             libayatana-appindicator3-dev
+
+      - name: Install tauri-cli
+        run: cargo install tauri-cli --version "^2" --locked
 
       - name: Build and upload with tauri-action
         uses: tauri-apps/tauri-action@v0


### PR DESCRIPTION
## Summary
- Remove conflicting `libappindicator3-dev` package on Linux (conflicts with `libayatana-appindicator3-dev`)
- Add `cargo install tauri-cli` step before `tauri-action` — the action expects the CLI to be pre-installed when using `tauriScript: cargo tauri`

## Test plan
- [ ] Merge and create a new release to verify all 3 platform builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)