### PR TITLE
fix: create sidecar placeholders before cargo tauri dev

### DIFF
--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "com.airepublic.pi",
   "build": {
     "beforeBuildCommand": { "script": "npm run build:desktop && node scripts/build-sandbox.mjs", "cwd": ".." },
-    "beforeDevCommand": { "script": "npm run dev:desktop", "cwd": ".." },
+    "beforeDevCommand": { "script": "node scripts/build-sandbox.mjs && npm run build:sidecar && npm run dev:desktop", "cwd": ".." },
     "devUrl": "http://localhost:5174",
     "frontendDist": "../dist/desktop"
   },


### PR DESCRIPTION
beforeDevCommand was only running vite, but cargo needs the externalBin files (windows-sandbox, chrome-devtools-mcp) to exist at compile time. Run build-sandbox.mjs for the windows-sandbox placeholder on non-Windows, and build:sidecar to build the real chrome-devtools-mcp binary, before starting the dev server.