### PR TITLE
fix: type check failure in scheduler test

### DIFF
--- a/src/core/scheduler/__tests__/SchedulerEventCompletion.test.ts
+++ b/src/core/scheduler/__tests__/SchedulerEventCompletion.test.ts
@@ -226,7 +226,7 @@ describe('handleSchedulerEventCompletion (bootstrap pattern)', () => {
     it('should use default message when both error and reason are missing', () => {
       const msg: EventMsg = {
         type: 'TaskFailed',
-        data: {},
+        data: {} as any,
       };
 
       handleSchedulerEventCompletion(state, msg);


### PR DESCRIPTION
## Summary
- Fixes CI Type Check failure introduced by #152 (scheduler PR)
- Adds `as any` cast on intentionally empty `TaskFailedEvent` data in `SchedulerEventCompletion.test.ts` to satisfy the required `reason` field while preserving the defensive code path test

## Test plan
- [ ] CI Type Check job passes
- [ ] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)