### PR TITLE
fix: resolve settings page crash from Svelte 5 infinite effect loop

### DIFF
--- a/src/webfront/pages/settings/Settings.svelte
+++ b/src/webfront/pages/settings/Settings.svelte
@@ -51,23 +51,23 @@
    * Load settings from ConfigStorageProvider with isolated AgentConfig
    */
   async function loadSettings() {
+    let configInstance: any = null;
     try {
-    isInitializing = true;
-    const configInstance = new (AgentConfig as any)();
+      isInitializing = true;
+      configInstance = new (AgentConfig as any)();
 
-    if (!configInstance) {
-      throw new Error('Failed to initialize AgentConfig');
-    }
-    await configInstance.initialize();
-
-    // Only expose the instance to children once it is fully initialized
-    settingsConfig = configInstance;
-
-    // Debug: log loaded selectedModelKey
-    const config = configInstance.getConfig();
-      console.log('[Settings] Loaded config, selectedModelKey:', config.selectedModelKey);
+      if (!configInstance) {
+        throw new Error('Failed to initialize AgentConfig');
+      }
+      await configInstance.initialize();
+      settingsConfig = configInstance;
     } catch (error) {
       console.error('[Settings] Failed to load settings:', error);
+      // Even on error, expose the instance if it exists — AgentConfig.initialize()
+      // internally falls back to defaults, so the instance is still usable.
+      if (configInstance && !settingsConfig) {
+        settingsConfig = configInstance;
+      }
     } finally {
       isInitializing = false;
     }
@@ -240,6 +240,10 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    /* Override AppShell's .content-area > * { overflow: hidden } which has equal
+       specificity but appears later in the compiled CSS. The settings page needs
+       visible overflow so the centered modal container isn't clipped. */
+    overflow: visible !important;
     background: rgba(0, 0, 0, 0.5);
     /* Terminal theme (default) */
     --browserx-primary: #00ff00;

--- a/src/webfront/settings/components/SettingsSearch.svelte
+++ b/src/webfront/settings/components/SettingsSearch.svelte
@@ -81,14 +81,19 @@
     });
   }
 
-  // Reactively rebuild index when $_t store changes (locale change)
+  // Reactively rebuild index when $_t store changes (locale change).
+  // Use local variables to avoid reading $state we just wrote (which would
+  // cause Svelte 5's effect to re-subscribe and loop infinitely).
   $effect(() => {
     const translate = $_t;
-    searchableItems = buildSearchableItems(translate);
-    fuseIndex = buildFuseIndex(searchableItems);
+    const items = buildSearchableItems(translate);
+    const fuse = buildFuseIndex(items);
+    searchableItems = items;
+    fuseIndex = fuse;
     // Re-run search with current query if index was rebuilt
-    if (query.trim()) {
-      performSearch(query);
+    const q = query.trim();
+    if (q) {
+      results = fuse.search(q);
     }
   });
 


### PR DESCRIPTION
## Summary
- Fixed `effect_update_depth_exceeded` crash in `SettingsSearch.svelte` caused by a `$effect` that read back from `$state` signals it had just written to, creating an infinite reactive loop in Svelte 5
- Improved `Settings.svelte` error handling to expose `AgentConfig` even on initialization errors (it internally falls back to defaults)
- Added `overflow: visible !important` CSS fix to prevent the settings modal container from being clipped

## Root Cause
The `$effect` in `SettingsSearch` wrote new arrays to `searchableItems` and `fuseIndex` state, then read them back via `buildFuseIndex(searchableItems)` and `performSearch(query)`. Svelte 5's `safe_not_equal` always considers new objects/arrays as changed, so the effect re-triggered infinitely (1000+ iterations), crashing the page and breaking event delegation for all category card clicks.

## Fix
Use local variables (`const items`, `const fuse`) for intermediate computation within the effect, only assigning to `$state` at the end without reading back.

## Test plan
- [ ] Open settings page in both Chrome extension and desktop app
- [ ] Verify all category cards are clickable and navigate correctly
- [ ] Use settings search — verify results appear and are selectable
- [ ] Check browser console for any `effect_update_depth_exceeded` errors
- [ ] Navigate between settings categories and back to menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)