### PR TITLE
fix: set cwd for tauri beforeDevCommand and beforeBuildCommand

### DIFF
--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -4,8 +4,8 @@
   "version": "0.1.0",
   "identifier": "com.airepublic.pi",
   "build": {
-    "beforeBuildCommand": "npm run build:desktop && node scripts/build-sandbox.mjs",
-    "beforeDevCommand": "npm run dev:desktop",
+    "beforeBuildCommand": { "script": "npm run build:desktop && node scripts/build-sandbox.mjs", "cwd": ".." },
+    "beforeDevCommand": { "script": "npm run dev:desktop", "cwd": ".." },
     "devUrl": "http://localhost:5174",
     "frontendDist": "../dist/desktop"
   },


### PR DESCRIPTION
## Summary
- `tauri:dev` npm script does `cd tauri && cargo tauri dev`, so Tauri's `beforeDevCommand` (`npm run dev:desktop`) runs from `tauri/` where there is no `package.json` — causing `Missing script: "dev:desktop"`
- Fix uses the object form with `"cwd": ".."` for both `beforeDevCommand` and `beforeBuildCommand` so they always run from the project root

## Test plan
- [ ] Run `npm run tauri:dev` — Vite dev server starts and Tauri window opens
- [ ] Run `npm run tauri:build` — production build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)