### PR TITLE
fix: add VITE_VAULT_SECRET to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,11 @@ jobs:
 
       - name: Create extension .env
         run: |
-          cat > src/extension/.env << 'EOF'
+          cat > src/extension/.env << EOF
           VITE_COOKIE_DOMAIN=.airepublic.com
           VITE_HOME_PAGE_BASE_URL=https://airepublic.com
           VITE_BACKEND_API_BASE_URL=https://helper.airepublic.com
+          VITE_VAULT_SECRET=${{ secrets.VITE_VAULT_SECRET }}
           EOF
 
       - name: Build extension


### PR DESCRIPTION
## Summary
- Add `VITE_VAULT_SECRET` from GitHub secrets to the extension build step in the release workflow
- Without this, the extension build fails because `check-env.js` requires `VITE_VAULT_SECRET` (32+ chars) for credential encryption

## Test plan
- [ ] Add `VITE_VAULT_SECRET` as a GitHub Actions secret (Settings > Secrets > Actions)
- [ ] Trigger a release and verify the extension build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)