### PR TITLE
fix: build chrome-devtools-mcp sidecar in release builds

### DIFF
--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "identifier": "com.airepublic.pi",
   "build": {
-    "beforeBuildCommand": { "script": "npm run build:desktop && node scripts/build-sandbox.mjs", "cwd": ".." },
+    "beforeBuildCommand": { "script": "npm run build:desktop && node scripts/build-sandbox.mjs && npm run build:sidecar", "cwd": ".." },
     "beforeDevCommand": { "script": "node scripts/build-sandbox.mjs && npm run build:sidecar && npm run dev:desktop", "cwd": ".." },
     "devUrl": "http://localhost:5174",
     "frontendDist": "../dist/desktop"


### PR DESCRIPTION
## Summary
- The `beforeBuildCommand` in `tauri.conf.json` was missing `npm run build:sidecar`, so the `chrome-devtools-mcp` sidecar binary was never built during release builds
- This caused the Tauri build to fail on all platforms with `resource path 'binaries/chrome-devtools-mcp-<triple>' doesn't exist`
- The `beforeDevCommand` already had this step — it was just missed in the build command

## Test plan
- [ ] Trigger a release build and verify all three platforms (macOS, Windows, Linux) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)