### PR TITLE
feat: multi-session threads with unified sessionId routing

### DIFF
--- a/src/desktop/channels/WebSocketChannel.ts
+++ b/src/desktop/channels/WebSocketChannel.ts
@@ -113,7 +113,7 @@ export class WebSocketChannel implements ChannelAdapter {
     }
 
     // Convert event to WebSocket message format
-    const wsMessage = this.eventToWSMessage(event.msg);
+    const wsMessage = this.eventToWSMessage(event.msg, event.sessionId);
     if (!wsMessage) {
       return;
     }
@@ -293,7 +293,8 @@ export class WebSocketChannel implements ChannelAdapter {
    * are relevant for WebSocket clients; the rest return null.
    */
   private eventToWSMessage(
-    event: EventMsg
+    event: EventMsg,
+    sessionId?: string
   ): WSOutboundMessage | null {
     const timestamp = Date.now();
     const turnId = this.lastActiveTurnId;
@@ -309,6 +310,7 @@ export class WebSocketChannel implements ChannelAdapter {
           type: 'assistant_chunk',
           turnId,
           content: event.data.delta,
+          sessionId,
           timestamp,
         } as WSAssistantChunk;
 
@@ -320,6 +322,7 @@ export class WebSocketChannel implements ChannelAdapter {
           tool: event.data.tool_name,
           input: event.data.params || {},
           toolUseId,
+          sessionId,
           timestamp,
         } as WSToolUse;
       }
@@ -332,6 +335,7 @@ export class WebSocketChannel implements ChannelAdapter {
           toolUseId,
           result: event.data.success ? 'success' : 'failed',
           success: event.data.success,
+          sessionId,
           timestamp,
         } as WSToolResult;
       }
@@ -346,6 +350,7 @@ export class WebSocketChannel implements ChannelAdapter {
           type: 'assistant_turn_complete',
           turnId,
           content: event.data.last_agent_message || '',
+          sessionId,
           timestamp,
         } as WSAssistantTurnComplete;
 
@@ -355,6 +360,7 @@ export class WebSocketChannel implements ChannelAdapter {
           code: event.data.code || 'ERROR',
           message: event.data.message,
           turnId,
+          sessionId,
           timestamp,
         } as WSError;
 

--- a/src/desktop/channels/websocket/types.ts
+++ b/src/desktop/channels/websocket/types.ts
@@ -73,6 +73,8 @@ export interface WSAssistantChunk extends WSMessage {
   turnId: string;
   /** Text content chunk */
   content: string;
+  /** Session ID for multi-session routing */
+  sessionId?: string;
 }
 
 /**
@@ -88,6 +90,8 @@ export interface WSToolUse extends WSMessage {
   input: Record<string, unknown>;
   /** Tool use ID */
   toolUseId: string;
+  /** Session ID for multi-session routing */
+  sessionId?: string;
 }
 
 /**
@@ -105,6 +109,8 @@ export interface WSToolResult extends WSMessage {
   success: boolean;
   /** Error message if failed */
   error?: string;
+  /** Session ID for multi-session routing */
+  sessionId?: string;
 }
 
 /**
@@ -121,6 +127,8 @@ export interface WSAssistantTurnComplete extends WSMessage {
     inputTokens: number;
     outputTokens: number;
   };
+  /** Session ID for multi-session routing */
+  sessionId?: string;
 }
 
 /**
@@ -134,6 +142,8 @@ export interface WSError extends WSMessage {
   message: string;
   /** Related turn ID if applicable */
   turnId?: string;
+  /** Session ID for multi-session routing */
+  sessionId?: string;
 }
 
 /**

--- a/src/server/channels/ServerChannel.ts
+++ b/src/server/channels/ServerChannel.ts
@@ -91,7 +91,8 @@ export class ServerChannel implements ChannelAdapter {
     this.eventSeq++;
     const eventMsg = event.msg;
     const eventName = this.eventMsgToName(eventMsg);
-    const frame = JSON.stringify(makeEvent(eventName, eventMsg, this.eventSeq));
+    const payload = event.sessionId ? { ...eventMsg, sessionId: event.sessionId } : eventMsg;
+    const frame = JSON.stringify(makeEvent(eventName, payload, this.eventSeq));
 
     const connections = getTrackedConnections();
     for (const conn of connections) {


### PR DESCRIPTION
## Summary
- Adds multi-thread conversation support with a tab-based UI (ThreadBar, ThreadTab components, threadStore)
- Implements unified `sessionId` propagation through the ChannelEvent envelope across all channel adapters (WebSocket, SSE, Tauri, SidePanel, TabPage)
- Routes events by sessionId to correct agent sessions, enabling independent parallel conversations
- Includes comprehensive test coverage (multi-session registry tests, thread store tests, multi-thread integration tests)

## Test plan
- [ ] Verify multiple chat threads can be created and switched between
- [ ] Confirm messages route to the correct session when multiple threads are active
- [ ] Validate sessionId appears in outbound WebSocket and SSE messages
- [ ] Run `npm test` to verify all new and existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)