### PR TITLE
fix: improve side panel layout for narrow widths

### DIFF
--- a/src/webfront/components/MessageInput.svelte
+++ b/src/webfront/components/MessageInput.svelte
@@ -349,17 +349,16 @@
 
 <div class="w-full">
   <!-- Tab Context Display -->
-  <div class="mb-2 flex items-center gap-2">
+  <div class="mb-2 flex flex-wrap items-center gap-2">
     {#if platform.hasTabSelection}
       <!-- Only apply mousedown preventDefault to TabContext area for drag behavior -->
       <div class="contents" onmousedown={(e) => e.preventDefault()}>
         <TabContext {tabId} onTabSelected={handleTabSelected} />
       </div>
     {/if}
-    <ApprovalModeIndicator />
-    <div class="flex-1"></div>
+    <div class="flex-1 min-w-0"></div>
     <!-- Top Right Button Group - NOT inside mousedown preventDefault area -->
-    <div class="flex items-center gap-2">
+    <div class="flex items-center gap-2 shrink-0">
       <ChatHistoryPopup onSelectConversation={onSelectConversation} />
       <Tooltip content={$_t("New Conversation")} placement="left">
         <button
@@ -424,6 +423,7 @@
         <div class="shrink-0">
           <ModelSelection onModelChanged={handleModelChanged} />
         </div>
+        <ApprovalModeIndicator />
 
         <!-- Spacer to push button to the right -->
         <div class="flex-1"></div>

--- a/src/webfront/components/common/TabContext.svelte
+++ b/src/webfront/components/common/TabContext.svelte
@@ -275,11 +275,11 @@
   }
 
   div[data-testid="tab-dropdown-menu"]::-webkit-scrollbar-thumb {
-    background: var(--color-term-dim-green);
+    background: var(--color-bx-border);
     border-radius: 4px;
   }
 
   div[data-testid="tab-dropdown-menu"]::-webkit-scrollbar-thumb:hover {
-    background: var(--color-term-green);
+    background: var(--color-bx-text-secondary);
   }
 </style>


### PR DESCRIPTION
## Summary
- Move ApprovalModeIndicator from the top bar to the input bar, next to ModelSelection, so it doesn't get pushed off-screen by long tab names
- Make the top bar wrap (`flex-wrap`) so chat history and new conversation buttons flow to a second line when the tab selector is too wide
- Use theme-aware scrollbar colors (`--color-bx-border`) for the tab dropdown instead of hardcoded green

## Test plan
- [ ] Open the extension in Chrome side panel with a narrow width
- [ ] Select a tab with a long title and verify chat history / new conversation buttons wrap to a second line
- [ ] Verify ApprovalModeIndicator appears next to the model selector in the input bar
- [ ] Verify tab dropdown scrollbar matches the current theme colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)