### PR TITLE
fix: bump express-rate-limit to fix rate-limit bypass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4652,12 +4652,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
+      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -5488,9 +5488,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"


### PR DESCRIPTION
## Summary
- Bumps `express-rate-limit` from `8.2.1` → `8.3.0` (transitive dep via `@modelcontextprotocol/sdk`)
- Fixes Dependabot alert #32: IPv4-mapped IPv6 addresses could bypass per-client rate limiting on dual-stack servers

## Remaining alerts (not fixable now)
- **svelte x4 (moderate):** `@event-calendar/*` v3 bundles svelte v4 internally. Upstream hasn't released a compatible fix. These are SSR-only vulnerabilities — we render client-side, so low actual risk.
- **glib (moderate, Rust):** Transitive Tauri/GTK dependency. Would require a Tauri major version upgrade.

## Test plan
- [ ] Verify `npm audit` no longer reports express-rate-limit vulnerability
- [ ] Verify server mode rate limiting still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)