### PR TITLE
fix: update updater signing public key

### DIFF
--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -64,7 +64,7 @@
       "open": true
     },
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDFFMURDMjEwMUFFMjdEOUEKUldTYWZlSWFFTUlkSGxzcFFrU3g5YkF6SUN2d2ZuUlBNUzI0bDdtdlM0dzZobUhlUkZPQzdwQjkK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDUwNEQyMTEzQzc3OTI0MzEKUldReEpIbkhFeUZOVUZBa01rK0s1RVlvYXVFc0EzNExaK2loUFhhbVR3TGszUUwvcFBkRG84V1cK",
       "endpoints": [
         "https://github.com/The-AI-Republic/browserx/releases/latest/download/latest.json"
       ],


### PR DESCRIPTION
## Summary
- Update updater signing public key to match newly generated password-protected key pair

## Before merging
- [ ] Update `TAURI_SIGNING_PRIVATE_KEY` secret with contents of `~/.tauri/pi.key`
- [ ] Add `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` secret with the key password

🤖 Generated with [Claude Code](https://claude.com/claude-code)