### PR TITLE
fix: create sidecar placeholders before cargo tauri dev

### DIFF
--- a/scripts/ensure-sidecar-placeholder.mjs
+++ b/scripts/ensure-sidecar-placeholder.mjs
@@ -1,0 +1,44 @@
+/**
+ * Ensure a placeholder chrome-devtools-mcp sidecar binary exists so that
+ * `cargo tauri dev` doesn't fail on the missing externalBin entry.
+ *
+ * The real sidecar is built by `npm run build:sidecar` (build-sidecar.mjs)
+ * which is only needed for production builds. During development the MCP
+ * server runs via Node.js directly, so an empty placeholder is sufficient.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+const PLATFORM_MAP = {
+  'win32-x64':    { triple: 'x86_64-pc-windows-msvc',   ext: '.exe' },
+  'darwin-arm64': { triple: 'aarch64-apple-darwin',      ext: '' },
+  'darwin-x64':   { triple: 'x86_64-apple-darwin',       ext: '' },
+  'linux-x64':    { triple: 'x86_64-unknown-linux-gnu',  ext: '' },
+};
+
+const key = `${process.platform}-${process.arch}`;
+const mapping = PLATFORM_MAP[key];
+
+if (!mapping) {
+  console.log(`Unsupported platform for sidecar placeholder: ${key}, skipping.`);
+  process.exit(0);
+}
+
+const binDir = path.join(root, 'tauri', 'binaries');
+fs.mkdirSync(binDir, { recursive: true });
+
+const placeholder = path.join(binDir, `chrome-devtools-mcp-${mapping.triple}${mapping.ext}`);
+if (!fs.existsSync(placeholder)) {
+  fs.writeFileSync(placeholder, '');
+  if (mapping.ext === '') {
+    fs.chmodSync(placeholder, 0o755);
+  }
+  console.log(`Created sidecar placeholder: ${placeholder}`);
+} else {
+  console.log(`Sidecar placeholder already exists: ${placeholder}`);
+}

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "com.airepublic.pi",
   "build": {
     "beforeBuildCommand": { "script": "npm run build:desktop && node scripts/build-sandbox.mjs", "cwd": ".." },
-    "beforeDevCommand": { "script": "npm run dev:desktop", "cwd": ".." },
+    "beforeDevCommand": { "script": "node scripts/build-sandbox.mjs && node scripts/ensure-sidecar-placeholder.mjs && npm run dev:desktop", "cwd": ".." },
     "devUrl": "http://localhost:5174",
     "frontendDist": "../dist/desktop"
   },


### PR DESCRIPTION
## Summary
- `cargo tauri dev` fails on Linux/macOS because Tauri's `externalBin` requires `windows-sandbox` and `chrome-devtools-mcp` binaries to exist at compile time, even on platforms where they're never executed
- `beforeBuildCommand` already ran `build-sandbox.mjs` to create placeholders, but `beforeDevCommand` did not
- Add `build-sandbox.mjs` and a new `ensure-sidecar-placeholder.mjs` (for `chrome-devtools-mcp`) to `beforeDevCommand` so empty placeholders are created before the Rust build

## Test plan
- [ ] Run `npm run tauri:dev` on Linux — cargo compiles and Tauri window opens
- [ ] Run `npm run tauri:dev` on macOS — same result
- [ ] Run `npm run tauri:build` — still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)