### PR TITLE
feat: unified sessionId and ChannelEvent envelope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -373,6 +373,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -413,6 +414,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1525,6 +1527,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
       "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2028,6 +2031,7 @@
       "integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "deepmerge": "^4.3.1",
@@ -2634,6 +2638,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2938,6 +2943,7 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -3031,6 +3037,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3374,6 +3381,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4235,6 +4243,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4613,6 +4622,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5308,6 +5318,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.4.tgz",
       "integrity": "sha512-ooiZW1Xy8rQ4oELQ++otI2T9DsKpV0M6c6cO6JGx4RTfav9poFFLlet9UMXHZnoM1yG0HWGlQLswBGX3RZmHtg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6886,6 +6897,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7992,6 +8004,7 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.7.tgz",
       "integrity": "sha512-uxck1KI7JWtlfP3H6HOWi/94soAl23jsGJkBzN2BAWcQng0+lTrRNhxActFqORgnO9BHVd1hKJhG+ljRuIUWfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -8408,6 +8421,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8521,6 +8535,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -8639,6 +8654,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -8964,6 +8980,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -9062,6 +9079,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/core/RepublicAgent.ts
+++ b/src/core/RepublicAgent.ts
@@ -135,7 +135,7 @@ export class RepublicAgent {
 
     // Create initial TurnContext with the model client
     const taskContext = new TurnContext(modelClient, {
-      sessionId: this.session.conversationId
+      sessionId: this.session.sessionId
     });
 
     // Configure PromptComposer for dynamic system prompt composition
@@ -958,7 +958,7 @@ export class RepublicAgent {
     this.emitEvent({
       type: 'ConversationPath',
       data: {
-        path: this.session.conversationId,
+        path: this.session.sessionId,
         messages_count: conversationHistory.items.length,
       },
     });

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -47,7 +47,7 @@ export type ExecutionState =
  * Session class managing conversation state
  */
 export class Session {
-  readonly conversationId: string;
+  readonly sessionId: string;
   private config?: AgentConfig;
   private sessionState: SessionState; // Pure data state
   private services: SessionServices | null = null; // Service collection
@@ -75,13 +75,13 @@ export class Session {
     toolRegistry?: ToolRegistry,
     initialHistory?: InitialHistory
   ) {
-    // For resumed mode, use the provided conversationId; otherwise generate a new one
-    if (initialHistory?.mode === 'resumed' && initialHistory.conversationId) {
-      this.conversationId = initialHistory.conversationId;
+    // For resumed mode, use the provided sessionId; otherwise generate a new one
+    if (initialHistory?.mode === 'resumed' && initialHistory.sessionId) {
+      this.sessionId = initialHistory.sessionId;
     } else {
-      this.conversationId = uuidv4();
-      if (!this.conversationId) {
-        this.conversationId = crypto.randomUUID();
+      this.sessionId = uuidv4();
+      if (!this.sessionId) {
+        this.sessionId = crypto.randomUUID();
       }
     }
 
@@ -122,7 +122,7 @@ export class Session {
       setReasoningSummary: () => { },
     } as any;
     this.turnContext = new TurnContext(dummyClient, {
-      sessionId: this.conversationId,
+      sessionId: this.sessionId,
       approvalPolicy: 'on-request',
       sandboxPolicy: { mode: 'workspace-write' },
     });
@@ -143,7 +143,7 @@ export class Session {
     // The initialization happens in the background
     if (this.isPersistent && (historyMode.mode === 'new' || historyMode.mode === 'forked')) {
       // Create new rollout
-      this.initializationPromise = this.initializeSession('create', this.conversationId, this.config).then(() => {
+      this.initializationPromise = this.initializeSession('create', this.sessionId, this.config).then(() => {
         // For forked mode, persist the forked history after rollout is created
         if (historyMode.mode === 'forked') {
           const history = this.sessionState.historySnapshot();
@@ -154,7 +154,7 @@ export class Session {
       });
     } else if (this.isPersistent && historyMode.mode === 'resumed') {
       // Resume from existing rollout (note: initializeSession will also reconstruct history)
-      this.initializationPromise = this.initializeSession('resume', this.conversationId, this.config).catch(err => {
+      this.initializationPromise = this.initializeSession('resume', this.sessionId, this.config).catch(err => {
         console.error('Failed to resume session:', err);
       });
     }
@@ -166,12 +166,12 @@ export class Session {
    */
   private async getOrCreateConversation(): Promise<string> {
     if (!this.services?.rollout) {
-      return this.conversationId;
+      return this.sessionId;
     }
 
     // For RolloutRecorder, we don't need to list/find conversations
-    // The conversationId is already set and RolloutRecorder handles persistence
-    return this.conversationId;
+    // The sessionId is already set and RolloutRecorder handles persistence
+    return this.sessionId;
   }
 
   /**
@@ -187,7 +187,7 @@ export class Session {
     const sessionMetaItems: RolloutItem[] = [{
       type: 'session_meta',
       payload: {
-        id: this.conversationId,
+        id: this.sessionId,
         timestamp: new Date().toISOString(),
         ...(tabId > 0 ? { tabId } : {}),
         originator: 'chrome-extension',
@@ -207,8 +207,8 @@ export class Session {
    */
   setTurnContext(context: TurnContext): void {
     // Ensure the turn context has the correct session ID
-    if (context.getSessionId() !== this.conversationId) {
-      context.update({ sessionId: this.conversationId });
+    if (context.getSessionId() !== this.sessionId) {
+      context.update({ sessionId: this.sessionId });
     }
     this.turnContext = context;
   }
@@ -298,7 +298,7 @@ export class Session {
     };
   } {
     return {
-      id: this.conversationId,
+      id: this.sessionId,
       state: this.sessionState.export(),
       metadata: {
         created: this.sessionState.getConversationHistory().metadata?.startTime || Date.now(),
@@ -328,7 +328,7 @@ export class Session {
     session.sessionState = SessionState.import(data.state);
 
     Object.assign(session, {
-      conversationId: data.id,
+      sessionId: data.id,
     });
 
     return session;
@@ -386,7 +386,7 @@ export class Session {
    * Get session ID (conversation ID)
    */
   getSessionId(): string {
-    return this.conversationId;
+    return this.sessionId;
   }
 
   /**
@@ -654,7 +654,7 @@ export class Session {
       // RolloutRecorder might have a getStatistics method or similar
       // For now, we'll return basic info
       rolloutStats = {
-        conversationId: this.conversationId,
+        sessionId: this.sessionId,
         messageCount: this.getMessageCount(),
         hasRollout: true
       };
@@ -686,7 +686,7 @@ export class Session {
     this.clearHistory();
 
     // Create new conversation ID
-    Object.assign(this, { conversationId: uuidv4() });
+    Object.assign(this, { sessionId: uuidv4() });
 
     // Reset tab binding to -1 (unbound)
     // Tab will be auto-bound by UI when side panel reopens
@@ -694,7 +694,7 @@ export class Session {
 
     // Initialize new RolloutRecorder for the new conversation
     if (this.isPersistent) {
-      await this.initializeSession('create', this.conversationId, this.config);
+      await this.initializeSession('create', this.sessionId, this.config);
     }
   }
 
@@ -708,7 +708,7 @@ export class Session {
         const closeEvent: EventMsg = {
           type: 'BackgroundEvent',
           data: {
-            message: `Session closed: ${this.conversationId} (${this.getMessageCount()} messages)`
+            message: `Session closed: ${this.sessionId} (${this.getMessageCount()} messages)`
           }
         };
 
@@ -731,7 +731,7 @@ export class Session {
    * Get session ID (conversation ID)
    */
   getId(): string {
-    return this.conversationId;
+    return this.sessionId;
   }
 
   /**
@@ -903,18 +903,18 @@ export class Session {
    */
   async initializeSession(
     mode: 'create' | 'resume',
-    conversationId: string,
+    sessionId: string,
     config?: AgentConfig
   ): Promise<void> {
     try {
-      const uuid = conversationId;
+      const uuid = sessionId;
 
       if (mode === 'create') {
         // Create new rollout
         const rollout = await RolloutRecorder.create(
           {
             type: 'create',
-            conversationId: uuid,
+            sessionId: uuid,
           },
           config as any
         );

--- a/src/core/__tests__/RepublicAgent.test.ts
+++ b/src/core/__tests__/RepublicAgent.test.ts
@@ -142,7 +142,7 @@ describe('RepublicAgent', () => {
 
     // Recreate shared mock instances before each test
     mockSessionInstance = {
-      conversationId: 'conv-123',
+      sessionId: 'conv-123',
       setEventEmitter: vi.fn(),
       setTurnContext: vi.fn(),
       getTurnContext: vi.fn().mockReturnValue({
@@ -250,7 +250,7 @@ describe('RepublicAgent', () => {
     it('should expose the session via getSession()', () => {
       const session = agent.getSession();
       expect(session).toBeDefined();
-      expect(session.conversationId).toBe('conv-123');
+      expect(session.sessionId).toBe('conv-123');
     });
 
     it('should expose the tool registry via getToolRegistry()', () => {

--- a/src/core/__tests__/Session.test.ts
+++ b/src/core/__tests__/Session.test.ts
@@ -2,7 +2,7 @@
  * Unit Tests: Session
  *
  * Comprehensive tests for the Session class covering:
- * - Constructor (old/new signatures, isPersistent, conversationId)
+ * - Constructor (old/new signatures, isPersistent, sessionId)
  * - initialize()
  * - addToHistory() / getConversationHistory() / clearHistory()
  * - export() / import()
@@ -125,38 +125,38 @@ describe('Session', () => {
   // Constructor
   // =========================================================================
   describe('Constructor', () => {
-    it('should generate a unique conversationId', () => {
+    it('should generate a unique sessionId', () => {
       const session = new Session(undefined, false);
-      expect(session.conversationId).toBe('test-uuid-1');
+      expect(session.sessionId).toBe('test-uuid-1');
     });
 
     it('should accept old boolean-only signature for backward compatibility', () => {
       const session = new Session(false);
       // isPersistent should be false
-      expect(session.conversationId).toBeTruthy();
+      expect(session.sessionId).toBeTruthy();
     });
 
     it('should default isPersistent to true when no arguments', () => {
       // We can verify by checking that initializeSession is called (persistent path)
-      // Just verify construction succeeds and conversationId is set
+      // Just verify construction succeeds and sessionId is set
       const session = new Session();
-      expect(session.conversationId).toBeTruthy();
+      expect(session.sessionId).toBeTruthy();
     });
 
-    it('should use provided conversationId for resumed mode', () => {
+    it('should use provided sessionId for resumed mode', () => {
       const session = new Session(undefined, false, undefined, undefined, {
         mode: 'resumed',
-        conversationId: 'my-custom-id',
+        sessionId: 'my-custom-id',
         rolloutItems: [],
       });
-      expect(session.conversationId).toBe('my-custom-id');
+      expect(session.sessionId).toBe('my-custom-id');
     });
 
-    it('should generate new conversationId for new mode', () => {
+    it('should generate new sessionId for new mode', () => {
       const session = new Session(undefined, false, undefined, undefined, {
         mode: 'new',
       });
-      expect(session.conversationId).toBe('test-uuid-1');
+      expect(session.sessionId).toBe('test-uuid-1');
     });
 
     it('should set tabId to -1 initially', () => {
@@ -407,7 +407,7 @@ describe('Session', () => {
 
       const exported = session.export();
 
-      expect(exported.id).toBe(session.conversationId);
+      expect(exported.id).toBe(session.sessionId);
       expect(exported.state).toBeDefined();
       expect(exported.state.history).toBeDefined();
       expect(exported.state.history.items).toHaveLength(1);
@@ -430,14 +430,14 @@ describe('Session', () => {
       expect((history.items[1] as any).role).toBe('assistant');
     });
 
-    it('should preserve conversationId through import', async () => {
+    it('should preserve sessionId through import', async () => {
       const session = new Session(undefined, false);
-      const originalId = session.conversationId;
+      const originalId = session.sessionId;
 
       const exported = session.export();
       const imported = Session.import(exported);
 
-      expect(imported.conversationId).toBe(originalId);
+      expect(imported.sessionId).toBe(originalId);
     });
 
     it('should accept optional services and toolRegistry in import', () => {
@@ -925,14 +925,14 @@ describe('Session', () => {
   // Session ID accessors
   // =========================================================================
   describe('Session ID accessors', () => {
-    it('getSessionId() should return conversationId', () => {
+    it('getSessionId() should return sessionId', () => {
       const session = new Session(undefined, false);
-      expect(session.getSessionId()).toBe(session.conversationId);
+      expect(session.getSessionId()).toBe(session.sessionId);
     });
 
-    it('getId() should return conversationId', () => {
+    it('getId() should return sessionId', () => {
       const session = new Session(undefined, false);
-      expect(session.getId()).toBe(session.conversationId);
+      expect(session.getId()).toBe(session.sessionId);
     });
   });
 
@@ -959,12 +959,12 @@ describe('Session', () => {
       expect(session.getTurnContext()).toBe(newContext);
     });
 
-    it('setTurnContext should align the context sessionId to conversationId', () => {
+    it('setTurnContext should align the context sessionId to sessionId', () => {
       const newContext = makeMockTurnContext();
-      // The mock context has sessionId 'test-session', which differs from the session's conversationId
+      // The mock context has sessionId 'test-session', which differs from the session's sessionId
       session.setTurnContext(newContext);
 
-      expect(newContext.getSessionId()).toBe(session.conversationId);
+      expect(newContext.getSessionId()).toBe(session.sessionId);
     });
 
     it('should allow updating turn context', () => {

--- a/src/core/__tests__/azure-workaround.integration.test.ts
+++ b/src/core/__tests__/azure-workaround.integration.test.ts
@@ -61,7 +61,7 @@ describe('Edge Case: Azure Endpoint Detection', () => {
     const azureClient = new TestableOpenAIResponsesClient({
       apiKey: 'test-key',
       baseUrl: 'https://my-resource.openai.azure.com',
-      conversationId: 'test-conv-1',
+      sessionId: 'test-conv-1',
       modelFamily: createModelFamily(),
       provider: createProvider({
         base_url: 'https://my-resource.openai.azure.com',
@@ -78,7 +78,7 @@ describe('Edge Case: Azure Endpoint Detection', () => {
     const client = new TestableOpenAIResponsesClient({
       apiKey: 'test-key',
       baseUrl: 'https://api.openai.com/v1',
-      conversationId: 'test-conv-2',
+      sessionId: 'test-conv-2',
       modelFamily: createModelFamily(),
       provider: createProvider({
         base_url: 'https://api.openai.com/v1',
@@ -103,7 +103,7 @@ describe('Edge Case: Azure Endpoint Detection', () => {
       const azureClient = new TestableOpenAIResponsesClient({
         apiKey: 'test-key',
         baseUrl,
-        conversationId: 'test-conv-3',
+        sessionId: 'test-conv-3',
         modelFamily: createModelFamily(),
         provider: createProvider({
           base_url: baseUrl,
@@ -121,7 +121,7 @@ describe('Edge Case: Azure Endpoint Detection', () => {
     const azureClient = new TestableOpenAIResponsesClient({
       baseUrl: 'https://my-resource.openai.azure.com',
       apiKey: 'test-key',
-      conversationId: 'test-conv-4',
+      sessionId: 'test-conv-4',
       modelFamily: createModelFamily(),
       provider: createProvider({
         base_url: 'https://my-resource.openai.azure.com',
@@ -142,7 +142,7 @@ describe('Edge Case: Azure Endpoint Detection', () => {
     const azureClient = new TestableOpenAIResponsesClient({
       apiKey: 'test-key',
       baseUrl: 'https://my-resource.openai.azure.com',
-      conversationId: 'test-conv-5',
+      sessionId: 'test-conv-5',
       modelFamily: createModelFamily(),
       provider: createProvider({
         base_url: 'https://my-resource.openai.azure.com',
@@ -160,7 +160,7 @@ describe('Edge Case: Azure Endpoint Detection', () => {
     const client = new TestableOpenAIResponsesClient({
       apiKey: 'test-key',
       baseUrl: 'https://api.example.com/azure-proxy',
-      conversationId: 'test-conv-6',
+      sessionId: 'test-conv-6',
       modelFamily: createModelFamily(),
       provider: createProvider({
         base_url: 'https://api.example.com/azure-proxy',
@@ -177,7 +177,7 @@ describe('Edge Case: Azure Endpoint Detection', () => {
     const azureClient = new TestableOpenAIResponsesClient({
       apiKey: 'test-key',
       baseUrl: 'https://my-resource.openai.azure.com',
-      conversationId: 'test-conv-7',
+      sessionId: 'test-conv-7',
       modelFamily: createModelFamily({
         supports_reasoning: true,
         supports_reasoning_summaries: true,

--- a/src/core/__tests__/invalid-api-key.integration.test.ts
+++ b/src/core/__tests__/invalid-api-key.integration.test.ts
@@ -70,7 +70,7 @@ describe('Edge Case: Invalid API Key', () => {
   it('should throw on 401 without retry (FR-033)', async () => {
     const client = new TestableOpenAIResponsesClient({
       apiKey: 'invalid-key',
-      conversationId: 'test-conv-1',
+      sessionId: 'test-conv-1',
       modelFamily: createModelFamily(),
       provider: createProvider(),
     });
@@ -108,7 +108,7 @@ describe('Edge Case: Invalid API Key', () => {
   it('should not retry on 403 forbidden error', async () => {
     const client = new TestableOpenAIResponsesClient({
       apiKey: 'api-key-without-permissions',
-      conversationId: 'test-conv-2',
+      sessionId: 'test-conv-2',
       modelFamily: createModelFamily(),
       provider: createProvider(),
     });
@@ -133,7 +133,7 @@ describe('Edge Case: Invalid API Key', () => {
   it('should retry on 429 rate limit error', async () => {
     const client = new TestableOpenAIResponsesClient({
       apiKey: 'valid-key',
-      conversationId: 'test-conv-3',
+      sessionId: 'test-conv-3',
       modelFamily: createModelFamily(),
       provider: createProvider(),
     });
@@ -174,7 +174,7 @@ describe('Edge Case: Invalid API Key', () => {
   it('should match quickstart edge case 1 example', async () => {
     const client = new TestableOpenAIResponsesClient({
       apiKey: 'invalid-key',
-      conversationId: 'test-conv-4',
+      sessionId: 'test-conv-4',
       modelFamily: createModelFamily(),
       provider: createProvider(),
     });

--- a/src/core/__tests__/missing-headers.integration.test.ts
+++ b/src/core/__tests__/missing-headers.integration.test.ts
@@ -44,7 +44,7 @@ describe('Edge Case: Missing Rate Limit Headers', () => {
   beforeEach(() => {
     client = new TestableOpenAIResponsesClient({
       apiKey: 'test-key',
-      conversationId: 'test-conv-1',
+      sessionId: 'test-conv-1',
       modelFamily: createModelFamily(),
       provider: createProvider(),
     });

--- a/src/core/__tests__/response-failed.integration.test.ts
+++ b/src/core/__tests__/response-failed.integration.test.ts
@@ -19,7 +19,7 @@ describe('Edge Case: response.failed SSE Event', () => {
   beforeEach(() => {
     client = new OpenAIResponsesClient({
       apiKey: 'test-key',
-      conversationId: 'test',
+      sessionId: 'test',
       modelFamily: {
         family: 'gpt-4',
         base_instructions: '',

--- a/src/core/channels/ChannelAdapter.ts
+++ b/src/core/channels/ChannelAdapter.ts
@@ -7,8 +7,7 @@
  * @module core/channels/ChannelAdapter
  */
 
-import type { EventMsg } from '@/core/protocol/types';
-import type { ChannelType, ChannelCapabilities, SubmissionHandler } from './types';
+import type { ChannelType, ChannelCapabilities, SubmissionHandler, ChannelEvent } from './types';
 
 /**
  * Channel Adapter Interface
@@ -99,7 +98,7 @@ export interface ChannelAdapter {
    * @param event - Event message to send
    * @param targetClientId - Optional specific client (for multi-client channels)
    */
-  sendEvent(event: EventMsg, targetClientId?: string): Promise<void>;
+  sendEvent(event: ChannelEvent, targetClientId?: string): Promise<void>;
 
   // ─────────────────────────────────────────────────────────────────────────
   // Capabilities

--- a/src/core/channels/ChannelManager.ts
+++ b/src/core/channels/ChannelManager.ts
@@ -7,9 +7,9 @@
  * @module core/channels/ChannelManager
  */
 
-import type { Op, EventMsg } from '@/core/protocol/types';
+import type { Op } from '@/core/protocol/types';
 import type { ChannelAdapter } from './ChannelAdapter';
-import type { SubmissionContext, ChannelInfo } from './types';
+import type { SubmissionContext, ChannelInfo, ChannelEvent } from './types';
 import { ServiceRegistry } from './ServiceRegistry';
 
 /**
@@ -102,7 +102,7 @@ export class ChannelManager {
    * @param channelId - Target channel ID
    * @param clientId - Optional specific client within the channel
    */
-  async dispatchEvent(event: EventMsg, channelId: string, clientId?: string): Promise<void> {
+  async dispatchEvent(event: ChannelEvent, channelId: string, clientId?: string): Promise<void> {
     const channel = this.channels.get(channelId);
     if (channel) {
       await channel.sendEvent(event, clientId);
@@ -116,7 +116,7 @@ export class ChannelManager {
    *
    * @param event - Event to broadcast
    */
-  async broadcastEvent(event: EventMsg): Promise<void> {
+  async broadcastEvent(event: ChannelEvent): Promise<void> {
     const promises = Array.from(this.channels.values()).map((channel) =>
       channel.sendEvent(event).catch((error) => {
         console.error(`Failed to send event to ${channel.channelId}:`, error);
@@ -175,13 +175,16 @@ export class ChannelManager {
       console.log(`[ChannelManager] ServiceRequest ${op.service} succeeded, sending response`);
       await channel.sendEvent(
         {
-          type: 'ServiceResponse',
-          data: {
-            requestId: op.requestId,
-            service: op.service,
-            success: true,
-            data: result,
+          msg: {
+            type: 'ServiceResponse',
+            data: {
+              requestId: op.requestId,
+              service: op.service,
+              success: true,
+              data: result,
+            },
           },
+          sessionId: context.sessionId,
         },
         context.userId
       );
@@ -189,13 +192,16 @@ export class ChannelManager {
       try {
         await channel.sendEvent(
           {
-            type: 'ServiceResponse',
-            data: {
-              requestId: op.requestId,
-              service: op.service,
-              success: false,
-              error: error instanceof Error ? error.message : String(error),
+            msg: {
+              type: 'ServiceResponse',
+              data: {
+                requestId: op.requestId,
+                service: op.service,
+                success: false,
+                error: error instanceof Error ? error.message : String(error),
+              },
             },
+            sessionId: context.sessionId,
           },
           context.userId
         );

--- a/src/core/channels/__tests__/ChannelManager.test.ts
+++ b/src/core/channels/__tests__/ChannelManager.test.ts
@@ -8,8 +8,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ChannelManager, getChannelManager } from '../ChannelManager';
 import type { ChannelAdapter } from '../ChannelAdapter';
-import type { Op, EventMsg } from '@/core/protocol/types';
-import type { SubmissionContext } from '../types';
+import type { Op } from '@/core/protocol/types';
+import type { SubmissionContext, ChannelEvent } from '../types';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -27,8 +27,8 @@ function createMockChannel(id: string, type: string = 'test'): ChannelAdapter {
   } as any;
 }
 
-function makeEvent(label: string): EventMsg {
-  return { type: 'AgentMessage', data: { message: label } } as any;
+function makeEvent(label: string): ChannelEvent {
+  return { msg: { type: 'AgentMessage', data: { message: label } } as any };
 }
 
 function makeOp(): Op {

--- a/src/core/channels/types.ts
+++ b/src/core/channels/types.ts
@@ -10,6 +10,18 @@ import type { Op } from '@/core/protocol/types';
 import type { EventMsg } from '@/core/protocol/events';
 
 /**
+ * Event envelope for channel transport.
+ * Wraps EventMsg with routing metadata (sessionId, etc.).
+ * EventMsg stays pure protocol; ChannelEvent adds transport concerns.
+ */
+export interface ChannelEvent {
+  /** The protocol event payload */
+  msg: EventMsg;
+  /** Session that produced this event (for multi-session routing) */
+  sessionId?: string;
+}
+
+/**
  * Channel type discriminator
  */
 export type ChannelType =
@@ -50,7 +62,7 @@ export interface SubmissionContext {
   /** Browser tab ID (extension mode) */
   tabId?: number;
   /** Direct reply function (messaging channels) */
-  replyCallback?: (event: EventMsg) => Promise<void>;
+  replyCallback?: (event: ChannelEvent) => Promise<void>;
 }
 
 /**
@@ -71,7 +83,7 @@ export interface ChannelAdapter {
   readonly channelType: ChannelType;
   initialize(): Promise<void>;
   onSubmission(handler: SubmissionHandler | ((...args: any[]) => Promise<void>)): void;
-  sendEvent(event: EventMsg, targetClientId?: string): Promise<void>;
+  sendEvent(event: ChannelEvent, targetClientId?: string): Promise<void>;
   getConnectionState(): ConnectionState;
   close(): Promise<void>;
 }

--- a/src/core/messaging/UIChannelClient.ts
+++ b/src/core/messaging/UIChannelClient.ts
@@ -12,6 +12,7 @@
 
 import type { Op } from '@/core/protocol/types';
 import type { EventMsg } from '@/core/protocol/events';
+import type { ChannelEvent } from '@/core/channels/types';
 import type { UIChannelTransport } from './transports/types';
 
 const SERVICE_REQUEST_TIMEOUT_MS = 30_000;
@@ -53,8 +54,8 @@ export class UIChannelClient {
     await this.transport.initialize();
 
     // Listen for all events from the transport
-    this.unlistenTransport = this.transport.onEvent((event: EventMsg) => {
-      this.handleEvent(event);
+    this.unlistenTransport = this.transport.onEvent((channelEvent: ChannelEvent) => {
+      this.handleChannelEvent(channelEvent);
     });
 
     this.initialized = true;
@@ -160,9 +161,11 @@ export class UIChannelClient {
   }
 
   /**
-   * Handle an incoming event from the transport
+   * Handle an incoming ChannelEvent from the transport
    */
-  private handleEvent(event: EventMsg): void {
+  private handleChannelEvent(channelEvent: ChannelEvent): void {
+    const event = channelEvent.msg;
+
     // Check if this is a ServiceResponse that matches a pending request
     if (event.type === 'ServiceResponse') {
       const data = (event as any).data as {
@@ -187,7 +190,7 @@ export class UIChannelClient {
       }
     }
 
-    // Dispatch to event handlers
+    // Dispatch to event handlers (pass full ChannelEvent so handlers can access sessionId)
     const handlers = this.eventHandlers.get(event.type);
     if (handlers) {
       const eventData = 'data' in event ? (event as any).data : undefined;
@@ -200,12 +203,12 @@ export class UIChannelClient {
       }
     }
 
-    // Also dispatch to wildcard handlers
+    // Also dispatch to wildcard handlers (pass full ChannelEvent)
     const wildcardHandlers = this.eventHandlers.get('*');
     if (wildcardHandlers) {
       for (const handler of wildcardHandlers) {
         try {
-          handler(event);
+          handler(channelEvent);
         } catch (err) {
           console.error('[UIChannelClient] Wildcard event handler threw:', err);
         }

--- a/src/core/messaging/__tests__/UIChannelClient.e2e.test.ts
+++ b/src/core/messaging/__tests__/UIChannelClient.e2e.test.ts
@@ -11,13 +11,14 @@ import { UIChannelClient } from '../UIChannelClient';
 import type { UIChannelTransport } from '../transports/types';
 import type { Op } from '@/core/protocol/types';
 import type { EventMsg } from '@/core/protocol/events';
+import type { ChannelEvent } from '@/core/channels/types';
 
 // ---------------------------------------------------------------------------
 // In-memory transport that simulates backend service handling
 // ---------------------------------------------------------------------------
 
 class InMemoryTransport implements UIChannelTransport {
-  private eventListeners: Array<(event: EventMsg) => void> = [];
+  private eventListeners: Array<(event: ChannelEvent) => void> = [];
   private serviceHandlers = new Map<string, (params: Record<string, unknown>) => unknown>();
 
   /** Register a mock service handler (simulates ServiceRegistry) */
@@ -55,13 +56,13 @@ class InMemoryTransport implements UIChannelTransport {
         }
 
         for (const listener of this.eventListeners) {
-          listener(responseEvent);
+          listener({ msg: responseEvent });
         }
       });
     }
   }
 
-  onEvent(handler: (event: EventMsg) => void): () => void {
+  onEvent(handler: (event: ChannelEvent) => void): () => void {
     this.eventListeners.push(handler);
     return () => {
       this.eventListeners = this.eventListeners.filter((h) => h !== handler);
@@ -153,7 +154,7 @@ describe('UIChannelClient end-to-end', () => {
     } as EventMsg;
 
     // Access transport's event dispatch (via sendOp won't work for events, simulate directly)
-    (transport as any).eventListeners.forEach((listener: any) => listener(stateEvent));
+    (transport as any).eventListeners.forEach((listener: any) => listener({ msg: stateEvent }));
 
     expect(handler).toHaveBeenCalledWith({ sessionId: 'sess-1', tabId: 42 });
   });

--- a/src/core/messaging/__tests__/UIChannelClient.test.ts
+++ b/src/core/messaging/__tests__/UIChannelClient.test.ts
@@ -3,24 +3,25 @@ import { UIChannelClient } from '../UIChannelClient';
 import type { UIChannelTransport } from '../transports/types';
 import type { Op } from '@/core/protocol/types';
 import type { EventMsg } from '@/core/protocol/events';
+import type { ChannelEvent } from '@/core/channels/types';
 
 // ---------------------------------------------------------------------------
 // Mock Transport
 // ---------------------------------------------------------------------------
 
 function createMockTransport(): UIChannelTransport & {
-  _handlers: Array<(event: EventMsg) => void>;
+  _handlers: Array<(event: ChannelEvent) => void>;
   _simulateEvent(event: EventMsg): void;
 } {
-  const handlers: Array<(event: EventMsg) => void> = [];
+  const handlers: Array<(event: ChannelEvent) => void> = [];
 
   return {
     _handlers: handlers,
     _simulateEvent(event: EventMsg) {
-      for (const h of handlers) h(event);
+      for (const h of handlers) h({ msg: event });
     },
     sendOp: vi.fn().mockResolvedValue(undefined),
-    onEvent: vi.fn((handler: (event: EventMsg) => void) => {
+    onEvent: vi.fn((handler: (event: ChannelEvent) => void) => {
       handlers.push(handler);
       return () => {
         const idx = handlers.indexOf(handler);

--- a/src/core/messaging/transports/ChromeExtensionTransport.ts
+++ b/src/core/messaging/transports/ChromeExtensionTransport.ts
@@ -9,10 +9,11 @@
 
 import type { Op } from '@/core/protocol/types';
 import type { EventMsg } from '@/core/protocol/events';
+import type { ChannelEvent } from '@/core/channels/types';
 import type { UIChannelTransport } from './types';
 
 export class ChromeExtensionTransport implements UIChannelTransport {
-  private listeners = new Set<(event: EventMsg) => void>();
+  private listeners = new Set<(event: ChannelEvent) => void>();
   private messageListener: ((message: any) => void) | null = null;
 
   async sendOp(op: Op, context?: Record<string, unknown>): Promise<void> {
@@ -27,7 +28,7 @@ export class ChromeExtensionTransport implements UIChannelTransport {
     }
   }
 
-  onEvent(handler: (event: EventMsg) => void): () => void {
+  onEvent(handler: (event: ChannelEvent) => void): () => void {
     this.listeners.add(handler);
     return () => {
       this.listeners.delete(handler);
@@ -37,21 +38,21 @@ export class ChromeExtensionTransport implements UIChannelTransport {
   async initialize(): Promise<void> {
     // Set up the chrome.runtime.onMessage listener to filter for events
     this.messageListener = (message: any) => {
-      let eventMsg: EventMsg | null = null;
+      let channelEvent: ChannelEvent | null = null;
 
-      // SidePanelChannel format: { type: 'event', event: EventMsg }
+      // SidePanelChannel format: { type: 'event', event: EventMsg, sessionId?: string }
       if (message?.type === 'event' && message.event) {
-        eventMsg = message.event as EventMsg;
+        channelEvent = { msg: message.event as EventMsg, sessionId: message.sessionId };
       }
       // Legacy event format: { type: 'EVENT', payload: { msg: EventMsg } }
       else if (message?.type === 'EVENT' && message.payload?.msg) {
-        eventMsg = message.payload.msg as EventMsg;
+        channelEvent = { msg: message.payload.msg as EventMsg };
       }
 
-      if (eventMsg) {
+      if (channelEvent) {
         for (const handler of this.listeners) {
           try {
-            handler(eventMsg);
+            handler(channelEvent);
           } catch (err) {
             console.error('[ChromeExtensionTransport] Event handler threw:', err);
           }

--- a/src/core/messaging/transports/TauriTransport.ts
+++ b/src/core/messaging/transports/TauriTransport.ts
@@ -9,10 +9,11 @@
 
 import type { Op } from '@/core/protocol/types';
 import type { EventMsg } from '@/core/protocol/events';
+import type { ChannelEvent } from '@/core/channels/types';
 import type { UIChannelTransport } from './types';
 
 export class TauriTransport implements UIChannelTransport {
-  private listeners: Array<(event: EventMsg) => void> = [];
+  private listeners: Array<(event: ChannelEvent) => void> = [];
   private unlistenFn: (() => void) | null = null;
   private emit: ((event: string, payload?: unknown) => Promise<void>) | null = null;
 
@@ -25,7 +26,7 @@ export class TauriTransport implements UIChannelTransport {
     console.log('[TauriTransport] sendOp emitted successfully');
   }
 
-  onEvent(handler: (event: EventMsg) => void): () => void {
+  onEvent(handler: (event: ChannelEvent) => void): () => void {
     this.listeners.push(handler);
     return () => {
       this.listeners = this.listeners.filter((h) => h !== handler);
@@ -40,19 +41,24 @@ export class TauriTransport implements UIChannelTransport {
 
     // Listen for events from the agent
     this.unlistenFn = await listen('pi:event', (event: { payload: unknown }) => {
-      const payload = event.payload as { msg?: EventMsg } | EventMsg;
+      const payload = event.payload as { msg?: EventMsg; sessionId?: string } | EventMsg;
       console.log('[TauriTransport] Received pi:event, payload type:', typeof payload, 'keys:', payload && typeof payload === 'object' ? Object.keys(payload).join(',') : 'n/a');
 
-      // Handle both wrapped { msg: EventMsg } and direct EventMsg formats
-      const eventMsg = ('msg' in payload && payload.msg) ? payload.msg : payload as EventMsg;
-
-      if (eventMsg && typeof eventMsg === 'object' && 'type' in eventMsg) {
-        console.log('[TauriTransport] Dispatching event:', (eventMsg as any).type);
-        for (const handler of this.listeners) {
-          handler(eventMsg);
-        }
+      // Handle both ChannelEvent { msg, sessionId } and direct EventMsg formats
+      let channelEvent: ChannelEvent;
+      if (payload && typeof payload === 'object' && 'msg' in payload && payload.msg) {
+        channelEvent = payload as ChannelEvent;
+      } else if (payload && typeof payload === 'object' && 'type' in payload) {
+        // Legacy: bare EventMsg without envelope
+        channelEvent = { msg: payload as EventMsg };
       } else {
         console.warn('[TauriTransport] Received pi:event but could not extract EventMsg:', JSON.stringify(payload).slice(0, 200));
+        return;
+      }
+
+      console.log('[TauriTransport] Dispatching event:', channelEvent.msg.type, 'sessionId:', channelEvent.sessionId);
+      for (const handler of this.listeners) {
+        handler(channelEvent);
       }
     });
     console.log('[TauriTransport] Initialized, listening on pi:event');

--- a/src/core/messaging/transports/WebSocketTransport.ts
+++ b/src/core/messaging/transports/WebSocketTransport.ts
@@ -8,6 +8,7 @@
 
 import type { Op } from '@/core/protocol/types';
 import type { EventMsg } from '@/core/protocol/events';
+import type { ChannelEvent } from '@/core/channels/types';
 import type { UIChannelTransport } from './types';
 
 export interface WebSocketTransportConfig {
@@ -16,7 +17,7 @@ export interface WebSocketTransportConfig {
 
 export class WebSocketTransport implements UIChannelTransport {
   private ws: WebSocket | null = null;
-  private listeners = new Set<(event: EventMsg) => void>();
+  private listeners = new Set<(event: ChannelEvent) => void>();
   private config: WebSocketTransportConfig;
 
   constructor(config: WebSocketTransportConfig) {
@@ -34,7 +35,7 @@ export class WebSocketTransport implements UIChannelTransport {
     }));
   }
 
-  onEvent(handler: (event: EventMsg) => void): () => void {
+  onEvent(handler: (event: ChannelEvent) => void): () => void {
     this.listeners.add(handler);
     return () => {
       this.listeners.delete(handler);
@@ -64,10 +65,13 @@ export class WebSocketTransport implements UIChannelTransport {
 
           // Handle event frames from the server
           if (data.type === 'event' && data.payload?.msg) {
-            const eventMsg = data.payload.msg as EventMsg;
+            const channelEvent: ChannelEvent = {
+              msg: data.payload.msg as EventMsg,
+              sessionId: data.payload.sessionId,
+            };
             for (const handler of this.listeners) {
               try {
-                handler(eventMsg);
+                handler(channelEvent);
               } catch (err) {
                 console.error('[WebSocketTransport] Event handler threw:', err);
               }

--- a/src/core/messaging/transports/types.ts
+++ b/src/core/messaging/transports/types.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Op } from '@/core/protocol/types';
-import type { EventMsg } from '@/core/protocol/events';
+import type { ChannelEvent } from '@/core/channels/types';
 
 /**
  * Transport interface for UIChannelClient.
@@ -19,7 +19,7 @@ export interface UIChannelTransport {
   sendOp(op: Op, context?: Record<string, unknown>): Promise<void>;
 
   /** Register a handler for incoming events. Returns an unlisten function. */
-  onEvent(handler: (event: EventMsg) => void): () => void;
+  onEvent(handler: (event: ChannelEvent) => void): () => void;
 
   /** Initialize the transport (establish connections, etc.) */
   initialize(): Promise<void>;

--- a/src/core/models/ModelClientFactory.ts
+++ b/src/core/models/ModelClientFactory.ts
@@ -240,7 +240,7 @@ export class ModelClientFactory {
     };
 
     // Generate conversation ID
-    const conversationId = this.generateConversationId();
+    const sessionId = this.generateConversationId();
 
     // Get reasoning effort if supported
     let reasoningEffort: string | undefined;
@@ -279,7 +279,7 @@ export class ModelClientFactory {
       return new OpenAIResponsesClient({
         apiKey,
         baseUrl: openAIClientBackendBaseUrl,
-        conversationId,
+        sessionId,
         modelFamily,
         provider: backendProvider,
         modelConfig,
@@ -293,7 +293,7 @@ export class ModelClientFactory {
     return new OpenAIChatCompletionClient({
       apiKey,
       baseUrl: openAIClientBackendBaseUrl,
-      conversationId,
+      sessionId,
       modelFamily,
       provider: backendProvider,
       modelConfig,
@@ -609,7 +609,7 @@ export class ModelClientFactory {
     };
 
     // Generate a conversation ID for prompt_cache_key usage
-    const conversationId = this.generateConversationId();
+    const sessionId = this.generateConversationId();
 
     // Get reasoning effort from model config
     // Default to 'medium' for models that support reasoning
@@ -626,7 +626,7 @@ export class ModelClientFactory {
           apiKey: config.apiKey,
           baseUrl: resolvedBaseUrl,
           organization,
-          conversationId,
+          sessionId,
           modelFamily,
           provider,
           modelConfig,
@@ -637,7 +637,7 @@ export class ModelClientFactory {
           apiKey: config.apiKey,
           baseUrl: resolvedBaseUrl,
           organization,
-          conversationId,
+          sessionId,
           modelFamily,
           provider,
           modelConfig,
@@ -648,7 +648,7 @@ export class ModelClientFactory {
           apiKey: config.apiKey,
           baseUrl: resolvedBaseUrl,
           organization,
-          conversationId,
+          sessionId,
           modelFamily,
           provider,
           modelConfig,
@@ -667,7 +667,7 @@ export class ModelClientFactory {
           apiKey: config.apiKey,
           baseUrl: resolvedBaseUrl,
           organization,
-          conversationId,
+          sessionId,
           modelFamily,
           provider,
           modelConfig,
@@ -683,7 +683,7 @@ export class ModelClientFactory {
           apiKey: config.apiKey,
           baseUrl: resolvedBaseUrl,
           organization,
-          conversationId,
+          sessionId,
           modelFamily,
           provider,
           modelConfig,

--- a/src/core/models/__tests__/OpenAIChatCompletionClient.test.ts
+++ b/src/core/models/__tests__/OpenAIChatCompletionClient.test.ts
@@ -57,7 +57,7 @@ describe('OpenAIChatCompletionClient', () => {
   beforeEach(() => {
     config = {
       apiKey: 'test-api-key',
-      conversationId: 'conv-123',
+      sessionId: 'conv-123',
       modelFamily: mockModelFamily,
       provider: mockProvider,
     };

--- a/src/core/models/__tests__/OpenAIChatCompletionClient.unit.test.ts
+++ b/src/core/models/__tests__/OpenAIChatCompletionClient.unit.test.ts
@@ -37,7 +37,7 @@ describe('OpenAIChatCompletionClient - Text Accumulation', () => {
     client = new OpenAIChatCompletionClient({
       apiKey: 'test-api-key',
       baseUrl: 'https://api.openai.com/v1',
-      conversationId: 'test-conversation',
+      sessionId: 'test-conversation',
       modelFamily: {
         family: 'gpt-4o',
         base_instructions: 'You are a helpful assistant.',
@@ -202,7 +202,7 @@ describe('OpenAIChatCompletionClient - Event Conversion Integration', () => {
     client = new OpenAIChatCompletionClient({
       apiKey: 'test-api-key',
       baseUrl: 'https://api.openai.com/v1',
-      conversationId: 'test-conversation',
+      sessionId: 'test-conversation',
       modelFamily: {
         family: 'gpt-4o',
         base_instructions: 'You are a helpful assistant.',
@@ -246,7 +246,7 @@ describe('OpenAIChatCompletionClient - Tool Call Handling', () => {
     client = new OpenAIChatCompletionClient({
       apiKey: 'test-api-key',
       baseUrl: 'https://api.openai.com/v1',
-      conversationId: 'test-conversation',
+      sessionId: 'test-conversation',
       modelFamily: {
         family: 'gpt-4o',
         base_instructions: 'You are a helpful assistant.',
@@ -390,7 +390,7 @@ describe('OpenAIChatCompletionClient - Multi-Turn Mixed Content', () => {
     client = new OpenAIChatCompletionClient({
       apiKey: 'test-api-key',
       baseUrl: 'https://api.openai.com/v1',
-      conversationId: 'test-conversation',
+      sessionId: 'test-conversation',
       modelFamily: {
         family: 'gpt-4o',
         base_instructions: 'You are a helpful assistant.',
@@ -475,7 +475,7 @@ describe('OpenAIChatCompletionClient - Payload Conversion', () => {
     client = new OpenAIChatCompletionClient({
       apiKey: 'test-api-key',
       baseUrl: 'https://api.openai.com/v1',
-      conversationId: 'test-conversation',
+      sessionId: 'test-conversation',
       modelFamily: {
         family: 'gpt-4o',
         base_instructions: 'You are a helpful assistant.',

--- a/src/core/models/__tests__/calculateBackoff.test.ts
+++ b/src/core/models/__tests__/calculateBackoff.test.ts
@@ -30,7 +30,7 @@ describe('calculateBackoff', () => {
 
     return new OpenAIResponsesClient({
       apiKey: 'test-key',
-      conversationId: 'test-conv',
+      sessionId: 'test-conv',
       modelFamily,
       provider,
     });

--- a/src/core/models/__tests__/convertTokenUsage.test.ts
+++ b/src/core/models/__tests__/convertTokenUsage.test.ts
@@ -39,7 +39,7 @@ describe('convertTokenUsage', () => {
 
     return new OpenAIResponsesClient({
       apiKey: 'test-key',
-      conversationId: 'test-conv',
+      sessionId: 'test-conv',
       modelFamily,
       provider,
     });

--- a/src/core/models/__tests__/error-handling.test.ts
+++ b/src/core/models/__tests__/error-handling.test.ts
@@ -800,7 +800,7 @@ describe('Error Handling and Retries Integration', () => {
     client = new OpenAIChatCompletionClient(
       {
         apiKey: 'test-api-key',
-        conversationId: 'error-test',
+        sessionId: 'error-test',
         modelFamily: mockModelFamily,
         provider: mockProvider,
       },

--- a/src/core/models/__tests__/parseRateLimitSnapshot.test.ts
+++ b/src/core/models/__tests__/parseRateLimitSnapshot.test.ts
@@ -30,7 +30,7 @@ describe('parseRateLimitSnapshot', () => {
 
     return new OpenAIResponsesClient({
       apiKey: 'test-key',
-      conversationId: 'test-conv',
+      sessionId: 'test-conv',
       modelFamily,
       provider,
     });

--- a/src/core/models/__tests__/sse-processing.perf.test.ts
+++ b/src/core/models/__tests__/sse-processing.perf.test.ts
@@ -33,7 +33,7 @@ describe('SSE Processing Performance', () => {
 
     return new OpenAIResponsesClient({
       apiKey: 'test-key',
-      conversationId: 'test-conv',
+      sessionId: 'test-conv',
       modelFamily,
       provider,
     });

--- a/src/core/models/__tests__/stream-init.perf.test.ts
+++ b/src/core/models/__tests__/stream-init.perf.test.ts
@@ -34,7 +34,7 @@ describe('Stream Initialization Performance', () => {
 
     return new OpenAIResponsesClient({
       apiKey: 'test-key',
-      conversationId: 'test-conv',
+      sessionId: 'test-conv',
       modelFamily,
       provider,
     });

--- a/src/core/models/__tests__/stream-lifecycle.integration.test.ts
+++ b/src/core/models/__tests__/stream-lifecycle.integration.test.ts
@@ -62,7 +62,7 @@ describe('Full Stream Lifecycle Integration', () => {
     client = new OpenAIChatCompletionClient(
       {
         apiKey: 'test-api-key',
-        conversationId: 'integration-test',
+        sessionId: 'integration-test',
         modelFamily: mockModelFamily,
         provider: mockProvider,
       },

--- a/src/core/models/client/OpenAIChatCompletionClient.ts
+++ b/src/core/models/client/OpenAIChatCompletionClient.ts
@@ -33,7 +33,7 @@ export interface OpenAIChatCompletionConfig {
   /** Organization ID */
   organization?: string;
   /** Conversation ID for session tracking */
-  conversationId: string;
+  sessionId: string;
   /** Model family configuration */
   modelFamily: ModelFamily;
   /** Model provider information */
@@ -80,7 +80,7 @@ export class OpenAIChatCompletionClient extends OpenAIResponsesClient {
       apiKey: config.apiKey,
       baseUrl: config.baseUrl,
       organization: config.organization,
-      conversationId: config.conversationId,
+      sessionId: config.sessionId,
       modelFamily: config.modelFamily,
       provider: config.provider,
       modelConfig: config.modelConfig,

--- a/src/core/models/client/OpenAIResponsesClient.ts
+++ b/src/core/models/client/OpenAIResponsesClient.ts
@@ -75,7 +75,7 @@ export interface OpenAIResponsesConfig {
   /** Organization ID */
   organization?: string;
   /** Conversation ID for session tracking */
-  conversationId: string;
+  sessionId: string;
   /** Model family configuration */
   modelFamily: ModelFamily;
   /** Model provider information */
@@ -102,7 +102,7 @@ export class OpenAIResponsesClient extends ModelClient {
   protected readonly apiKey: string | null;
   protected readonly baseUrl: string;
   protected readonly organization?: string;
-  protected readonly conversationId: string;
+  protected readonly sessionId: string;
   protected readonly modelFamily: ModelFamily;
   protected readonly provider: ModelProviderInfo;
   protected reasoningEffort?: ReasoningEffortConfig;
@@ -143,7 +143,7 @@ export class OpenAIResponsesClient extends ModelClient {
     }
 
     this.organization = config.organization;
-    this.conversationId = config.conversationId;
+    this.sessionId = config.sessionId;
     this.modelFamily = config.modelFamily;
     this.provider = config.provider;
     this.modelConfig = config.modelConfig;
@@ -405,7 +405,7 @@ export class OpenAIResponsesClient extends ModelClient {
       ...(storeValue !== undefined && { store: storeValue }), // Conditionally include store
       stream: true,
       ...(include !== undefined && include.length > 0 && { include }), // Conditionally include
-      prompt_cache_key: this.conversationId,
+      prompt_cache_key: this.sessionId,
       text: textControls,
       ...(this.serviceTier && { service_tier: this.serviceTier }), // Conditionally include service_tier
     };
@@ -1056,8 +1056,8 @@ export class OpenAIResponsesClient extends ModelClient {
       const options: any = {};
       if (this.provider.name === 'openai') {
         options.headers = {
-          'conversation_id': this.conversationId,
-          'session_id': this.conversationId,
+          'conversation_id': this.sessionId,
+          'session_id': this.sessionId,
         };
       }
 

--- a/src/core/registry/AgentRegistry.ts
+++ b/src/core/registry/AgentRegistry.ts
@@ -137,12 +137,6 @@ export class AgentRegistry {
 
     // Allocate a session letter
     const letterIndex = this._allocateLetterIndex();
-    const session = new AgentSession(sessionConfig, letterIndex);
-
-    // Set up persistence if storage is configured
-    if (this._storage) {
-      session.setStorage(this._storage);
-    }
 
     // T057: Wrap agent creation in try-catch for graceful error handling
     let agent: RepublicAgent;
@@ -150,22 +144,9 @@ export class AgentRegistry {
       if (this._registryConfig.agentFactory) {
         // Server/Desktop path: use provided factory for agent creation
         agent = await this._registryConfig.agentFactory(this._config);
-
-        // Set event dispatcher via factory if provided
-        if (this._registryConfig.eventDispatcherFactory) {
-          agent.setEventDispatcher(this._registryConfig.eventDispatcherFactory(session.sessionId));
-        }
       } else {
         // Extension path: create agent and wire events through ChannelManager
         agent = new RepublicAgent(this._config, undefined, undefined, new UserNotifier());
-
-        // Route events through ChannelManager (unified across all platforms)
-        agent.setEventDispatcher((event) => {
-          import('@/core/channels/ChannelManager').then(({ getChannelManager }) => {
-            getChannelManager().broadcastEvent(event.msg).catch(() => {});
-          }).catch(() => {});
-        });
-
         await agent.initialize();
 
         // Configure extension-specific approval gate
@@ -189,12 +170,13 @@ export class AgentRegistry {
       }
     } catch (initError) {
       // Agent initialization failed - clean up and emit error event
-      console.error(`[AgentRegistry] Failed to initialize agent for session ${session.sessionId}:`, initError);
+      const tempId = `failed_${Date.now()}`;
+      console.error(`[AgentRegistry] Failed to initialize agent:`, initError);
 
       // Emit failure event for monitoring/UI feedback
       this._emitEvent({
         type: 'session:error',
-        sessionId: session.sessionId,
+        sessionId: tempId,
         error: initError instanceof Error ? initError.message : 'Agent initialization failed',
         timestamp: Date.now(),
       });
@@ -204,6 +186,27 @@ export class AgentRegistry {
         `Failed to create ${sessionConfig.type} session: ` +
         `${initError instanceof Error ? initError.message : 'Agent initialization failed'}`
       );
+    }
+
+    // Create AgentSession with the agent's sessionId (Session is the single source of truth)
+    const agentSessionId = agent.getSession().sessionId;
+    const session = new AgentSession({ ...sessionConfig, sessionId: agentSessionId }, letterIndex);
+
+    // Set up persistence if storage is configured
+    if (this._storage) {
+      session.setStorage(this._storage);
+    }
+
+    // Wire event dispatcher with the unified sessionId
+    if (this._registryConfig.eventDispatcherFactory) {
+      agent.setEventDispatcher(this._registryConfig.eventDispatcherFactory(session.sessionId));
+    } else {
+      // Extension path: route events through ChannelManager
+      agent.setEventDispatcher((event) => {
+        import('@/core/channels/ChannelManager').then(({ getChannelManager }) => {
+          getChannelManager().broadcastEvent({ msg: event.msg, sessionId: session.sessionId }).catch(() => {});
+        }).catch(() => {});
+      });
     }
 
     // Attach agent to session
@@ -407,9 +410,11 @@ export class AgentRegistry {
     // Broadcast to UI via channel
     import('@/core/channels/ChannelManager').then(({ getChannelManager }) => {
       getChannelManager().broadcastEvent({
-        type: 'BackgroundEvent' as any,
-        data: { message: 'session_event', level: 'info', sessionEvent: event },
-      } as any).catch(() => {});
+        msg: {
+          type: 'BackgroundEvent' as any,
+          data: { message: 'session_event', level: 'info', sessionEvent: event },
+        } as any,
+      }).catch(() => {});
     }).catch(() => {});
   }
 

--- a/src/core/registry/AgentSession.ts
+++ b/src/core/registry/AgentSession.ts
@@ -41,16 +41,15 @@ export class AgentSession {
    * @param config Session configuration
    * @param letterIndex Index for session letter assignment (0-25)
    */
-  constructor(config: SessionConfig, letterIndex: number = 0) {
+  constructor(config: SessionConfig & { sessionId?: string }, letterIndex: number = 0) {
     this._internal = config.internal ?? false;
-    this._sessionId = `session_${uuidv4()}`;
+    this._sessionId = config.sessionId ?? uuidv4();
     this._sessionLetter = SESSION_LETTERS[letterIndex % SESSION_LETTERS.length];
 
     const now = Date.now();
     this._metadata = {
       sessionId: this._sessionId,
       sessionLetter: this._sessionLetter,
-      conversationId: '', // Set when agent is attached
       type: config.type,
       state: 'initializing',
       createdAt: now,
@@ -109,7 +108,6 @@ export class AgentSession {
     }
 
     this._agent = agent;
-    this._metadata.conversationId = agent.getSession().conversationId;
     this._updateActivity();
   }
 
@@ -211,10 +209,10 @@ export class AgentSession {
   }
 
   /**
-   * Get the underlying agent's conversation ID
+   * Get the session ID (same across all layers)
    */
-  getConversationId(): string {
-    return this._metadata.conversationId;
+  getSessionId(): string {
+    return this._sessionId;
   }
 
   // ==========================================================================

--- a/src/core/registry/SessionStorage.ts
+++ b/src/core/registry/SessionStorage.ts
@@ -15,7 +15,6 @@ import type { SessionMetadata, SessionType, SessionState } from './types';
 export interface PersistedSession {
   sessionId: string;
   sessionLetter: string;
-  conversationId: string;
   type: SessionType;
   state: SessionState;
   createdAt: number;
@@ -40,7 +39,6 @@ export class SessionStorage {
     const record: PersistedSession = {
       sessionId: metadata.sessionId,
       sessionLetter: metadata.sessionLetter,
-      conversationId: metadata.conversationId,
       type: metadata.type,
       state: metadata.state,
       createdAt: metadata.createdAt,

--- a/src/core/registry/__tests__/AgentSession.test.ts
+++ b/src/core/registry/__tests__/AgentSession.test.ts
@@ -9,7 +9,7 @@ import type { SessionConfig } from '@/core/registry/types';
 
 // Mock RepublicAgent session - shared object so spies work correctly
 const mockSession = {
-  conversationId: 'conv_test_123',
+  sessionId: 'conv_test_123',
   abortAllTasks: vi.fn(),
   close: vi.fn(),
   setTabId: vi.fn(),
@@ -139,12 +139,12 @@ describe('AgentSession', () => {
   });
 
   describe('agent attachment', () => {
-    it('attaches agent and updates conversationId', () => {
+    it('attaches agent and updates sessionId', () => {
       const session = new AgentSession({ type: 'primary' }, 0);
       session.attachAgent(mockAgent as any);
 
       expect(session.agent).toBe(mockAgent);
-      expect(session.metadata.conversationId).toBe('conv_test_123');
+      expect(session.metadata.sessionId).toBe('conv_test_123');
     });
 
     it('throws when attaching agent twice', () => {

--- a/src/core/registry/__tests__/registry-persistence.integration.test.ts
+++ b/src/core/registry/__tests__/registry-persistence.integration.test.ts
@@ -41,7 +41,7 @@ vi.mock('@/core/RepublicAgent', () => {
       setEventDispatcher = vi.fn();
       getSession() {
         return {
-          conversationId: `conv_${Date.now()}`,
+          sessionId: `conv_${Date.now()}`,
           abortAllTasks: vi.fn().mockResolvedValue(undefined),
           close: vi.fn().mockResolvedValue(undefined),
           setTabId: vi.fn(),
@@ -190,7 +190,6 @@ describe('AgentRegistry Session Persistence (Feature 015)', () => {
         {
           sessionId: 'session_1',
           sessionLetter: 'a',
-          conversationId: 'conv_1',
           type: 'scheduled',
           state: 'idle',
           createdAt: Date.now() - 1000,
@@ -203,7 +202,6 @@ describe('AgentRegistry Session Persistence (Feature 015)', () => {
         {
           sessionId: 'session_2',
           sessionLetter: 'b',
-          conversationId: 'conv_2',
           type: 'scheduled',
           state: 'idle',
           createdAt: Date.now() - 2000,
@@ -229,7 +227,6 @@ describe('AgentRegistry Session Persistence (Feature 015)', () => {
         {
           sessionId: 'session_active',
           sessionLetter: 'a',
-          conversationId: 'conv_1',
           type: 'scheduled',
           state: 'idle',
           createdAt: Date.now(),
@@ -242,7 +239,6 @@ describe('AgentRegistry Session Persistence (Feature 015)', () => {
         {
           sessionId: 'session_terminated',
           sessionLetter: 'b',
-          conversationId: 'conv_2',
           type: 'scheduled',
           state: 'terminated',
           createdAt: Date.now(),
@@ -269,7 +265,6 @@ describe('AgentRegistry Session Persistence (Feature 015)', () => {
       const persistedSession: PersistedSession = {
         sessionId: 'session_to_resume',
         sessionLetter: 'c',
-        conversationId: 'conv_resume',
         type: 'scheduled',
         state: 'idle',
         createdAt: Date.now() - 5000,
@@ -294,7 +289,6 @@ describe('AgentRegistry Session Persistence (Feature 015)', () => {
       const persistedSession: PersistedSession = {
         sessionId: activeSession.sessionId, // Same ID as active session
         sessionLetter: 'a',
-        conversationId: 'conv_active',
         type: 'scheduled',
         state: 'idle',
         createdAt: Date.now(),
@@ -322,7 +316,6 @@ describe('AgentRegistry Session Persistence (Feature 015)', () => {
       const persistedSession: PersistedSession = {
         sessionId: 'session_overflow',
         sessionLetter: 'd',
-        conversationId: 'conv_overflow',
         type: 'scheduled',
         state: 'idle',
         createdAt: Date.now(),
@@ -396,7 +389,6 @@ describe('AgentRegistry Session Persistence (Feature 015)', () => {
       const oldSession: PersistedSession = {
         sessionId: 'old_session',
         sessionLetter: 'a',
-        conversationId: 'conv_old',
         type: 'scheduled',
         state: 'idle',
         createdAt: now - 48 * 60 * 60 * 1000, // 48 hours ago
@@ -410,7 +402,6 @@ describe('AgentRegistry Session Persistence (Feature 015)', () => {
       const recentSession: PersistedSession = {
         sessionId: 'recent_session',
         sessionLetter: 'b',
-        conversationId: 'conv_recent',
         type: 'scheduled',
         state: 'idle',
         createdAt: now - 1 * 60 * 60 * 1000, // 1 hour ago
@@ -438,7 +429,6 @@ describe('AgentRegistry Session Persistence (Feature 015)', () => {
       const terminatedSession: PersistedSession = {
         sessionId: 'terminated_session',
         sessionLetter: 'a',
-        conversationId: 'conv_terminated',
         type: 'scheduled',
         state: 'terminated',
         createdAt: Date.now() - 1000, // Very recent
@@ -478,7 +468,6 @@ describe('AgentRegistry Session Persistence (Feature 015)', () => {
       const persistedSession: PersistedSession = {
         sessionId: originalSessionId,
         sessionLetter: session.sessionLetter,
-        conversationId: session.metadata.conversationId,
         type: 'scheduled',
         state: 'idle',
         createdAt: session.metadata.createdAt,
@@ -515,7 +504,6 @@ describe('AgentRegistry Session Persistence (Feature 015)', () => {
       const primarySession: PersistedSession = {
         sessionId: 'primary_old',
         sessionLetter: 'a',
-        conversationId: 'conv_primary',
         type: 'primary',
         state: 'idle',
         createdAt: Date.now(),
@@ -554,7 +542,6 @@ describe('SessionStorage Unit Tests', () => {
     const metadata: SessionMetadata = {
       sessionId: 'session_unit',
       sessionLetter: 'a',
-      conversationId: 'conv_unit',
       type: 'scheduled',
       state: 'idle',
       createdAt: Date.now(),
@@ -581,7 +568,6 @@ describe('SessionStorage Unit Tests', () => {
     const mockSession: PersistedSession = {
       sessionId: 'session_get',
       sessionLetter: 'b',
-      conversationId: 'conv_get',
       type: 'scheduled',
       state: 'active',
       createdAt: Date.now(),
@@ -611,7 +597,6 @@ describe('SessionStorage Unit Tests', () => {
       {
         sessionId: 'scheduled_1',
         sessionLetter: 'a',
-        conversationId: 'conv_1',
         type: 'scheduled',
         state: 'idle',
         createdAt: Date.now(),

--- a/src/core/registry/types.ts
+++ b/src/core/registry/types.ts
@@ -49,9 +49,6 @@ export interface SessionMetadata {
   /** Single letter identifier (a, b, c...) for tab group naming */
   sessionLetter: string;
 
-  /** Conversation ID for history lookup */
-  conversationId: string;
-
   /** Session type */
   type: SessionType;
 

--- a/src/core/scheduler/Scheduler.ts
+++ b/src/core/scheduler/Scheduler.ts
@@ -123,7 +123,7 @@ export class Scheduler {
     this.setEventEmitter((event) => {
       try {
         getChannelManager().dispatchEvent(
-          { type: 'BackgroundEvent', data: { message: 'scheduler_job_status', level: 'info', schedulerEvent: event } },
+          { msg: { type: 'BackgroundEvent', data: { message: 'scheduler_job_status', level: 'info', schedulerEvent: event } } },
           channelId
         ).catch((error) => {
           console.error('[Scheduler] Failed to dispatch event:', error);

--- a/src/core/services/session-services.ts
+++ b/src/core/services/session-services.ts
@@ -12,7 +12,7 @@ import type { ServiceHandler } from '@/core/channels/ServiceRegistry';
 export interface SessionServiceDeps {
   getAgent: () => {
     getSession(): {
-      conversationId: string;
+      sessionId: string;
       isActiveTurn(): boolean;
       getTabId(): number;
       getConversationHistory(): { items: unknown[] };
@@ -42,7 +42,7 @@ export interface SessionServiceDeps {
   resetTabs?: () => Promise<void>;
 
   /** Resume a session from stored history */
-  resumeSession?: (conversationId: string) => Promise<{ conversationId: string; history: unknown[] }>;
+  resumeSession?: (sessionId: string) => Promise<{ sessionId: string; history: unknown[] }>;
 }
 
 export function createSessionServices(deps: SessionServiceDeps): Record<string, ServiceHandler> {
@@ -58,7 +58,7 @@ export function createSessionServices(deps: SessionServiceDeps): Record<string, 
       const conversationHistory = session.getConversationHistory();
 
       return {
-        sessionId: session.conversationId,
+        sessionId: session.sessionId,
         isActiveTurn: session.isActiveTurn(),
         tabId,
         history: conversationHistory.items,
@@ -86,8 +86,8 @@ export function createSessionServices(deps: SessionServiceDeps): Record<string, 
       if (!deps.resumeSession) {
         throw new Error('Session resume not supported on this platform');
       }
-      const { conversationId } = params as { conversationId: string };
-      return deps.resumeSession(conversationId);
+      const { sessionId } = params as { sessionId: string };
+      return deps.resumeSession(sessionId);
     },
 
     'session.list': async () => {

--- a/src/core/session/state/__tests__/types.test.ts
+++ b/src/core/session/state/__tests__/types.test.ts
@@ -53,7 +53,7 @@ describe('isNewHistory', () => {
   it('should return false for resumed history', () => {
     const history: InitialHistory = {
       mode: 'resumed',
-      conversationId: 'conv-1',
+      sessionId: 'conv-1',
       rolloutItems: [],
     };
     expect(isNewHistory(history)).toBe(false);
@@ -81,7 +81,7 @@ describe('isResumedHistory', () => {
   it('should return true for resumed history', () => {
     const history: InitialHistory = {
       mode: 'resumed',
-      conversationId: 'conv-123',
+      sessionId: 'conv-123',
       rolloutItems: [{ id: '1' }],
     };
     expect(isResumedHistory(history)).toBe(true);
@@ -101,14 +101,14 @@ describe('isResumedHistory', () => {
     expect(isResumedHistory(history)).toBe(false);
   });
 
-  it('should narrow type to include conversationId and rolloutItems', () => {
+  it('should narrow type to include sessionId and rolloutItems', () => {
     const history: InitialHistory = {
       mode: 'resumed',
-      conversationId: 'conv-abc',
+      sessionId: 'conv-abc',
       rolloutItems: [{ data: 'test' }],
     };
     if (isResumedHistory(history)) {
-      expect(history.conversationId).toBe('conv-abc');
+      expect(history.sessionId).toBe('conv-abc');
       expect(history.rolloutItems).toEqual([{ data: 'test' }]);
     }
   });
@@ -116,7 +116,7 @@ describe('isResumedHistory', () => {
   it('should handle empty rolloutItems', () => {
     const history: InitialHistory = {
       mode: 'resumed',
-      conversationId: 'conv-empty',
+      sessionId: 'conv-empty',
       rolloutItems: [],
     };
     expect(isResumedHistory(history)).toBe(true);
@@ -141,7 +141,7 @@ describe('isForkedHistory', () => {
   it('should return false for resumed history', () => {
     const history: InitialHistory = {
       mode: 'resumed',
-      conversationId: 'conv-1',
+      sessionId: 'conv-1',
       rolloutItems: [],
     };
     expect(isForkedHistory(history)).toBe(false);
@@ -180,7 +180,7 @@ describe('Type guard mutual exclusivity', () => {
   it('resumed history: only isResumedHistory returns true', () => {
     const history: InitialHistory = {
       mode: 'resumed',
-      conversationId: 'conv-1',
+      sessionId: 'conv-1',
       rolloutItems: [],
     };
     expect(isNewHistory(history)).toBe(false);
@@ -289,21 +289,21 @@ describe('Interface structure verification', () => {
 
   it('should create a valid ConfigureSession', () => {
     const config: ConfigureSession = {
-      conversationId: 'conv-1',
+      sessionId: 'conv-1',
       instructions: 'You are a helpful assistant',
       cwd: '/home/user',
       model: 'gpt-4',
     };
-    expect(config.conversationId).toBe('conv-1');
+    expect(config.sessionId).toBe('conv-1');
     expect(config.instructions).toBe('You are a helpful assistant');
     expect(config.model).toBe('gpt-4');
   });
 
-  it('should allow minimal ConfigureSession with only conversationId', () => {
+  it('should allow minimal ConfigureSession with only sessionId', () => {
     const config: ConfigureSession = {
-      conversationId: 'conv-minimal',
+      sessionId: 'conv-minimal',
     };
-    expect(config.conversationId).toBe('conv-minimal');
+    expect(config.sessionId).toBe('conv-minimal');
     expect(config.instructions).toBeUndefined();
     expect(config.cwd).toBeUndefined();
     expect(config.model).toBeUndefined();

--- a/src/core/session/state/types.ts
+++ b/src/core/session/state/types.ts
@@ -107,7 +107,7 @@ export type TurnAbortReason = 'Replaced' | 'UserInterrupt' | 'Error' | 'Timeout'
  */
 export interface ConfigureSession {
   /** Conversation ID for this session */
-  conversationId: string;
+  sessionId: string;
 
   /** Initial instructions for the agent */
   instructions?: string;
@@ -134,7 +134,7 @@ export interface ConfigureSession {
  */
 export type InitialHistory =
   | { mode: 'new' }
-  | { mode: 'resumed'; conversationId: string; rolloutItems: any[] } // RolloutItem[] from rollout
+  | { mode: 'resumed'; sessionId: string; rolloutItems: any[] } // RolloutItem[] from rollout
   | { mode: 'forked'; rolloutItems: any[]; sourceConversationId: string };
 
 /**
@@ -144,7 +144,7 @@ export function isNewHistory(history: InitialHistory): history is { mode: 'new' 
   return history.mode === 'new';
 }
 
-export function isResumedHistory(history: InitialHistory): history is { mode: 'resumed'; conversationId: string; rolloutItems: any[] } {
+export function isResumedHistory(history: InitialHistory): history is { mode: 'resumed'; sessionId: string; rolloutItems: any[] } {
   return history.mode === 'resumed';
 }
 

--- a/src/core/storage/StorageProvider.ts
+++ b/src/core/storage/StorageProvider.ts
@@ -27,7 +27,7 @@ import type { ListOptions, QueryFilter, Transaction } from './types';
  * const provider = new SQLiteStorageProvider({ path: '~/.pi/data/pi.db' });
  * await provider.initialize();
  * const messages = await provider.query('messages', {
- *   where: { conversationId: 'conv-123' },
+ *   where: { sessionId: 'conv-123' },
  *   orderBy: 'timestamp',
  *   order: 'asc'
  * });

--- a/src/desktop/agent/DesktopAgentBootstrap.ts
+++ b/src/desktop/agent/DesktopAgentBootstrap.ts
@@ -169,7 +169,7 @@ export class DesktopAgentBootstrap {
         // Notify the UI that auth has changed so it re-runs health check
         if (this.agent && this.channel) {
           channelManager.dispatchEvent(
-            { type: 'BackgroundEvent', data: { message: 'Agent reinitialized after auth change', level: 'info' } },
+            { msg: { type: 'BackgroundEvent', data: { message: 'Agent reinitialized after auth change', level: 'info' } } as any },
             this.channel.channelId
           ).catch(() => {});
         }
@@ -297,8 +297,8 @@ export class DesktopAgentBootstrap {
     // Set the event dispatcher on RepublicAgent
     // Events will be routed through ChannelManager to TauriChannel
     this.agent.setEventDispatcher((event) => {
-      // Dispatch event to the Tauri channel
-      channelManager.dispatchEvent(event.msg, this.channel!.channelId).catch((error) => {
+      // Dispatch event to the Tauri channel as ChannelEvent with sessionId
+      channelManager.dispatchEvent({ msg: event.msg, sessionId: this.agent!.getSession().sessionId }, this.channel!.channelId).catch((error) => {
         console.error('[DesktopAgentBootstrap] Failed to dispatch event:', error);
       });
 
@@ -528,7 +528,7 @@ export class DesktopAgentBootstrap {
             return agent;
           },
           eventDispatcherFactory: (sessionId) => (event) => {
-            channelManager.dispatchEvent(event.msg, this.channel!.channelId).catch(() => {});
+            channelManager.dispatchEvent({ msg: event.msg, sessionId }, this.channel!.channelId).catch(() => {});
             this.handleSchedulerEventCompletion(event.msg);
           },
         });
@@ -656,12 +656,12 @@ export class DesktopAgentBootstrap {
    * creates a fresh RepublicAgent with the resumed history, and returns the
    * reconstructed conversation items.
    */
-  async resumeSession(conversationId: string): Promise<unknown[]> {
+  async resumeSession(sessionId: string): Promise<unknown[]> {
     if (!this.agent) {
       throw new Error('Agent not initialized');
     }
 
-    console.log('[DesktopAgentBootstrap] Resuming session:', conversationId);
+    console.log('[DesktopAgentBootstrap] Resuming session:', sessionId);
 
     // 1. Preserve auth manager from the current agent
     const authManager = this.agent.getModelClientFactory().getAuthManager();
@@ -675,7 +675,7 @@ export class DesktopAgentBootstrap {
 
     // 4. Load rollout history from storage
     const { RolloutRecorder } = await import('@/storage/rollout/RolloutRecorder');
-    const initialHistory = await RolloutRecorder.getRolloutHistory(conversationId);
+    const initialHistory = await RolloutRecorder.getRolloutHistory(sessionId);
 
     if (initialHistory.type !== 'resumed' || !initialHistory.payload?.history) {
       throw new Error('Conversation not found or has no history');
@@ -685,7 +685,7 @@ export class DesktopAgentBootstrap {
     const config = await AgentConfig.getInstance();
     this.agent = new RepublicAgent(config, {
       mode: 'resumed' as const,
-      conversationId,
+      sessionId,
       rolloutItems: initialHistory.payload.history,
     }, undefined, new UserNotifier());
 

--- a/src/desktop/channels/TauriChannel.ts
+++ b/src/desktop/channels/TauriChannel.ts
@@ -22,8 +22,8 @@ import type {
   SubmissionHandler,
   SubmissionContext,
   ChannelCapabilities,
+  ChannelEvent,
 } from '@/core/channels/types';
-import type { EventMsg } from '@/core/protocol/events';
 import type { Op } from '@/core/protocol/types';
 import { t } from '@/webfront/lib/i18n';
 
@@ -60,8 +60,8 @@ interface SubmissionMessage {
  * });
  *
  * await channel.sendEvent({
- *   type: 'AssistantTextDelta',
- *   data: { delta: 'Hello!' }
+ *   msg: { type: 'AssistantTextDelta', data: { delta: 'Hello!' } },
+ *   sessionId: 'abc-123',
  * });
  * ```
  */
@@ -146,7 +146,7 @@ export class TauriChannel implements ChannelAdapter {
   /**
    * Send an event to the UI via Tauri event system
    */
-  async sendEvent(event: EventMsg, _targetClientId?: string): Promise<void> {
+  async sendEvent(event: ChannelEvent, _targetClientId?: string): Promise<void> {
     if (!this.initialized) {
       throw new Error('TauriChannel not initialized');
     }
@@ -223,9 +223,11 @@ export class TauriChannel implements ChannelAdapter {
     if (!message || !message.op) {
       console.error('[TauriChannel] Invalid submission: missing op field', message);
       await this.sendEvent({
-        type: 'Error',
-        data: {
-          message: t('Invalid submission format: missing op field'),
+        msg: {
+          type: 'Error',
+          data: {
+            message: t('Invalid submission format: missing op field'),
+          },
         },
       });
       return;
@@ -234,9 +236,11 @@ export class TauriChannel implements ChannelAdapter {
     if (!message.op.type) {
       console.error('[TauriChannel] Invalid submission: op missing type field', message);
       await this.sendEvent({
-        type: 'Error',
-        data: {
-          message: t('Invalid submission format: op missing type field'),
+        msg: {
+          type: 'Error',
+          data: {
+            message: t('Invalid submission format: op missing type field'),
+          },
         },
       });
       return;
@@ -255,9 +259,11 @@ export class TauriChannel implements ChannelAdapter {
       console.error('[TauriChannel] Handler error:', error);
       // Emit error event back to UI
       await this.sendEvent({
-        type: 'Error',
-        data: {
-          message: error instanceof Error ? error.message : t('Unknown error processing submission'),
+        msg: {
+          type: 'Error',
+          data: {
+            message: error instanceof Error ? error.message : t('Unknown error processing submission'),
+          },
         },
       });
     }

--- a/src/desktop/channels/WebSocketChannel.ts
+++ b/src/desktop/channels/WebSocketChannel.ts
@@ -12,6 +12,7 @@ import type {
   ChannelType,
   ConnectionState,
   SubmissionContext,
+  ChannelEvent,
 } from '@/core/channels/types';
 import type { EventMsg } from '@/core/protocol/events';
 
@@ -106,13 +107,13 @@ export class WebSocketChannel implements ChannelAdapter {
   /**
    * Send an event to a specific client or broadcast
    */
-  async sendEvent(event: EventMsg, targetClientId?: string): Promise<void> {
+  async sendEvent(event: ChannelEvent, targetClientId?: string): Promise<void> {
     if (!this.initialized) {
       throw new Error('WebSocketChannel not initialized');
     }
 
     // Convert event to WebSocket message format
-    const wsMessage = this.eventToWSMessage(event);
+    const wsMessage = this.eventToWSMessage(event.msg);
     if (!wsMessage) {
       return;
     }
@@ -179,7 +180,7 @@ export class WebSocketChannel implements ChannelAdapter {
     message: WSUserTurn
   ): Promise<void> {
     const turnId = `turn-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    const conversationId = message.conversationId || `conv-${clientId}`;
+    const sessionId = message.sessionId || `conv-${clientId}`;
 
     // Track the turn
     this.currentTurns.set(turnId, { clientId, turnId });
@@ -194,7 +195,7 @@ export class WebSocketChannel implements ChannelAdapter {
         type: 'user_turn',
         content: message.content,
         images: message.images,
-        conversationId,
+        sessionId,
         turnId,
       },
       timestamp: Date.now(),
@@ -204,7 +205,7 @@ export class WebSocketChannel implements ChannelAdapter {
     await this.server.send(clientId, {
       type: 'assistant_turn_start',
       turnId,
-      conversationId,
+      sessionId,
       timestamp: Date.now(),
     } as WSAssistantTurnStart);
 

--- a/src/desktop/channels/__tests__/WebSocketChannel.test.ts
+++ b/src/desktop/channels/__tests__/WebSocketChannel.test.ts
@@ -27,6 +27,7 @@ vi.mock('../websocket/WebSocketServer', () => ({
 
 import { WebSocketChannel } from '../WebSocketChannel';
 import type { EventMsg } from '@/core/protocol/events';
+import type { ChannelEvent } from '@/core/channels/types';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -83,7 +84,7 @@ describe('WebSocketChannel', () => {
         data: { delta: 'hello' },
       };
 
-      await channel.sendEvent(event);
+      await channel.sendEvent({ msg: event });
 
       // No turn active → event is dropped (not sent)
       expect(mockServer.send).not.toHaveBeenCalled();
@@ -104,7 +105,7 @@ describe('WebSocketChannel', () => {
         type: 'AgentMessageDelta',
         data: { delta: 'response' },
       };
-      await channel.sendEvent(event);
+      await channel.sendEvent({ msg: event });
 
       // broadcast is used when no targetClientId
       const broadcastCall = mockServer.broadcast.mock.calls[0];
@@ -120,7 +121,7 @@ describe('WebSocketChannel', () => {
         type: 'TaskComplete',
         data: { last_agent_message: 'done' },
       };
-      await channel.sendEvent(completeEvent);
+      await channel.sendEvent({ msg: completeEvent });
 
       // The TaskComplete itself should be sent
       expect(mockServer.broadcast).toHaveBeenCalledTimes(1);
@@ -131,7 +132,7 @@ describe('WebSocketChannel', () => {
         type: 'AgentMessageDelta',
         data: { delta: 'orphan' },
       };
-      await channel.sendEvent(deltaEvent);
+      await channel.sendEvent({ msg: deltaEvent });
       expect(mockServer.broadcast).not.toHaveBeenCalled();
     });
 
@@ -151,7 +152,7 @@ describe('WebSocketChannel', () => {
         type: 'AgentMessageDelta',
         data: { delta: 'orphan' },
       };
-      await channel.sendEvent(event);
+      await channel.sendEvent({ msg: event });
       expect(mockServer.broadcast).not.toHaveBeenCalled();
     });
   });
@@ -175,7 +176,7 @@ describe('WebSocketChannel', () => {
           start_time: 1000,
         },
       };
-      await channel.sendEvent(startEvent);
+      await channel.sendEvent({ msg: startEvent });
 
       const startMsg = mockServer.broadcast.mock.calls[0][0];
       expect(startMsg.type).toBe('tool_use');
@@ -193,7 +194,7 @@ describe('WebSocketChannel', () => {
           success: true,
         },
       };
-      await channel.sendEvent(endEvent);
+      await channel.sendEvent({ msg: endEvent });
 
       const endMsg = mockServer.broadcast.mock.calls[0][0];
       expect(endMsg.type).toBe('tool_result');
@@ -210,7 +211,7 @@ describe('WebSocketChannel', () => {
         type: 'ToolExecutionStart',
         data: { tool_name: 'web_search' },
       };
-      await channel.sendEvent(startEvent);
+      await channel.sendEvent({ msg: startEvent });
 
       const startMsg = mockServer.broadcast.mock.calls[0][0];
       const startToolUseId = startMsg.toolUseId;
@@ -223,7 +224,7 @@ describe('WebSocketChannel', () => {
         type: 'ToolExecutionEnd',
         data: { tool_name: 'web_search', success: true },
       };
-      await channel.sendEvent(endEvent);
+      await channel.sendEvent({ msg: endEvent });
 
       const endMsg = mockServer.broadcast.mock.calls[0][0];
       expect(endMsg.toolUseId).toBe(startToolUseId);
@@ -239,7 +240,7 @@ describe('WebSocketChannel', () => {
         type: 'ToolExecutionEnd',
         data: { tool_name: 'orphan_tool', success: false },
       };
-      await channel.sendEvent(endEvent);
+      await channel.sendEvent({ msg: endEvent });
 
       const endMsg = mockServer.broadcast.mock.calls[0][0];
       expect(endMsg.toolUseId).toBe('tool-orphan_tool-unknown');
@@ -263,7 +264,7 @@ describe('WebSocketChannel', () => {
           params: { selector: '#btn', button: 'left' },
         },
       };
-      await channel.sendEvent(startEvent);
+      await channel.sendEvent({ msg: startEvent });
 
       const msg = mockServer.broadcast.mock.calls[0][0];
       expect(msg.input).toEqual({ selector: '#btn', button: 'left' });
@@ -278,7 +279,7 @@ describe('WebSocketChannel', () => {
         type: 'ToolExecutionStart',
         data: { tool_name: 'screenshot' },
       };
-      await channel.sendEvent(startEvent);
+      await channel.sendEvent({ msg: startEvent });
 
       const msg = mockServer.broadcast.mock.calls[0][0];
       expect(msg.input).toEqual({});
@@ -297,10 +298,10 @@ describe('WebSocketChannel', () => {
     });
 
     it('maps AgentMessageDelta to assistant_chunk', async () => {
-      await channel.sendEvent({
+      await channel.sendEvent({ msg: {
         type: 'AgentMessageDelta',
         data: { delta: 'hello world' },
-      });
+      } });
 
       const msg = mockServer.broadcast.mock.calls[0][0];
       expect(msg.type).toBe('assistant_chunk');
@@ -309,10 +310,10 @@ describe('WebSocketChannel', () => {
     });
 
     it('maps TaskComplete to assistant_turn_complete', async () => {
-      await channel.sendEvent({
+      await channel.sendEvent({ msg: {
         type: 'TaskComplete',
         data: { last_agent_message: 'All done.' },
-      });
+      } });
 
       const msg = mockServer.broadcast.mock.calls[0][0];
       expect(msg.type).toBe('assistant_turn_complete');
@@ -320,10 +321,10 @@ describe('WebSocketChannel', () => {
     });
 
     it('maps Error to error with code', async () => {
-      await channel.sendEvent({
+      await channel.sendEvent({ msg: {
         type: 'Error',
         data: { message: 'something broke', code: 'RATE_LIMIT' },
-      });
+      } });
 
       const msg = mockServer.broadcast.mock.calls[0][0];
       expect(msg.type).toBe('error');
@@ -332,20 +333,20 @@ describe('WebSocketChannel', () => {
     });
 
     it('defaults error code to ERROR when not provided', async () => {
-      await channel.sendEvent({
+      await channel.sendEvent({ msg: {
         type: 'Error',
         data: { message: 'unknown failure' },
-      });
+      } });
 
       const msg = mockServer.broadcast.mock.calls[0][0];
       expect(msg.code).toBe('ERROR');
     });
 
     it('drops unknown event types silently', async () => {
-      await channel.sendEvent({
+      await channel.sendEvent({ msg: {
         type: 'AgentReasoning',
         data: { content: 'thinking...' },
-      } as EventMsg);
+      } as EventMsg });
 
       expect(mockServer.broadcast).not.toHaveBeenCalled();
       expect(mockServer.send).not.toHaveBeenCalled();
@@ -366,7 +367,7 @@ describe('WebSocketChannel', () => {
 
       // After close, events should be dropped (no active turn, not initialized)
       await expect(
-        channel.sendEvent({ type: 'AgentMessageDelta', data: { delta: 'after close' } }),
+        channel.sendEvent({ msg: { type: 'AgentMessageDelta', data: { delta: 'after close' } } }),
       ).rejects.toThrow('WebSocketChannel not initialized');
     });
   });

--- a/src/desktop/channels/websocket/WebSocketServer.ts
+++ b/src/desktop/channels/websocket/WebSocketServer.ts
@@ -95,7 +95,7 @@ const DEFAULT_CONFIG: WebSocketServerConfig = {
  *     await server.send(clientId, {
  *       type: 'assistant_turn_start',
  *       turnId: 'turn-123',
- *       conversationId: 'conv-456',
+ *       sessionId: 'conv-456',
  *     });
  *   }
  * });

--- a/src/desktop/channels/websocket/types.ts
+++ b/src/desktop/channels/websocket/types.ts
@@ -48,7 +48,7 @@ export interface WSUserTurn extends WSMessage {
   /** User message content */
   content: string;
   /** Optional conversation ID */
-  conversationId?: string;
+  sessionId?: string;
   /** Attached images (base64) */
   images?: string[];
 }
@@ -61,7 +61,7 @@ export interface WSAssistantTurnStart extends WSMessage {
   /** Turn ID */
   turnId: string;
   /** Conversation ID */
-  conversationId: string;
+  sessionId: string;
 }
 
 /**

--- a/src/extension/background/service-worker.ts
+++ b/src/extension/background/service-worker.ts
@@ -403,7 +403,7 @@ async function registerServiceHandlers(): Promise<void> {
       const primaryAgent = registry?.getPrimarySession()?.agent ?? agent;
       if (primaryAgent) {
         primaryAgent.setEventDispatcher((event) => {
-          channelManager.dispatchEvent(event.msg, 'sidepanel-main').catch(() => {});
+          channelManager.dispatchEvent({ msg: event.msg }, 'sidepanel-main').catch(() => {});
         });
       }
     }
@@ -463,8 +463,8 @@ async function registerServiceHandlers(): Promise<void> {
     serviceRegistry.register('session.resume', async (params) => {
       if (!agent) throw new Error('Agent not initialized');
 
-      const { conversationId } = params as { conversationId: string };
-      console.log('[ServiceWorker] Resuming session:', conversationId);
+      const { sessionId } = params as { sessionId: string };
+      console.log('[ServiceWorker] Resuming session:', sessionId);
 
       const currentSession = agent.getSession();
       await currentSession.abortAllTasks('UserInterrupt');
@@ -473,20 +473,20 @@ async function registerServiceHandlers(): Promise<void> {
       await tabManager.reset();
       await currentSession.close();
 
-      const initialHistory = await RolloutRecorder.getRolloutHistory(conversationId);
+      const initialHistory = await RolloutRecorder.getRolloutHistory(sessionId);
       if (initialHistory.type !== 'resumed' || !initialHistory.payload?.history) {
         throw new Error('Conversation not found or has no history');
       }
 
       agent = new RepublicAgent(agentConfig!, {
         mode: 'resumed' as const,
-        conversationId,
+        sessionId,
         rolloutItems: initialHistory.payload.history,
       }, undefined, new UserNotifier());
 
       // Wire event dispatch through channel
       agent.setEventDispatcher((event) => {
-        channelManager.dispatchEvent(event.msg, 'sidepanel-main').catch(() => {});
+        channelManager.dispatchEvent({ msg: event.msg }, 'sidepanel-main').catch(() => {});
       });
 
       if (currentAuthManager) {
@@ -502,7 +502,7 @@ async function registerServiceHandlers(): Promise<void> {
       const history = session.getConversationHistory();
 
       console.log('[ServiceWorker] Session resumed with', history.items.length, 'items');
-      return { conversationId, history: history.items };
+      return { sessionId, history: history.items };
     });
 
     serviceRegistry.register('agent.configUpdate', async () => {
@@ -522,7 +522,7 @@ async function registerServiceHandlers(): Promise<void> {
 
           // Wire event dispatch through channel
           agent!.setEventDispatcher((event) => {
-            channelManager.dispatchEvent(event.msg, 'sidepanel-main').catch(() => {});
+            channelManager.dispatchEvent({ msg: event.msg }, 'sidepanel-main').catch(() => {});
           });
 
           if (currentAuthManager && agent) {
@@ -541,7 +541,7 @@ async function registerServiceHandlers(): Promise<void> {
 
           agent = new RepublicAgent(agentConfig, undefined, undefined, new UserNotifier());
           agent.setEventDispatcher((event) => {
-            channelManager.dispatchEvent(event.msg, 'sidepanel-main').catch(() => {});
+            channelManager.dispatchEvent({ msg: event.msg }, 'sidepanel-main').catch(() => {});
           });
 
           if (currentAuthManager) {
@@ -559,7 +559,7 @@ async function registerServiceHandlers(): Promise<void> {
 
         // Notify UI via channel
         channelManager.dispatchEvent(
-          { type: 'BackgroundEvent', data: { message: 'Agent reinitialized', level: 'info' } },
+          { msg: { type: 'BackgroundEvent', data: { message: 'Agent reinitialized', level: 'info' } } },
           'sidepanel-main'
         ).catch(() => {});
 
@@ -1302,7 +1302,7 @@ function setupPeriodicTasks(): void {
         if (session?.agent) {
           const event = await session.agent.getNextEvent();
           if (event && channelManager) {
-            await channelManager.broadcastEvent(event.msg);
+            await channelManager.broadcastEvent({ msg: event.msg, sessionId: sessionMeta.sessionId });
           }
         }
       }
@@ -1312,7 +1312,7 @@ function setupPeriodicTasks(): void {
       if (event) {
         try {
           const { getChannelManager } = await import('@/core/channels/ChannelManager');
-          await getChannelManager().broadcastEvent(event.msg);
+          await getChannelManager().broadcastEvent({ msg: event.msg });
         } catch { /* channel not ready */ }
       }
     }

--- a/src/extension/channels/SidePanelChannel.ts
+++ b/src/extension/channels/SidePanelChannel.ts
@@ -13,8 +13,10 @@ import type {
   ChannelCapabilities,
   SubmissionHandler,
   SubmissionContext,
+  ChannelEvent,
 } from '@/core/channels/types';
-import type { EventMsg, Op } from '@/core/protocol/types';
+import type { EventMsg } from '@/core/protocol/events';
+import type { Op } from '@/core/protocol/types';
 
 /**
  * Message types for side panel communication
@@ -74,7 +76,7 @@ export class SidePanelChannel implements ChannelAdapter {
           channelType: this.channelType,
           tabId: message.tabId ?? sender.tab?.id,
           sessionId: message.sessionId,
-          replyCallback: async (event: EventMsg) => {
+          replyCallback: async (event) => {
             await this.sendEvent(event);
           },
         };
@@ -120,10 +122,11 @@ export class SidePanelChannel implements ChannelAdapter {
     this.submissionHandler = handler;
   }
 
-  async sendEvent(event: EventMsg, _targetClientId?: string): Promise<void> {
+  async sendEvent(event: ChannelEvent, _targetClientId?: string): Promise<void> {
     const message: SidePanelMessage = {
       type: 'event',
-      event,
+      event: event.msg,
+      sessionId: event.sessionId,
     };
 
     try {

--- a/src/extension/channels/TabPageChannel.ts
+++ b/src/extension/channels/TabPageChannel.ts
@@ -13,8 +13,10 @@ import type {
   ChannelCapabilities,
   SubmissionHandler,
   SubmissionContext,
+  ChannelEvent,
 } from '@/core/channels/types';
-import type { EventMsg, Op } from '@/core/protocol/types';
+import type { EventMsg } from '@/core/protocol/events';
+import type { Op } from '@/core/protocol/types';
 
 /**
  * Message types for tab page communication
@@ -83,7 +85,7 @@ export class TabPageChannel implements ChannelAdapter {
           channelType: this.channelType,
           tabId: this.tabId,
           sessionId: message.sessionId,
-          replyCallback: async (event: EventMsg) => {
+          replyCallback: async (event) => {
             await this.sendEvent(event);
           },
         };
@@ -129,11 +131,12 @@ export class TabPageChannel implements ChannelAdapter {
     this.submissionHandler = handler;
   }
 
-  async sendEvent(event: EventMsg, _targetClientId?: string): Promise<void> {
+  async sendEvent(event: ChannelEvent, _targetClientId?: string): Promise<void> {
     const message: TabPageMessage = {
       type: 'tabpage-event',
       tabId: this.tabId,
-      event,
+      event: event.msg,
+      sessionId: event.sessionId,
     };
 
     try {

--- a/src/server/agent/ServerAgentBootstrap.ts
+++ b/src/server/agent/ServerAgentBootstrap.ts
@@ -321,7 +321,7 @@ export class ServerAgentBootstrap {
 
     this.agent.setEventDispatcher((event) => {
       // Dispatch to ServerChannel → WebSocket clients
-      channelManager.dispatchEvent(event.msg, this.channel!.channelId).catch((error) => {
+      channelManager.dispatchEvent({ msg: event.msg }, this.channel!.channelId).catch((error) => {
         console.error('[ServerAgentBootstrap] Failed to dispatch event:', error);
       });
 
@@ -563,7 +563,7 @@ export class ServerAgentBootstrap {
           },
           eventDispatcherFactory: (sessionId) => (event) => {
             // Forward events to WebSocket clients AND intercept completions
-            channelManager.dispatchEvent(event.msg, this.channel!.channelId).catch(() => {});
+            channelManager.dispatchEvent({ msg: event.msg, sessionId }, this.channel!.channelId).catch(() => {});
             this.handleSchedulerEventCompletion(event.msg);
           },
         });

--- a/src/server/channels/ServerChannel.ts
+++ b/src/server/channels/ServerChannel.ts
@@ -18,6 +18,7 @@ import type {
   ChannelCapabilities,
 } from '@/core/channels/types';
 import type { EventMsg } from '@/core/protocol/events';
+import type { ChannelEvent } from '@/core/channels/types';
 import type { Op } from '@/core/protocol/types';
 import { shouldReceiveEvent } from '../auth/authorize';
 import { makeEvent } from '@applepi/ws-server';
@@ -82,14 +83,15 @@ export class ServerChannel implements ChannelAdapter {
    * If targetClientId is specified, send only to that connection.
    * Otherwise, broadcast to all eligible connections (filtered by scope).
    */
-  async sendEvent(event: EventMsg, targetClientId?: string): Promise<void> {
+  async sendEvent(event: ChannelEvent, targetClientId?: string): Promise<void> {
     if (!this.initialized) {
       throw new Error('ServerChannel not initialized');
     }
 
     this.eventSeq++;
-    const eventName = this.eventMsgToName(event);
-    const frame = JSON.stringify(makeEvent(eventName, event, this.eventSeq));
+    const eventMsg = event.msg;
+    const eventName = this.eventMsgToName(eventMsg);
+    const frame = JSON.stringify(makeEvent(eventName, eventMsg, this.eventSeq));
 
     const connections = getTrackedConnections();
     for (const conn of connections) {

--- a/src/server/plugins/channel-bridge.ts
+++ b/src/server/plugins/channel-bridge.ts
@@ -12,6 +12,7 @@
 import type { ChannelAdapter } from '@/core/channels/ChannelAdapter';
 import type {
   ChannelType,
+  ChannelEvent,
   SubmissionHandler,
   SubmissionContext,
   ChannelCapabilities,
@@ -146,16 +147,17 @@ export class ChannelPluginBridge implements ChannelAdapter {
     this.submissionHandler = handler;
   }
 
-  async sendEvent(event: EventMsg, _targetClientId?: string): Promise<void> {
+  async sendEvent(event: ChannelEvent, _targetClientId?: string): Promise<void> {
+    const msg = event.msg;
     // Convert agent events to outbound plugin messages
-    if (event.type === 'AgentMessage' && this.plugin.outbound) {
+    if (msg.type === 'AgentMessage' && this.plugin.outbound) {
       const outboundCtx: ChannelOutboundContext = {
         accountId: this.accountId,
         target: '', // Set by the submission context's replyCallback
       };
 
       try {
-        await this.plugin.outbound.sendText(outboundCtx, event.data.message);
+        await this.plugin.outbound.sendText(outboundCtx, msg.data.message);
       } catch (err) {
         console.error(`[ChannelBridge] ${this.channelId} outbound error:`, err);
       }
@@ -235,14 +237,14 @@ export class ChannelPluginBridge implements ChannelAdapter {
       channelType: this.channelType,
       userId: msg.senderId,
       sessionId: sessionKey,
-      replyCallback: async (event: EventMsg) => {
-        if (event.type === 'AgentMessage') {
+      replyCallback: async (event: ChannelEvent) => {
+        if (event.msg.type === 'AgentMessage') {
           const outCtx: ChannelOutboundContext = {
             accountId: this.accountId,
             target: msg.channelId,
             threadId: msg.threadId,
           };
-          await this.plugin.outbound.sendText(outCtx, event.data.message);
+          await this.plugin.outbound.sendText(outCtx, event.msg.data.message);
         }
       },
     };

--- a/src/storage/__tests__/rollout-integration.test.ts
+++ b/src/storage/__tests__/rollout-integration.test.ts
@@ -44,7 +44,7 @@ describe('Rollout Integration Tests', () => {
       // Step 1: Create new rollout
       const createParams: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
         instructions: 'Test integration',
       };
       const recorder1 = await RolloutRecorder.create(createParams);
@@ -104,7 +104,7 @@ describe('Rollout Integration Tests', () => {
       // Session 1: Create and add some items
       const rec1 = await RolloutRecorder.create({
         type: 'create',
-        conversationId: id1,
+        sessionId: id1,
       });
       await rec1.recordItems([
         { type: 'response_item', payload: { type: 'message', content: 'First' } },
@@ -135,7 +135,7 @@ describe('Rollout Integration Tests', () => {
 
       const recorder = await RolloutRecorder.create({
         type: 'create',
-        conversationId: id1,
+        sessionId: id1,
       });
 
       // Queue multiple record operations
@@ -161,7 +161,7 @@ describe('Rollout Integration Tests', () => {
 
       // Create expired rollout (TTL=0 means expiresAt = now, already expired)
       const expiredRecorder = await RolloutRecorder.create(
-        { type: 'create', conversationId: expiredId },
+        { type: 'create', sessionId: expiredId },
         { storage: { rolloutTTL: 0 } }
       );
       await expiredRecorder.recordItems([
@@ -174,7 +174,7 @@ describe('Rollout Integration Tests', () => {
 
       // Create permanent rollout
       const permanentRecorder = await RolloutRecorder.create(
-        { type: 'create', conversationId: permanentId },
+        { type: 'create', sessionId: permanentId },
         { storage: { rolloutTTL: 'permanent' } }
       );
       await permanentRecorder.recordItems([
@@ -200,7 +200,7 @@ describe('Rollout Integration Tests', () => {
 
       // Create rollout with items, set to expire immediately (TTL=0)
       const recorder = await RolloutRecorder.create(
-        { type: 'create', conversationId: id },
+        { type: 'create', sessionId: id },
         { storage: { rolloutTTL: 0 } }
       );
       await recorder.recordItems([
@@ -228,7 +228,7 @@ describe('Rollout Integration Tests', () => {
         const id = `${i.toString().padStart(8, '0')}-7777-4777-8777-777777777777`;
         const recorder = await RolloutRecorder.create({
           type: 'create',
-          conversationId: id,
+          sessionId: id,
         });
         await recorder.recordItems([
           { type: 'response_item', payload: { type: 'message', content: `Item ${i}` } },

--- a/src/storage/__tests__/rollout-performance.perf.test.ts
+++ b/src/storage/__tests__/rollout-performance.perf.test.ts
@@ -25,7 +25,7 @@ describe('Rollout Performance Tests', () => {
       const conversationId: ConversationId = '5973b6c0-94b8-4f7b-a530-2aeb6098ae0e';
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
 
       const recorder = await RolloutRecorder.create(params);
@@ -50,7 +50,7 @@ describe('Rollout Performance Tests', () => {
       const conversationId: ConversationId = '1111b6c0-94b8-4f7b-a530-2aeb6098ae0e';
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
 
       const recorder = await RolloutRecorder.create(params);
@@ -77,7 +77,7 @@ describe('Rollout Performance Tests', () => {
       const conversationId: ConversationId = '2222b6c0-94b8-4f7b-a530-2aeb6098ae0e';
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
 
       const recorder = await RolloutRecorder.create(params);
@@ -115,7 +115,7 @@ describe('Rollout Performance Tests', () => {
         const id = `${i.toString().padStart(8, '0')}-0000-4000-8000-000000000000`;
         const params: RolloutRecorderParams = {
           type: 'create',
-          conversationId: id,
+          sessionId: id,
         };
         createPromises.push(
           RolloutRecorder.create(params).then(async (recorder) => {
@@ -148,7 +148,7 @@ describe('Rollout Performance Tests', () => {
         const id = `${i.toString().padStart(8, '0')}-1111-4111-8111-111111111111`;
         const params: RolloutRecorderParams = {
           type: 'create',
-          conversationId: id,
+          sessionId: id,
         };
         const config = {
           storage: { rolloutTTL: 0 }, // Expire immediately
@@ -185,7 +185,7 @@ describe('Rollout Performance Tests', () => {
       const conversationId: ConversationId = '3333b6c0-94b8-4f7b-a530-2aeb6098ae0e';
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
 
       const recorder = await RolloutRecorder.create(params);

--- a/src/storage/rollout/RolloutRecorder.ts
+++ b/src/storage/rollout/RolloutRecorder.ts
@@ -124,11 +124,11 @@ export class RolloutRecorder {
     params: Extract<RolloutRecorderParams, { type: 'create' }>,
     config?: IAgentConfigWithStorage
   ): Promise<RolloutRecorder> {
-    const { conversationId, instructions } = params;
+    const { sessionId, instructions } = params;
 
     // Validate conversation ID
-    if (!isValidConversationId(conversationId)) {
-      throw createInvalidIdError(conversationId);
+    if (!isValidConversationId(sessionId)) {
+      throw createInvalidIdError(sessionId);
     }
 
     // Calculate expiration
@@ -136,17 +136,17 @@ export class RolloutRecorder {
 
     // Initialize writer with provider
     const provider = await RolloutRecorder.getProvider();
-    const writer = await RolloutWriter.create(conversationId, 0, provider);
+    const writer = await RolloutWriter.create(sessionId, 0, provider);
 
     // Create metadata record with placeholder title
     const now = Date.now();
     const metadata: RolloutMetadataRecord = {
-      id: conversationId,
+      id: sessionId,
       created: now,
       updated: now,
       expiresAt,
       sessionMeta: {
-        id: conversationId,
+        id: sessionId,
         timestamp: getCurrentTimestamp(),
         originator: 'chrome-extension',
         cliVersion: '1.0.0', // TODO: Load from package.json or config
@@ -158,7 +158,7 @@ export class RolloutRecorder {
     };
 
     // Lazy initialization: don't write metadata or sessionMetaItem yet
-    const recorder = new RolloutRecorder(writer, conversationId, false);
+    const recorder = new RolloutRecorder(writer, sessionId, false);
     recorder.pendingMetadata = metadata;
     recorder.pendingSessionMeta = {
       type: 'session_meta',
@@ -405,7 +405,7 @@ export class RolloutRecorder {
     const history = await RolloutRecorder.loadAllItems(rolloutId);
 
     const resumedHistory: ResumedHistory = {
-      conversationId: rolloutId,
+      sessionId: rolloutId,
       history,
       rolloutId,
     };

--- a/src/storage/rollout/__tests__/RolloutRecorder.test.ts
+++ b/src/storage/rollout/__tests__/RolloutRecorder.test.ts
@@ -92,7 +92,7 @@ describe('RolloutRecorder', () => {
     it('should create new rollout with conversationId', async () => {
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
 
       const recorder = await RolloutRecorder.create(params);
@@ -103,7 +103,7 @@ describe('RolloutRecorder', () => {
     it('should create IndexedDB database "ApplePiRollouts"', async () => {
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
 
       await RolloutRecorder.create(params);
@@ -116,7 +116,7 @@ describe('RolloutRecorder', () => {
     it('should create rollouts record with default 60-day expiration', async () => {
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
 
       const recorder = await RolloutRecorder.create(params);
@@ -134,7 +134,7 @@ describe('RolloutRecorder', () => {
     it('should write SessionMeta as first item (sequence 0)', async () => {
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
         instructions: 'Test instructions',
       };
 
@@ -148,7 +148,7 @@ describe('RolloutRecorder', () => {
     it('should support custom TTL config (30 days)', async () => {
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
       const config: IAgentConfigWithStorage = {
         storage: { rolloutTTL: 30 },
@@ -163,7 +163,7 @@ describe('RolloutRecorder', () => {
     it('should support permanent storage (no expiration)', async () => {
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
       const config: IAgentConfigWithStorage = {
         storage: { rolloutTTL: 'permanent' },
@@ -178,7 +178,7 @@ describe('RolloutRecorder', () => {
     it('should reject invalid conversation ID (non-UUID)', async () => {
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId: 'not-a-uuid',
+        sessionId: 'not-a-uuid',
       };
 
       await expect(RolloutRecorder.create(params)).rejects.toThrow(/Invalid conversation ID/);
@@ -187,7 +187,7 @@ describe('RolloutRecorder', () => {
     it('should include instructions in SessionMeta', async () => {
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
         instructions: 'Help me debug',
       };
 
@@ -201,7 +201,7 @@ describe('RolloutRecorder', () => {
       // Create a rollout and trigger lazy initialization by recording an item
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
       const recorder = await RolloutRecorder.create(params);
       await recorder.recordItems([
@@ -225,7 +225,7 @@ describe('RolloutRecorder', () => {
       // Create rollout with items
       const createParams: RolloutRecorderParams = {
         type: 'create',
-        conversationId: '1234b6c0-94b8-4f7b-a530-2aeb6098ae0e',
+        sessionId: '1234b6c0-94b8-4f7b-a530-2aeb6098ae0e',
       };
       const recorder1 = await RolloutRecorder.create(createParams);
       await recorder1.recordItems([
@@ -265,7 +265,7 @@ describe('RolloutRecorder', () => {
     beforeEach(async () => {
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
       recorder = await RolloutRecorder.create(params);
     });
@@ -347,7 +347,7 @@ describe('RolloutRecorder', () => {
     beforeEach(async () => {
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
       recorder = await RolloutRecorder.create(params);
     });
@@ -382,7 +382,7 @@ describe('RolloutRecorder', () => {
     it('should return correct conversation ID', async () => {
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
       const recorder = await RolloutRecorder.create(params);
 
@@ -392,7 +392,7 @@ describe('RolloutRecorder', () => {
     it('should return stable value across lifetime', async () => {
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
       const recorder = await RolloutRecorder.create(params);
 
@@ -408,7 +408,7 @@ describe('RolloutRecorder', () => {
     it('should flush pending writes before shutdown', async () => {
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
       const recorder = await RolloutRecorder.create(params);
 
@@ -426,7 +426,7 @@ describe('RolloutRecorder', () => {
     it('should be idempotent (multiple shutdowns)', async () => {
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
       const recorder = await RolloutRecorder.create(params);
 
@@ -440,7 +440,7 @@ describe('RolloutRecorder', () => {
     it('should make instance unusable after shutdown', async () => {
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
       const recorder = await RolloutRecorder.create(params);
       await recorder.shutdown();
@@ -506,7 +506,7 @@ describe('RolloutRecorder', () => {
       // Create rollout with items
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
       const recorder = await RolloutRecorder.create(params);
       await recorder.recordItems([
@@ -521,14 +521,14 @@ describe('RolloutRecorder', () => {
       expect(history.type).toBe('resumed');
       if (history.type === 'resumed') {
         expect(history.payload.history.length).toBeGreaterThan(0);
-        expect(history.payload.conversationId).toBe(conversationId);
+        expect(history.payload.sessionId).toBe(conversationId);
       }
     });
 
     it('should handle rollout with only session meta', async () => {
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
       const recorder = await RolloutRecorder.create(params);
       // Trigger lazy initialization by recording a single item
@@ -555,7 +555,7 @@ describe('RolloutRecorder', () => {
     it('should return correct counts after recording items', async () => {
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
       const recorder = await RolloutRecorder.create(params);
       await recorder.recordItems([
@@ -576,13 +576,13 @@ describe('RolloutRecorder', () => {
       const id1 = conversationId;
       const id2 = '1111b6c0-94b8-4f7b-a530-2aeb6098ae0e';
 
-      const rec1 = await RolloutRecorder.create({ type: 'create', conversationId: id1 });
+      const rec1 = await RolloutRecorder.create({ type: 'create', sessionId: id1 });
       await rec1.recordItems([
         { type: 'response_item', payload: { type: 'message', content: 'A' } },
       ]);
       await rec1.shutdown();
 
-      const rec2 = await RolloutRecorder.create({ type: 'create', conversationId: id2 });
+      const rec2 = await RolloutRecorder.create({ type: 'create', sessionId: id2 });
       await rec2.recordItems([
         { type: 'response_item', payload: { type: 'message', content: 'B' } },
       ]);
@@ -598,7 +598,7 @@ describe('RolloutRecorder', () => {
   describe('Section 9: cleanupExpired() static method - T018', () => {
     it('should delete expired rollouts', async () => {
       // Create a rollout first so the DB/stores exist
-      const params: RolloutRecorderParams = { type: 'create', conversationId };
+      const params: RolloutRecorderParams = { type: 'create', sessionId: conversationId };
       const recorder = await RolloutRecorder.create(params);
       await recorder.recordItems([
         { type: 'response_item', payload: { type: 'Message', content: 'test' } },
@@ -612,7 +612,7 @@ describe('RolloutRecorder', () => {
 
     it('should return count of deleted rollouts', async () => {
       // Create a rollout first so the DB/stores exist
-      const params: RolloutRecorderParams = { type: 'create', conversationId };
+      const params: RolloutRecorderParams = { type: 'create', sessionId: conversationId };
       const recorder = await RolloutRecorder.create(params);
       await recorder.recordItems([
         { type: 'response_item', payload: { type: 'Message', content: 'test' } },
@@ -627,7 +627,7 @@ describe('RolloutRecorder', () => {
       // Create permanent rollout and trigger initialization
       const params: RolloutRecorderParams = {
         type: 'create',
-        conversationId,
+        sessionId: conversationId,
       };
       const config: IAgentConfigWithStorage = {
         storage: { rolloutTTL: 'permanent' },
@@ -648,7 +648,7 @@ describe('RolloutRecorder', () => {
 
     it('should cascade delete rollout items', async () => {
       // Create a rollout first so the DB/stores exist
-      const params: RolloutRecorderParams = { type: 'create', conversationId };
+      const params: RolloutRecorderParams = { type: 'create', sessionId: conversationId };
       const recorder = await RolloutRecorder.create(params);
       await recorder.recordItems([
         { type: 'response_item', payload: { type: 'Message', content: 'test' } },

--- a/src/storage/rollout/helpers.ts
+++ b/src/storage/rollout/helpers.ts
@@ -133,11 +133,11 @@ export function isValidUUID(uuid: string): boolean {
 
 /**
  * Validate conversation ID (must be valid UUID).
- * @param conversationId - Conversation ID to validate
+ * @param sessionId - Conversation ID to validate
  * @returns True if valid
  */
-export function isValidConversationId(conversationId: ConversationId): boolean {
-  return isValidUUID(conversationId);
+export function isValidConversationId(sessionId: ConversationId): boolean {
+  return isValidUUID(sessionId);
 }
 
 // ============================================================================
@@ -146,11 +146,11 @@ export function isValidConversationId(conversationId: ConversationId): boolean {
 
 /**
  * Create an error for invalid conversation ID.
- * @param conversationId - The invalid ID
+ * @param sessionId - The invalid ID
  * @returns Error object
  */
-export function createInvalidIdError(conversationId: string): Error {
-  return new Error(`Invalid conversation ID: ${conversationId}. Must be a valid UUID.`);
+export function createInvalidIdError(sessionId: string): Error {
+  return new Error(`Invalid conversation ID: ${sessionId}. Must be a valid UUID.`);
 }
 
 /**

--- a/src/storage/rollout/types.ts
+++ b/src/storage/rollout/types.ts
@@ -32,7 +32,7 @@ export type ConversationId = string;
 export type RolloutRecorderParams =
   | {
     type: 'create';
-    conversationId: ConversationId;
+    sessionId: ConversationId;
     instructions?: string;
   }
   | {
@@ -227,7 +227,7 @@ export interface ConversationsPage {
  */
 export interface ResumedHistory {
   /** Conversation ID */
-  conversationId: ConversationId;
+  sessionId: ConversationId;
   /** All rollout items in chronological order */
   history: RolloutItem[];
   /** IndexedDB rollout identifier */

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -33,18 +33,18 @@ export class GeminiLogger {
   /**
    * Log stream start event
    */
-  static streamStart(modelName: string, conversationId: string): void {
+  static streamStart(modelName: string, sessionId: string): void {
     if (!this.enabled) return;
-    console.log(`[Gemini] Stream starting - Model: ${modelName}, Conversation: ${conversationId}`);
+    console.log(`[Gemini] Stream starting - Model: ${modelName}, Conversation: ${sessionId}`);
   }
 
   /**
    * Log stream end event
    */
-  static streamEnd(conversationId: string, totalChunks?: number): void {
+  static streamEnd(sessionId: string, totalChunks?: number): void {
     if (!this.enabled) return;
     const chunksInfo = totalChunks !== undefined ? `, Total chunks: ${totalChunks}` : '';
-    console.log(`[Gemini] Stream ended - Conversation: ${conversationId}${chunksInfo}`);
+    console.log(`[Gemini] Stream ended - Conversation: ${sessionId}${chunksInfo}`);
   }
 
   /**

--- a/src/webfront/components/MessageInput.svelte
+++ b/src/webfront/components/MessageInput.svelte
@@ -20,7 +20,7 @@
   export let placeholder: string = t('>> Enter command...');
   export let onSubmit: (value: string) => void = () => {};
   export let onStop: () => void = () => {};
-  export let onSelectConversation: (conversationId: string) => void = () => {};
+  export let onSelectConversation: (sessionId: string) => void = () => {};
   export let onNewConversation: () => void = () => {};
   export let tabId: number = -1;
   export let isProcessing: boolean = false;

--- a/src/webfront/components/chat/ChatHistoryList.svelte
+++ b/src/webfront/components/chat/ChatHistoryList.svelte
@@ -5,7 +5,7 @@
   import { _t } from '../../lib/i18n';
 
   // Props
-  export let onSelectConversation: (conversationId: string) => void = () => {};
+  export let onSelectConversation: (sessionId: string) => void = () => {};
   export let onClose: () => void = () => {};
 
   // State
@@ -176,8 +176,8 @@
     }
   }
 
-  function handleSelectConversation(conversationId: string) {
-    onSelectConversation(conversationId);
+  function handleSelectConversation(sessionId: string) {
+    onSelectConversation(sessionId);
     onClose();
   }
 </script>

--- a/src/webfront/components/chat/ChatHistoryPopup.svelte
+++ b/src/webfront/components/chat/ChatHistoryPopup.svelte
@@ -5,7 +5,7 @@
   import { uiTheme, type UITheme } from '../../stores/themeStore';
   import { _t } from '../../lib/i18n';
 
-  export let onSelectConversation: (conversationId: string) => void = () => {};
+  export let onSelectConversation: (sessionId: string) => void = () => {};
 
   let showPopup = false;
   let currentTheme: UITheme = 'terminal';
@@ -22,8 +22,8 @@
     showPopup = false;
   }
 
-  function handleSelectConversation(conversationId: string) {
-    onSelectConversation(conversationId);
+  function handleSelectConversation(sessionId: string) {
+    onSelectConversation(sessionId);
     closePopup();
   }
 </script>

--- a/src/webfront/components/threads/ThreadBar.svelte
+++ b/src/webfront/components/threads/ThreadBar.svelte
@@ -17,20 +17,20 @@
   onDestroy(unsubTheme);
 
   const dispatch = createEventDispatcher<{
-    threadSelect: { threadId: string };
-    threadClose: { threadId: string };
+    threadSelect: { sessionId: string };
+    threadClose: { sessionId: string };
     newThread: void;
   }>();
 
   $: threads = $threadStore.threads;
-  $: activeThreadId = $threadStore.activeThreadId;
+  $: activeSessionId = $threadStore.activeSessionId;
 
-  function handleThreadSelect(event: CustomEvent<{ threadId: string }>) {
-    dispatch('threadSelect', { threadId: event.detail.threadId });
+  function handleThreadSelect(event: CustomEvent<{ sessionId: string }>) {
+    dispatch('threadSelect', { sessionId: event.detail.sessionId });
   }
 
-  function handleThreadClose(event: CustomEvent<{ threadId: string }>) {
-    dispatch('threadClose', { threadId: event.detail.threadId });
+  function handleThreadClose(event: CustomEvent<{ sessionId: string }>) {
+    dispatch('threadClose', { sessionId: event.detail.sessionId });
   }
 
   function handleNewThread() {
@@ -56,10 +56,10 @@
   aria-label="Conversation threads"
 >
   <div class="flex items-end gap-0.5 flex-1 min-w-0">
-    {#each threads as thread (thread.id)}
+    {#each threads as thread (thread.sessionId)}
       <ThreadTab
         {thread}
-        isActive={thread.id === activeThreadId}
+        isActive={thread.sessionId === activeSessionId}
         showClose={threads.length > 1}
         on:select={handleThreadSelect}
         on:close={handleThreadClose}

--- a/src/webfront/components/threads/ThreadTab.svelte
+++ b/src/webfront/components/threads/ThreadTab.svelte
@@ -16,19 +16,19 @@
   onDestroy(unsubTheme);
 
   const dispatch = createEventDispatcher<{
-    select: { threadId: string };
-    close: { threadId: string };
+    select: { sessionId: string };
+    close: { sessionId: string };
   }>();
 
   $: displayTitle = thread.title.length > 20 ? thread.title.substring(0, 20) + '...' : thread.title;
 
   function handleSelect() {
-    dispatch('select', { threadId: thread.id });
+    dispatch('select', { sessionId: thread.sessionId });
   }
 
   function handleClose(event: MouseEvent) {
     event.stopPropagation();
-    dispatch('close', { threadId: thread.id });
+    dispatch('close', { sessionId: thread.sessionId });
   }
 
   function handleKeydown(event: KeyboardEvent) {
@@ -42,7 +42,7 @@
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       event.stopPropagation();
-      dispatch('close', { threadId: thread.id });
+      dispatch('close', { sessionId: thread.sessionId });
     }
   }
 </script>

--- a/src/webfront/pages/chat/Main.svelte
+++ b/src/webfront/pages/chat/Main.svelte
@@ -151,14 +151,22 @@
       console.log('[App] UIChannelClient initialized');
 
       // Listen for all events from backend (wildcard)
-      // Filter out event types that have their own dedicated handlers
+      // Wildcard handler receives ChannelEvent { msg, sessionId }
       const HANDLED_EVENT_TYPES = new Set(['StateUpdate', 'BackgroundEvent', 'ServiceResponse']);
       unsubscribers.push(
-        client.onEvent('*', (eventMsg: any) => {
+        client.onEvent('*', (channelEvent: any) => {
+          const eventMsg = channelEvent?.msg ?? channelEvent;
           if (HANDLED_EVENT_TYPES.has(eventMsg?.type)) return;
-          // Wrap EventMsg in Event envelope for handleEvent compatibility
           const event: Event = { id: `evt_${Date.now()}`, msg: eventMsg };
-          handleEvent(event);
+          const eventSessionId = channelEvent?.sessionId;
+
+          if (!eventSessionId || eventSessionId === activeSessionId) {
+            // Active thread — render immediately
+            handleEvent(event);
+          } else {
+            // Background thread — buffer in threadStates
+            handleEventForSession(event, eventSessionId);
+          }
         })
       );
 
@@ -666,6 +674,7 @@
         },
         {
           tabId: currentTabId, // Include current tab selection in context
+          sessionId: activeSessionId, // Route to correct agent session
         },
       );
 
@@ -788,8 +797,8 @@
    * Resume a conversation from chat history
    * Loads the selected conversation and restores its state
    */
-  async function resumeConversation(conversationId: string) {
-    console.log('[App] Resuming conversation:', conversationId);
+  async function resumeConversation(sessionId: string) {
+    console.log('[App] Resuming conversation:', sessionId);
 
     // Clear current UI state
     messages = [];
@@ -803,10 +812,10 @@
     try {
       if (!client) throw new Error('Message service not available');
       // Request session resume from backend
-      const response = await (await getInitializedUIClient()).serviceRequest<{ history?: unknown[] }>('session.resume', { conversationId });
+      const response = await (await getInitializedUIClient()).serviceRequest<{ history?: unknown[] }>('session.resume', { sessionId });
 
       const historyItems = response?.history;
-      console.log('[App] Conversation resumed:', conversationId, 'with', historyItems?.length || 0, 'items');
+      console.log('[App] Conversation resumed:', sessionId, 'with', historyItems?.length || 0, 'items');
 
       // Restore history to UI using shared helper
       if (historyItems && Array.isArray(historyItems)) {
@@ -972,7 +981,7 @@
 
       // Try to get session list from registry
       const listResponse = await c.serviceRequest<{
-        sessions: Array<{ sessionId: string; conversationId: string; type: string; state: string }>;
+        sessions: Array<{ sessionId: string; type: string; state: string }>;
         maxConcurrent: number;
         activeCount: number;
       }>('session.list');
@@ -985,9 +994,8 @@
         const existingSessionIds = new Set(currentState.threads.map(t => t.sessionId));
 
         for (const session of backendSessions) {
-          const sid = session.sessionId || session.conversationId;
-          if (!existingSessionIds.has(sid)) {
-            threadStore.createThread(sid, 'New Thread');
+          if (!existingSessionIds.has(session.sessionId)) {
+            threadStore.createThread(session.sessionId, 'New Thread');
           }
         }
       } else {
@@ -1006,8 +1014,8 @@
 
       // Ensure we have an active thread
       const finalState = get(threadStore);
-      if (finalState.threads.length > 0 && !finalState.activeThreadId) {
-        threadStore.setActiveThread(finalState.threads[0].id);
+      if (finalState.threads.length > 0 && !finalState.activeSessionId) {
+        threadStore.setActiveThread(finalState.threads[0].sessionId);
       }
 
       // Set active session ID for event routing
@@ -1054,11 +1062,11 @@
         currentTabId: -1,
         eventProcessor: new EventProcessor(),
       };
-      threadStates.set(newThread.id, newState);
+      threadStates.set(sessionId, newState);
 
       // Switch to the new thread
       activeSessionId = sessionId;
-      loadThreadState(newThread.id);
+      loadThreadState(sessionId);
 
       // Update session limits
       await updateSessionLimits();
@@ -1066,7 +1074,7 @@
       // Auto-bind to active browser tab
       await bindToActiveTab();
 
-      console.log(`[App] Created new thread: ${newThread.id} with session: ${sessionId}`);
+      console.log(`[App] Created new thread with session: ${sessionId}`);
     } catch (error) {
       console.error('[App] Failed to create new thread:', error);
     }
@@ -1075,40 +1083,35 @@
   /**
    * Handle thread selection from ThreadBar
    */
-  function handleThreadSelect(event: CustomEvent<{ threadId: string }>) {
-    const { threadId } = event.detail;
-    switchToThread(threadId);
+  function handleThreadSelect(event: CustomEvent<{ sessionId: string }>) {
+    const { sessionId } = event.detail;
+    switchToThread(sessionId);
   }
 
   /**
-   * Switch to a specific thread
+   * Switch to a specific thread by sessionId
    */
-  function switchToThread(threadId: string) {
-    const currentActiveThread = threadStore.getActiveThread();
-
+  function switchToThread(sessionId: string) {
     // Save current thread state before switching
-    if (currentActiveThread) {
-      saveThreadState(currentActiveThread.id);
+    if (activeSessionId) {
+      saveThreadState(activeSessionId);
     }
 
     // Set new active thread
-    threadStore.setActiveThread(threadId);
+    threadStore.setActiveThread(sessionId);
 
     // Update active session ID BEFORE loading state so that events arriving
     // during the transition are routed to the correct thread
-    const newThread = threadStore.getActiveThread();
-    if (newThread) {
-      activeSessionId = newThread.sessionId;
-    }
+    activeSessionId = sessionId;
 
     // Load state for new thread
-    loadThreadState(threadId);
+    loadThreadState(sessionId);
   }
 
   /**
    * Save current UI state to thread state map
    */
-  function saveThreadState(threadId: string) {
+  function saveThreadState(sessionId: string) {
     const state: ThreadConversationState = {
       messages: [...messages],
       processedEvents: [...processedEvents],
@@ -1117,14 +1120,14 @@
       currentTabId,
       eventProcessor: eventProcessor,
     };
-    threadStates.set(threadId, state);
+    threadStates.set(sessionId, state);
   }
 
   /**
    * Load thread state from map to UI
    */
-  function loadThreadState(threadId: string) {
-    const state = threadStates.get(threadId);
+  function loadThreadState(sessionId: string) {
+    const state = threadStates.get(sessionId);
     if (state) {
       messages = [...state.messages];
       processedEvents = [...state.processedEvents];
@@ -1157,17 +1160,17 @@
   /**
    * Handle thread close from ThreadBar
    */
-  async function handleThreadClose(event: CustomEvent<{ threadId: string }>) {
-    const { threadId } = event.detail;
-    await closeThread(threadId);
+  async function handleThreadClose(event: CustomEvent<{ sessionId: string }>) {
+    const { sessionId } = event.detail;
+    await closeThread(sessionId);
   }
 
   /**
    * Close a thread and terminate its session
    */
-  async function closeThread(threadId: string) {
+  async function closeThread(sessionId: string) {
     const state = get(threadStore);
-    const threadToClose = state.threads.find(t => t.id === threadId);
+    const threadToClose = state.threads.find(t => t.sessionId === sessionId);
 
     if (!threadToClose) return;
 
@@ -1185,37 +1188,36 @@
     // Terminate the session in backend
     try {
       const c = await getInitializedUIClient();
-      await c.serviceRequest('session.close', { sessionId: threadToClose.sessionId });
+      await c.serviceRequest('session.close', { sessionId });
     } catch (error) {
-      console.error(`[App] Failed to close session ${threadToClose.sessionId}:`, error);
+      console.error(`[App] Failed to close session ${sessionId}:`, error);
     }
 
     // Remove thread state
-    threadStates.delete(threadId);
+    threadStates.delete(sessionId);
 
     // Close thread in store (this handles switching to another thread)
-    threadStore.closeThread(threadId);
+    threadStore.closeThread(sessionId);
 
     // Update active session
     const newActiveThread = threadStore.getActiveThread();
     if (newActiveThread) {
       activeSessionId = newActiveThread.sessionId;
-      loadThreadState(newActiveThread.id);
+      loadThreadState(newActiveThread.sessionId);
     }
 
     // Update session limits
     await updateSessionLimits();
 
-    console.log(`[App] Closed thread: ${threadId}`);
+    console.log(`[App] Closed thread: ${sessionId}`);
   }
 
   /**
    * Handle new thread button click from ThreadBar
    */
   async function handleNewThread() {
-    const currentThread = threadStore.getActiveThread();
-    if (currentThread) {
-      saveThreadState(currentThread.id);
+    if (activeSessionId) {
+      saveThreadState(activeSessionId);
     }
     await createNewThread();
   }
@@ -1224,10 +1226,10 @@
    * Handle event for a specific session (background thread)
    */
   function handleEventForSession(event: Event, sessionId: string) {
-    const thread = threadStore.getThreadBySessionId(sessionId);
+    const thread = threadStore.getThread(sessionId);
     if (!thread) return;
 
-    let state = threadStates.get(thread.id);
+    let state = threadStates.get(sessionId);
     if (!state) {
       state = {
         messages: [],
@@ -1237,7 +1239,7 @@
         currentTabId: -1,
         eventProcessor: new EventProcessor(),
       };
-      threadStates.set(thread.id, state);
+      threadStates.set(sessionId, state);
     }
 
     // Process event for this thread's state
@@ -1254,23 +1256,23 @@
       state.isProcessing = false;
     }
 
-    threadStates.set(thread.id, state);
+    threadStates.set(sessionId, state);
   }
 
   /**
    * Handle session terminated event
    */
   function handleSessionTerminated(sessionId: string) {
-    const thread = threadStore.getThreadBySessionId(sessionId);
+    const thread = threadStore.getThread(sessionId);
     if (thread) {
-      console.log(`[App] Session ${sessionId} terminated, removing thread ${thread.id}`);
-      threadStates.delete(thread.id);
-      threadStore.closeThread(thread.id);
+      console.log(`[App] Session ${sessionId} terminated, removing thread`);
+      threadStates.delete(sessionId);
+      threadStore.closeThread(sessionId);
 
       const newActiveThread = threadStore.getActiveThread();
       if (newActiveThread) {
         activeSessionId = newActiveThread.sessionId;
-        loadThreadState(newActiveThread.id);
+        loadThreadState(newActiveThread.sessionId);
       } else {
         createNewThread();
       }
@@ -1300,7 +1302,7 @@
     const activeThread = threadStore.getActiveThread();
     if (activeThread && activeThread.title === 'New Thread') {
       const title = message.length > 30 ? message.substring(0, 30) + '...' : message;
-      threadStore.updateThreadTitle(activeThread.id, title);
+      threadStore.updateThreadTitle(activeThread.sessionId, title);
     }
   }
 </script>

--- a/src/webfront/pages/chat/__tests__/multi-thread.integration.test.ts
+++ b/src/webfront/pages/chat/__tests__/multi-thread.integration.test.ts
@@ -112,10 +112,10 @@ class MultiThreadStateManager {
 
   /** Handle incoming event for a specific session (background thread) */
   handleEventForSession(event: { id: string; msg: { type: string; [key: string]: any } }, sessionId: string) {
-    const thread = threadStore.getThreadBySessionId(sessionId);
+    const thread = threadStore.getThread(sessionId);
     if (!thread) return;
 
-    let state = this.threadStates.get(thread.id);
+    let state = this.threadStates.get(thread.sessionId);
     if (!state) {
       state = {
         messages: [],
@@ -125,7 +125,7 @@ class MultiThreadStateManager {
         currentTabId: -1,
         eventProcessor: createMockEventProcessor(),
       };
-      this.threadStates.set(thread.id, state);
+      this.threadStates.set(thread.sessionId, state);
     }
 
     const processed = state.eventProcessor.processEvent(event);
@@ -140,14 +140,14 @@ class MultiThreadStateManager {
       state.isProcessing = false;
     }
 
-    this.threadStates.set(thread.id, state);
+    this.threadStates.set(thread.sessionId, state);
   }
 
   /** Switch to a specific thread (replicates switchToThread in Main.svelte) */
   switchToThread(threadId: string) {
     const currentActiveThread = threadStore.getActiveThread();
     if (currentActiveThread) {
-      this.saveThreadState(currentActiveThread.id);
+      this.saveThreadState(currentActiveThread.sessionId);
     }
 
     threadStore.setActiveThread(threadId);
@@ -195,7 +195,7 @@ describe('Multi-thread integration (UI state management)', () => {
       mgr.isProcessing = true;
       mgr.currentTabId = 42;
 
-      mgr.saveThreadState(thread.id);
+      mgr.saveThreadState(thread.sessionId);
 
       // Nuke UI state
       mgr.messages = [];
@@ -204,7 +204,7 @@ describe('Multi-thread integration (UI state management)', () => {
       mgr.isProcessing = false;
       mgr.currentTabId = -1;
 
-      mgr.loadThreadState(thread.id);
+      mgr.loadThreadState(thread.sessionId);
 
       expect(mgr.messages).toEqual([{ type: 'user', content: 'hi', timestamp: 1 }]);
       expect(mgr.processedEvents).toEqual([{ id: 'pe1', type: 'AgentMessage' }]);
@@ -217,13 +217,13 @@ describe('Multi-thread integration (UI state management)', () => {
       const thread = threadStore.createThread('s1');
 
       mgr.messages = [{ type: 'user', content: 'original', timestamp: 1 }];
-      mgr.saveThreadState(thread.id);
+      mgr.saveThreadState(thread.sessionId);
 
       // Mutate the current UI array
       mgr.messages.push({ type: 'agent', content: 'extra', timestamp: 2 });
 
       // Reload — should get the original snapshot
-      mgr.loadThreadState(thread.id);
+      mgr.loadThreadState(thread.sessionId);
       expect(mgr.messages).toHaveLength(1);
       expect(mgr.messages[0].content).toBe('original');
     });
@@ -232,16 +232,16 @@ describe('Multi-thread integration (UI state management)', () => {
       const t1 = threadStore.createThread('s1');
       const t2 = threadStore.createThread('s2');
 
-      mgr.saveThreadState(t1.id);
+      mgr.saveThreadState(t1.sessionId);
       const ep1 = mgr.eventProcessor;
 
       mgr.eventProcessor = createMockEventProcessor();
-      mgr.saveThreadState(t2.id);
+      mgr.saveThreadState(t2.sessionId);
 
-      mgr.loadThreadState(t1.id);
+      mgr.loadThreadState(t1.sessionId);
       const ep1Loaded = mgr.eventProcessor;
 
-      mgr.loadThreadState(t2.id);
+      mgr.loadThreadState(t2.sessionId);
       const ep2Loaded = mgr.eventProcessor;
 
       expect(ep1Loaded).toBe(ep1);
@@ -279,8 +279,8 @@ describe('Multi-thread integration (UI state management)', () => {
       const event = { id: 'evt_1', msg: { type: 'AgentMessage', data: {} } };
       mgr.handleEventForSession(event, 'session_1');
 
-      const state1 = mgr.threadStates.get(thread1.id);
-      const state2 = mgr.threadStates.get(thread2.id);
+      const state1 = mgr.threadStates.get(thread1.sessionId);
+      const state2 = mgr.threadStates.get(thread2.sessionId);
 
       expect(state1?.processedEvents).toHaveLength(1);
       expect(state2).toBeUndefined(); // Not touched
@@ -309,8 +309,8 @@ describe('Multi-thread integration (UI state management)', () => {
         'session_new'
       );
 
-      expect(mgr.threadStates.has(thread.id)).toBe(true);
-      expect(mgr.threadStates.get(thread.id)?.processedEvents).toHaveLength(1);
+      expect(mgr.threadStates.has(thread.sessionId)).toBe(true);
+      expect(mgr.threadStates.get(thread.sessionId)?.processedEvents).toHaveLength(1);
     });
 
     it('ignores unknown sessionId', () => {
@@ -330,7 +330,7 @@ describe('Multi-thread integration (UI state management)', () => {
         'session_x'
       );
 
-      expect(mgr.threadStates.get(thread.id)?.isProcessing).toBe(true);
+      expect(mgr.threadStates.get(thread.sessionId)?.isProcessing).toBe(true);
     });
 
     it('sets isProcessing=false on TaskComplete', () => {
@@ -345,7 +345,7 @@ describe('Multi-thread integration (UI state management)', () => {
         'session_x'
       );
 
-      expect(mgr.threadStates.get(thread.id)?.isProcessing).toBe(false);
+      expect(mgr.threadStates.get(thread.sessionId)?.isProcessing).toBe(false);
     });
 
     it('sets isProcessing=false on TaskFailed', () => {
@@ -360,7 +360,7 @@ describe('Multi-thread integration (UI state management)', () => {
         'session_x'
       );
 
-      expect(mgr.threadStates.get(thread.id)?.isProcessing).toBe(false);
+      expect(mgr.threadStates.get(thread.sessionId)?.isProcessing).toBe(false);
     });
   });
 
@@ -374,13 +374,13 @@ describe('Multi-thread integration (UI state management)', () => {
       const t2 = threadStore.createThread('s2');
 
       // Put some state on t1
-      threadStore.setActiveThread(t1.id);
+      threadStore.setActiveThread(t1.sessionId);
       mgr.activeSessionId = 's1';
       mgr.messages = [{ type: 'user', content: 'thread1 msg', timestamp: 1 }];
       mgr.inputText = 'draft1';
 
       // Switch to t2
-      mgr.switchToThread(t2.id);
+      mgr.switchToThread(t2.sessionId);
 
       // t2 should have fresh state
       expect(mgr.messages).toEqual([]);
@@ -388,7 +388,7 @@ describe('Multi-thread integration (UI state management)', () => {
       expect(mgr.activeSessionId).toBe('s2');
 
       // Switch back to t1 — should restore saved state
-      mgr.switchToThread(t1.id);
+      mgr.switchToThread(t1.sessionId);
 
       expect(mgr.messages).toEqual([{ type: 'user', content: 'thread1 msg', timestamp: 1 }]);
       expect(mgr.inputText).toBe('draft1');
@@ -399,8 +399,8 @@ describe('Multi-thread integration (UI state management)', () => {
       const t1 = threadStore.createThread('s1');
       const t2 = threadStore.createThread('s2');
 
-      threadStore.setActiveThread(t1.id);
-      mgr.switchToThread(t2.id);
+      threadStore.setActiveThread(t1.sessionId);
+      mgr.switchToThread(t2.sessionId);
 
       expect(mgr.activeSessionId).toBe('s2');
     });
@@ -441,22 +441,22 @@ describe('Multi-thread integration (UI state management)', () => {
       const t2 = threadStore.createThread('s2');
 
       // Start on t1
-      threadStore.setActiveThread(t1.id);
+      threadStore.setActiveThread(t1.sessionId);
       mgr.activeSessionId = 's1';
       mgr.messages = [{ type: 'user', content: 'msg_t1', timestamp: 1 }];
-      mgr.saveThreadState(t1.id);
+      mgr.saveThreadState(t1.sessionId);
 
       // Switch to t2, add different messages
-      mgr.switchToThread(t2.id);
+      mgr.switchToThread(t2.sessionId);
       mgr.messages = [{ type: 'agent', content: 'msg_t2', timestamp: 2 }];
-      mgr.saveThreadState(t2.id);
+      mgr.saveThreadState(t2.sessionId);
 
       // Load t1 — should see t1's messages
-      mgr.loadThreadState(t1.id);
+      mgr.loadThreadState(t1.sessionId);
       expect(mgr.messages).toEqual([{ type: 'user', content: 'msg_t1', timestamp: 1 }]);
 
       // Load t2 — should see t2's messages
-      mgr.loadThreadState(t2.id);
+      mgr.loadThreadState(t2.sessionId);
       expect(mgr.messages).toEqual([{ type: 'agent', content: 'msg_t2', timestamp: 2 }]);
     });
 
@@ -471,10 +471,10 @@ describe('Multi-thread integration (UI state management)', () => {
       );
 
       // t1 should be processing
-      expect(mgr.threadStates.get(t1.id)?.isProcessing).toBe(true);
+      expect(mgr.threadStates.get(t1.sessionId)?.isProcessing).toBe(true);
 
       // t2 should NOT be processing (state doesn't even exist yet)
-      expect(mgr.threadStates.get(t2.id)?.isProcessing).toBeUndefined();
+      expect(mgr.threadStates.get(t2.sessionId)?.isProcessing).toBeUndefined();
     });
 
     it('background events accumulate correctly for each thread', () => {
@@ -486,8 +486,8 @@ describe('Multi-thread integration (UI state management)', () => {
       mgr.handleEventForSession({ id: 'e2', msg: { type: 'AgentMessage', data: {} } }, 's1');
       mgr.handleEventForSession({ id: 'e3', msg: { type: 'AgentMessage', data: {} } }, 's2');
 
-      expect(mgr.threadStates.get(t1.id)?.processedEvents).toHaveLength(2);
-      expect(mgr.threadStates.get(t2.id)?.processedEvents).toHaveLength(1);
+      expect(mgr.threadStates.get(t1.sessionId)?.processedEvents).toHaveLength(2);
+      expect(mgr.threadStates.get(t2.sessionId)?.processedEvents).toHaveLength(1);
     });
 
     it('switching threads reveals accumulated background events', () => {
@@ -495,7 +495,7 @@ describe('Multi-thread integration (UI state management)', () => {
       const t2 = threadStore.createThread('s2');
 
       // Simulate: active on t1, background events arrive for t2
-      threadStore.setActiveThread(t1.id);
+      threadStore.setActiveThread(t1.sessionId);
       mgr.activeSessionId = 's1';
       mgr.messages = [{ type: 'user', content: 'active thread', timestamp: 1 }];
 
@@ -503,7 +503,7 @@ describe('Multi-thread integration (UI state management)', () => {
       mgr.handleEventForSession({ id: 'bg2', msg: { type: 'AgentMessage', data: {} } }, 's2');
 
       // Switch to t2
-      mgr.switchToThread(t2.id);
+      mgr.switchToThread(t2.sessionId);
 
       // Should see the 2 accumulated events
       expect(mgr.processedEvents).toHaveLength(2);

--- a/src/webfront/stores/__tests__/threadStore.test.ts
+++ b/src/webfront/stores/__tests__/threadStore.test.ts
@@ -39,7 +39,6 @@ describe('threadStore', () => {
       const thread = threadStore.createThread('session_abc');
 
       expect(thread.sessionId).toBe('session_abc');
-      expect(thread.id).toBeTruthy();
       expect(thread.title).toBe('New Thread');
       expect(thread.createdAt).toBeGreaterThan(0);
     });
@@ -48,14 +47,14 @@ describe('threadStore', () => {
       const thread = threadStore.createThread('session_abc');
       const state = get(threadStore);
 
-      expect(state.activeThreadId).toBe(thread.id);
+      expect(state.activeSessionId).toBe(thread.sessionId);
     });
 
-    it('assigns unique IDs to each thread', () => {
+    it('assigns unique sessionIds to each thread', () => {
       const thread1 = threadStore.createThread('session_1');
       const thread2 = threadStore.createThread('session_2');
 
-      expect(thread1.id).not.toBe(thread2.id);
+      expect(thread1.sessionId).not.toBe(thread2.sessionId);
     });
 
     it('uses a custom title when provided', () => {
@@ -83,7 +82,7 @@ describe('threadStore', () => {
       const thread2 = threadStore.createThread('s2');
       const state = get(threadStore);
 
-      expect(state.activeThreadId).toBe(thread2.id);
+      expect(state.activeSessionId).toBe(thread2.sessionId);
     });
   });
 
@@ -95,10 +94,10 @@ describe('threadStore', () => {
     it('removes the specified thread', () => {
       const thread = threadStore.createThread('s1');
       threadStore.createThread('s2');
-      threadStore.closeThread(thread.id);
+      threadStore.closeThread(thread.sessionId);
 
       const state = get(threadStore);
-      expect(state.threads.find((t) => t.id === thread.id)).toBeUndefined();
+      expect(state.threads.find((t) => t.sessionId === thread.sessionId)).toBeUndefined();
     });
 
     it('selects an adjacent thread when closing the active thread', () => {
@@ -107,21 +106,21 @@ describe('threadStore', () => {
       threadStore.createThread('s3');
 
       // thread3 is active (last created). Switch to thread2, then close it.
-      threadStore.setActiveThread(thread2.id);
-      threadStore.closeThread(thread2.id);
+      threadStore.setActiveThread(thread2.sessionId);
+      threadStore.closeThread(thread2.sessionId);
 
       const state = get(threadStore);
       // Should pick the thread at the same index or previous
-      expect(state.activeThreadId).not.toBe(thread2.id);
-      expect(state.threads.some((t) => t.id === state.activeThreadId)).toBe(true);
+      expect(state.activeSessionId).not.toBe(thread2.sessionId);
+      expect(state.threads.some((t) => t.sessionId === state.activeSessionId)).toBe(true);
     });
 
-    it('sets activeThreadId to null when closing the last thread', () => {
+    it('sets activeSessionId to null when closing the last thread', () => {
       const thread = threadStore.createThread('s1');
-      threadStore.closeThread(thread.id);
+      threadStore.closeThread(thread.sessionId);
 
       const state = get(threadStore);
-      expect(state.activeThreadId).toBeNull();
+      expect(state.activeSessionId).toBeNull();
       expect(state.threads).toHaveLength(0);
     });
 
@@ -139,18 +138,18 @@ describe('threadStore', () => {
       const thread1 = threadStore.createThread('s1');
       const thread2 = threadStore.createThread('s2');
       // Activate and close the first thread
-      threadStore.setActiveThread(thread1.id);
-      threadStore.closeThread(thread1.id);
+      threadStore.setActiveThread(thread1.sessionId);
+      threadStore.closeThread(thread1.sessionId);
 
       const state = get(threadStore);
-      expect(state.activeThreadId).toBe(thread2.id);
+      expect(state.activeSessionId).toBe(thread2.sessionId);
     });
 
     it('persists after closing', () => {
       const thread = threadStore.createThread('s1');
       vi.mocked(mockConfigStorage.set).mockClear();
 
-      threadStore.closeThread(thread.id);
+      threadStore.closeThread(thread.sessionId);
       expect(mockConfigStorage.set).toHaveBeenCalled();
     });
   });
@@ -164,10 +163,10 @@ describe('threadStore', () => {
       const thread1 = threadStore.createThread('s1');
       threadStore.createThread('s2');
 
-      threadStore.setActiveThread(thread1.id);
+      threadStore.setActiveThread(thread1.sessionId);
       const state = get(threadStore);
 
-      expect(state.activeThreadId).toBe(thread1.id);
+      expect(state.activeSessionId).toBe(thread1.sessionId);
     });
 
     it('is a no-op for a nonexistent thread ID', () => {
@@ -177,7 +176,7 @@ describe('threadStore', () => {
       threadStore.setActiveThread('nonexistent');
       const stateAfter = get(threadStore);
 
-      expect(stateAfter.activeThreadId).toBe(stateBefore.activeThreadId);
+      expect(stateAfter.activeSessionId).toBe(stateBefore.activeSessionId);
     });
   });
 
@@ -188,38 +187,38 @@ describe('threadStore', () => {
   describe('updateThreadTitle', () => {
     it('updates the title of the specified thread', () => {
       const thread = threadStore.createThread('s1');
-      threadStore.updateThreadTitle(thread.id, 'Renamed Thread');
+      threadStore.updateThreadTitle(thread.sessionId, 'Renamed Thread');
 
       const state = get(threadStore);
-      expect(state.threads.find((t) => t.id === thread.id)?.title).toBe('Renamed Thread');
+      expect(state.threads.find((t) => t.sessionId === thread.sessionId)?.title).toBe('Renamed Thread');
     });
 
     it('does not affect other threads', () => {
       const thread1 = threadStore.createThread('s1', 'Thread A');
       const thread2 = threadStore.createThread('s2', 'Thread B');
 
-      threadStore.updateThreadTitle(thread1.id, 'Updated A');
+      threadStore.updateThreadTitle(thread1.sessionId, 'Updated A');
 
       const state = get(threadStore);
-      expect(state.threads.find((t) => t.id === thread2.id)?.title).toBe('Thread B');
+      expect(state.threads.find((t) => t.sessionId === thread2.sessionId)?.title).toBe('Thread B');
     });
   });
 
   // =========================================================================
-  // getThreadBySessionId
+  // getThread
   // =========================================================================
 
-  describe('getThreadBySessionId', () => {
+  describe('getThread', () => {
     it('returns the thread matching the sessionId', () => {
       const thread = threadStore.createThread('session_123');
-      const found = threadStore.getThreadBySessionId('session_123');
+      const found = threadStore.getThread('session_123');
 
-      expect(found?.id).toBe(thread.id);
+      expect(found?.sessionId).toBe(thread.sessionId);
     });
 
     it('returns undefined for an unknown sessionId', () => {
       threadStore.createThread('session_abc');
-      const found = threadStore.getThreadBySessionId('unknown');
+      const found = threadStore.getThread('unknown');
 
       expect(found).toBeUndefined();
     });
@@ -234,7 +233,7 @@ describe('threadStore', () => {
       const thread = threadStore.createThread('s1');
       const active = threadStore.getActiveThread();
 
-      expect(active?.id).toBe(thread.id);
+      expect(active?.sessionId).toBe(thread.sessionId);
     });
 
     it('returns undefined when no threads exist', () => {
@@ -250,15 +249,15 @@ describe('threadStore', () => {
   });
 
   // =========================================================================
-  // removeThreadBySessionId
+  // removeThread
   // =========================================================================
 
-  describe('removeThreadBySessionId', () => {
+  describe('removeThread', () => {
     it('finds and removes the thread by sessionId', () => {
       threadStore.createThread('session_to_remove');
       threadStore.createThread('session_to_keep');
 
-      threadStore.removeThreadBySessionId('session_to_remove');
+      threadStore.removeThread('session_to_remove');
 
       const state = get(threadStore);
       expect(state.threads).toHaveLength(1);
@@ -269,7 +268,7 @@ describe('threadStore', () => {
       threadStore.createThread('s1');
       const before = get(threadStore);
 
-      threadStore.removeThreadBySessionId('nonexistent');
+      threadStore.removeThread('nonexistent');
 
       const after = get(threadStore);
       expect(after.threads).toHaveLength(before.threads.length);
@@ -284,9 +283,9 @@ describe('threadStore', () => {
     it('restores threads from config storage', async () => {
       const stored: ThreadStoreState = {
         threads: [
-          { id: 't1', sessionId: 's1', title: 'Restored', createdAt: 1000 },
+          { sessionId: 's1', title: 'Restored', createdAt: 1000 },
         ],
-        activeThreadId: 't1',
+        activeSessionId: 's1',
       };
       mockConfigStorage.get.mockResolvedValue(stored);
 
@@ -304,11 +303,11 @@ describe('threadStore', () => {
       const result = await threadStore.restoreThreads();
 
       expect(result.threads).toHaveLength(0);
-      expect(result.activeThreadId).toBeNull();
+      expect(result.activeSessionId).toBeNull();
     });
 
     it('returns initial state when storage has empty threads array', async () => {
-      mockConfigStorage.get.mockResolvedValue({ threads: [], activeThreadId: null });
+      mockConfigStorage.get.mockResolvedValue({ threads: [], activeSessionId: null });
 
       const result = await threadStore.restoreThreads();
 
@@ -338,14 +337,14 @@ describe('threadStore', () => {
   // =========================================================================
 
   describe('clear', () => {
-    it('resets all threads and activeThreadId', () => {
+    it('resets all threads and activeSessionId', () => {
       threadStore.createThread('s1');
       threadStore.createThread('s2');
       threadStore.clear();
 
       const state = get(threadStore);
       expect(state.threads).toHaveLength(0);
-      expect(state.activeThreadId).toBeNull();
+      expect(state.activeSessionId).toBeNull();
     });
   });
 
@@ -355,22 +354,22 @@ describe('threadStore', () => {
 
       const newState: ThreadStoreState = {
         threads: [
-          { id: 'x1', sessionId: 'sx1', title: 'Set', createdAt: 500 },
-          { id: 'x2', sessionId: 'sx2', title: 'State', createdAt: 600 },
+          { sessionId: 'sx1', title: 'Set', createdAt: 500 },
+          { sessionId: 'sx2', title: 'State', createdAt: 600 },
         ],
-        activeThreadId: 'x2',
+        activeSessionId: 'sx2',
       };
 
       threadStore.setState(newState);
 
       const state = get(threadStore);
       expect(state.threads).toHaveLength(2);
-      expect(state.activeThreadId).toBe('x2');
+      expect(state.activeSessionId).toBe('sx2');
     });
 
     it('persists the new state', () => {
       vi.mocked(mockConfigStorage.set).mockClear();
-      threadStore.setState({ threads: [], activeThreadId: null });
+      threadStore.setState({ threads: [], activeSessionId: null });
 
       expect(mockConfigStorage.set).toHaveBeenCalled();
     });
@@ -385,7 +384,7 @@ describe('threadStore', () => {
       const thread = threadStore.createThread('s1');
       const active = get(activeThread);
 
-      expect(active?.id).toBe(thread.id);
+      expect(active?.sessionId).toBe(thread.sessionId);
     });
 
     it('is undefined when no threads exist', () => {
@@ -408,7 +407,7 @@ describe('threadStore', () => {
       const thread = threadStore.createThread('s1');
       threadStore.createThread('s2');
 
-      threadStore.closeThread(thread.id);
+      threadStore.closeThread(thread.sessionId);
       expect(get(threadCount)).toBe(1);
     });
   });

--- a/src/webfront/stores/threadStore.ts
+++ b/src/webfront/stores/threadStore.ts
@@ -3,6 +3,7 @@
  *
  * Manages sidepanel thread UI state using Svelte store.
  * Each thread corresponds to an AgentRegistry session.
+ * sessionId is the universal key — same value used in UI, registry, and runtime.
  * Persists thread state via ConfigStorageProvider.
  */
 
@@ -11,11 +12,10 @@ import { getConfigStorage, isConfigStorageInitialized } from '@/core/storage/Con
 
 /**
  * Sidepanel thread representation
+ * sessionId is the universal identifier (same as AgentSession.sessionId and Session.sessionId)
  */
 export interface SidePanelThread {
-  /** Unique thread ID (uuid) */
-  id: string;
-  /** AgentRegistry session ID */
+  /** Universal session ID (same across UI, registry, and runtime) */
   sessionId: string;
   /** Display title */
   title: string;
@@ -28,7 +28,7 @@ export interface SidePanelThread {
  */
 export interface ThreadStoreState {
   threads: SidePanelThread[];
-  activeThreadId: string | null;
+  activeSessionId: string | null;
 }
 
 /**
@@ -37,23 +37,12 @@ export interface ThreadStoreState {
 const STORAGE_KEY = 'browserx_sidepanel_threads';
 
 /**
- * Generate a UUID v4
- */
-function generateUUID(): string {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-}
-
-/**
  * Create the thread store
  */
 function createThreadStore() {
   const initialState: ThreadStoreState = {
     threads: [],
-    activeThreadId: null,
+    activeSessionId: null,
   };
 
   const { subscribe, set, update }: Writable<ThreadStoreState> = writable(initialState);
@@ -63,13 +52,12 @@ function createThreadStore() {
 
     /**
      * Create a new thread for a session
-     * @param sessionId The AgentRegistry session ID
+     * @param sessionId The universal session ID
      * @param title Optional initial title (defaults to "New Thread")
      * @returns The created thread
      */
     createThread: (sessionId: string, title: string = 'New Thread'): SidePanelThread => {
       const newThread: SidePanelThread = {
-        id: generateUUID(),
         sessionId,
         title,
         createdAt: Date.now(),
@@ -77,7 +65,7 @@ function createThreadStore() {
 
       update((state) => ({
         threads: [...state.threads, newThread],
-        activeThreadId: newThread.id,
+        activeSessionId: newThread.sessionId,
       }));
 
       persistThreads();
@@ -86,27 +74,27 @@ function createThreadStore() {
     },
 
     /**
-     * Close a thread by ID
-     * @param threadId The thread ID to close
+     * Close a thread by session ID
+     * @param sessionId The session ID to close
      */
-    closeThread: (threadId: string): void => {
+    closeThread: (sessionId: string): void => {
       update((state) => {
-        const threadIndex = state.threads.findIndex((t) => t.id === threadId);
+        const threadIndex = state.threads.findIndex((t) => t.sessionId === sessionId);
         if (threadIndex === -1) return state;
 
-        const newThreads = state.threads.filter((t) => t.id !== threadId);
+        const newThreads = state.threads.filter((t) => t.sessionId !== sessionId);
 
-        let newActiveId = state.activeThreadId;
-        if (state.activeThreadId === threadId && newThreads.length > 0) {
+        let newActiveId = state.activeSessionId;
+        if (state.activeSessionId === sessionId && newThreads.length > 0) {
           const newIndex = Math.min(threadIndex, newThreads.length - 1);
-          newActiveId = newThreads[newIndex]?.id || null;
+          newActiveId = newThreads[newIndex]?.sessionId || null;
         } else if (newThreads.length === 0) {
           newActiveId = null;
         }
 
         return {
           threads: newThreads,
-          activeThreadId: newActiveId,
+          activeSessionId: newActiveId,
         };
       });
 
@@ -114,13 +102,13 @@ function createThreadStore() {
     },
 
     /**
-     * Set the active thread
-     * @param threadId The thread ID to activate
+     * Set the active thread by session ID
+     * @param sessionId The session ID to activate
      */
-    setActiveThread: (threadId: string): void => {
+    setActiveThread: (sessionId: string): void => {
       update((state) => {
-        if (state.threads.some((t) => t.id === threadId)) {
-          return { ...state, activeThreadId: threadId };
+        if (state.threads.some((t) => t.sessionId === sessionId)) {
+          return { ...state, activeSessionId: sessionId };
         }
         return state;
       });
@@ -130,24 +118,24 @@ function createThreadStore() {
 
     /**
      * Update a thread's title
-     * @param threadId The thread ID to update
+     * @param sessionId The session ID of the thread to update
      * @param title The new title
      */
-    updateThreadTitle: (threadId: string, title: string): void => {
+    updateThreadTitle: (sessionId: string, title: string): void => {
       update((state) => ({
         ...state,
-        threads: state.threads.map((t) => (t.id === threadId ? { ...t, title } : t)),
+        threads: state.threads.map((t) => (t.sessionId === sessionId ? { ...t, title } : t)),
       }));
 
       persistThreads();
     },
 
     /**
-     * Get a thread by its session ID
+     * Get a thread by session ID (direct lookup)
      * @param sessionId The session ID to find
      * @returns The thread or undefined
      */
-    getThreadBySessionId: (sessionId: string): SidePanelThread | undefined => {
+    getThread: (sessionId: string): SidePanelThread | undefined => {
       const state = get({ subscribe });
       return state.threads.find((t) => t.sessionId === sessionId);
     },
@@ -158,19 +146,15 @@ function createThreadStore() {
      */
     getActiveThread: (): SidePanelThread | undefined => {
       const state = get({ subscribe });
-      return state.threads.find((t) => t.id === state.activeThreadId);
+      return state.threads.find((t) => t.sessionId === state.activeSessionId);
     },
 
     /**
-     * Remove a thread by session ID (for external session termination)
+     * Remove a thread by session ID
      * @param sessionId The session ID
      */
-    removeThreadBySessionId: (sessionId: string): void => {
-      const state = get({ subscribe });
-      const thread = state.threads.find((t) => t.sessionId === sessionId);
-      if (thread) {
-        threadStore.closeThread(thread.id);
-      }
+    removeThread: (sessionId: string): void => {
+      threadStore.closeThread(sessionId);
     },
 
     /**
@@ -235,7 +219,7 @@ export const threadStore = createThreadStore();
 
 // Derived store for the active thread
 export const activeThread = derived(threadStore, ($threadStore) =>
-  $threadStore.threads.find((t) => t.id === $threadStore.activeThreadId)
+  $threadStore.threads.find((t) => t.sessionId === $threadStore.activeSessionId)
 );
 
 // Derived store for thread count


### PR DESCRIPTION
## Summary

- **ID Unification**: Eliminate `conversationId` and `thread.id` — use `Session.sessionId` (UUID) as the single identifier across all layers: UI threadStore, AgentSession registry, Session runtime, and RolloutRecorder persistence.
- **ChannelEvent Envelope**: Wrap `EventMsg` in `{ msg: EventMsg, sessionId?: string }` at the channel layer, separating transport routing from protocol. Enables correct event routing to the right UI thread in multi-tab.
- **AgentRegistry restructure**: Agent is now created first, then `AgentSession` receives the agent's `sessionId`, ensuring a single source of truth for IDs.

## Test plan

- [x] `npx tsc --noEmit` passes with zero errors
- [ ] Run full test suite (`npm test`)
- [ ] Verify multi-tab switching routes events to correct thread
- [ ] Verify session resume works with new `sessionId` field
- [ ] Verify rollout recording uses `sessionId` throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)