### PR TITLE
fix: create universal-apple-darwin sidecar binaries for macOS bundling

### DIFF
--- a/scripts/build-sandbox.mjs
+++ b/scripts/build-sandbox.mjs
@@ -47,7 +47,7 @@ if (process.platform !== 'win32') {
   const binDir = path.join(root, 'tauri', 'binaries');
   fs.mkdirSync(binDir, { recursive: true });
   const triples = process.platform === 'darwin'
-    ? ['aarch64-apple-darwin', 'x86_64-apple-darwin']
+    ? ['aarch64-apple-darwin', 'x86_64-apple-darwin', 'universal-apple-darwin']
     : [mapping.triple];
   for (const triple of triples) {
     const placeholder = path.join(binDir, `windows-sandbox-${triple}`);

--- a/scripts/build-sidecar.mjs
+++ b/scripts/build-sidecar.mjs
@@ -163,3 +163,15 @@ for (const target of targets) {
   console.log(`\n✓ Sidecar built: ${outputPath}`);
   console.log('  (Launcher extracts chrome-devtools-mcp at runtime and runs it with system Node.js)\n');
 }
+
+// On macOS, create a universal binary via lipo for Tauri's bundler
+// (--target universal-apple-darwin expects a binary named with that triple).
+if (process.platform === 'darwin') {
+  const arm64Bin = path.join(binDir, 'chrome-devtools-mcp-aarch64-apple-darwin');
+  const x64Bin = path.join(binDir, 'chrome-devtools-mcp-x86_64-apple-darwin');
+  const universalBin = path.join(binDir, 'chrome-devtools-mcp-universal-apple-darwin');
+  console.log('Creating universal binary via lipo...');
+  execSync(`lipo -create -output "${universalBin}" "${arm64Bin}" "${x64Bin}"`, { stdio: 'inherit' });
+  fs.chmodSync(universalBin, 0o755);
+  console.log(`✓ Universal sidecar: ${universalBin}`);
+}


### PR DESCRIPTION
## Summary
- Tauri's bundler with `--target universal-apple-darwin` expects sidecars named `*-universal-apple-darwin`, not the individual arch triples
- `build-sandbox.mjs`: add `universal-apple-darwin` to the placeholder list
- `build-sidecar.mjs`: use `lipo` to merge arm64 + x64 binaries into a universal fat binary

## Test plan
- [ ] Merge and re-trigger v0.0.49 release
- [ ] Verify macOS universal build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)