### PR TITLE
fix: initialize CredentialStore in ServerAgentBootstrap

### DIFF
--- a/src/server/agent/ServerAgentBootstrap.ts
+++ b/src/server/agent/ServerAgentBootstrap.ts
@@ -107,10 +107,20 @@ export class ServerAgentBootstrap {
 
     try {
       // 0. Initialize StorageProvider (used by subsystems)
-      const { isStorageProviderInitialized, initializeStorageProvider } = await import('@/core/storage');
+      const { isStorageProviderInitialized, initializeStorageProvider, isCredentialStoreInitialized, initializeCredentialStore } = await import('@/core/storage');
       if (!isStorageProviderInitialized()) {
         await initializeStorageProvider();
         console.log('[ServerAgentBootstrap] StorageProvider initialized (SQLite)');
+      }
+
+      // 0b. Initialize credential store (for secure API key storage)
+      if (!isCredentialStoreInitialized()) {
+        try {
+          await initializeCredentialStore();
+          console.log('[ServerAgentBootstrap] CredentialStore initialized (FileCredentialStore)');
+        } catch (error) {
+          console.warn('[ServerAgentBootstrap] CredentialStore initialization failed (non-fatal):', error);
+        }
       }
 
       // 1. Initialize config storage (must happen before AgentConfig)


### PR DESCRIPTION
## Summary
- **ServerAgentBootstrap** was missing `initializeCredentialStore()`, causing `AgentConfig.getCredentials()` to always return `null` in server mode
- API keys could not be stored or retrieved via the credential store, breaking any credential-dependent operations
- Added initialization between StorageProvider and ConfigStorage init, guarded with `isCredentialStoreInitialized()` check and non-fatal try/catch

## Test plan
- [x] Existing CredentialStore tests pass (47/47)
- [ ] Verify server mode can store and retrieve API keys after startup
- [ ] Confirm `AgentConfig.getCredentials()` returns a valid store in server mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)