### PR TITLE
feat(track-11): config-driven parallel_tool_calls + buffer Responses-API path

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -83,6 +83,9 @@ export const DEFAULT_TOOLS_CONFIG: IToolsConfig = {
   mcpTools: false,
   customTools: {},
 
+  // Track 11: dark by default. Enable to let the model batch tool calls.
+  parallelToolCalls: false,
+
   // Shared configuration metadata
   enabled: [
     'web_scraping',

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -438,6 +438,15 @@ export interface IToolsConfig {
   mcpTools?: boolean;
   customTools?: Record<string, boolean>;
 
+  /**
+   * Allow the model to emit multiple tool calls in one response (Track 11).
+   * When true, Track 02's orchestrator runs concurrency-safe calls in
+   * parallel (bounded) and unsafe calls sequentially. Applies to all
+   * OpenAI-compatible providers; Gemini already emits the parallel format
+   * natively. Default false (conservative — preserves current behavior).
+   */
+  parallelToolCalls?: boolean;
+
   // Shared configuration metadata
   enabled?: string[];
   disabled?: string[];

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -1018,7 +1018,9 @@ export class Session {
         let llmCaller = null;
 
         if (memoryApiKey) {
-          // Preferred path: dedicated gpt-4o-mini client via OpenAI key
+          // Preferred path: dedicated gpt-4o-mini client via OpenAI key.
+          // Track 11 note: memory extraction is a single tool-less completion;
+          // it intentionally does not take the agent's parallelToolCalls flag.
           const memoryLLMClient = new OpenAIChatCompletionClient({
             apiKey: memoryApiKey,
             baseUrl: useBackendForMemory && backendBaseUrl ? backendBaseUrl + '/openai' : undefined,
@@ -1388,7 +1390,9 @@ export class Session {
         };
       }
 
-      // All other providers use OpenAI-compatible Chat Completions API
+      // All other providers use OpenAI-compatible Chat Completions API.
+      // Track 11 note: memory-search is a single tool-less completion; it
+      // intentionally does not take the agent's parallelToolCalls flag.
       const { OpenAIChatCompletionClient } = await import('./models/client/OpenAIChatCompletionClient');
       const client = new OpenAIChatCompletionClient({
         apiKey: providerApiKey,

--- a/src/core/TurnManager.ts
+++ b/src/core/TurnManager.ts
@@ -226,6 +226,14 @@ export class TurnManager {
     const processedItems: ProcessedResponseItem[] = [];
     let totalTokenUsage: TokenUsage | undefined;
 
+    // Track 11: OpenAI Responses API / xAI emit N separate `function_call`
+    // output items for parallel tool calls (Chat Completions providers
+    // accumulate into one `message` item — handled by the orchestrator path
+    // in handleResponseItem). Buffer the legacy items and run them through
+    // Track 02's orchestrator at `Completed` instead of executing each
+    // sequentially as it arrives.
+    const bufferedToolCalls: any[] = [];
+
     try {
       // Process streaming response
       // Loop processes ResponseEvent items from the model stream.
@@ -254,7 +262,16 @@ export class TurnManager {
               event.item.modelKey = this.turnContext.getSelectedModelKey();
             }
 
-            // Item (message or tool call) is complete
+            // Track 11: defer legacy `function_call` items so a parallel
+            // batch runs through the concurrency orchestrator at `Completed`
+            // rather than executing each one sequentially here. Non-tool
+            // items (message/reasoning/web_search) keep immediate handling.
+            if (event.item?.type === 'function_call') {
+              bufferedToolCalls.push(event.item);
+              break;
+            }
+
+            // Item (message or unified tool_calls) is complete
             const response = await this.handleResponseItem(event.item);
             processedItems.push({
               item: event.item,
@@ -277,6 +294,22 @@ export class TurnManager {
           case 'Completed': {
             // Stream completed with final token usage
             totalTokenUsage = event.tokenUsage;
+
+            // Track 11: flush any buffered legacy `function_call` items
+            // through Track 02's orchestrator (safe calls concurrent,
+            // unsafe sequential, results in original order). Pushed into
+            // processedItems before the post-turn hook so the
+            // `lastTurnHadToolCalls` detection below still sees them.
+            if (bufferedToolCalls.length > 0) {
+              const results = await this.executeBufferedToolCalls(bufferedToolCalls);
+              for (let i = 0; i < bufferedToolCalls.length; i++) {
+                processedItems.push({
+                  item: bufferedToolCalls[i],
+                  response: results[i],
+                });
+              }
+              bufferedToolCalls.length = 0;
+            }
 
             // Track 05b: fire post-turn hooks before returning. Hooks are
             // owned by Session (since TurnManager is per-task but post-turn
@@ -909,6 +942,41 @@ export class TurnManager {
         `\n\n[Result truncated from ${output.length} to ${threshold} chars — persistence failed: ${reason}]`
       );
     }
+  }
+
+  /**
+   * Track 11: run buffered legacy `function_call` items through Track 02's
+   * concurrency orchestrator. Returns one result per input call in original
+   * order. Mirrors the unified-format (`message` + `tool_calls[]`) path in
+   * handleResponseItem, including the Track 09 tier-2 aggregate budget.
+   */
+  private async executeBufferedToolCalls(calls: any[]): Promise<any[]> {
+    const prepared = calls.map((tc) =>
+      prepareToolCall(
+        { id: tc.call_id, function: { name: tc.name, arguments: tc.arguments } },
+        this.toolRegistry,
+      ),
+    );
+    const batches = partitionToolCalls(prepared);
+    const results = await executeToolCallBatches(
+      batches,
+      async (call: PreparedToolCall) => {
+        try {
+          return await this.executeToolCall(
+            call.name,
+            call.parsedArguments,
+            call.id,
+          );
+        } catch (error) {
+          return {
+            type: 'function_call_output',
+            call_id: call.id,
+            output: `Error: ${error instanceof Error ? error.message : String(error)}`,
+          };
+        }
+      },
+    );
+    return this.maybeEnforceTier2(results, prepared);
   }
 
   /**

--- a/src/core/TurnManager.ts
+++ b/src/core/TurnManager.ts
@@ -226,6 +226,14 @@ export class TurnManager {
     const processedItems: ProcessedResponseItem[] = [];
     let totalTokenUsage: TokenUsage | undefined;
 
+    // Track 11: only buffer/orchestrate when the feature is enabled. With
+    // the flag off (default) the model is told not to parallelize, so there
+    // is never more than one function_call — buffering would only add the
+    // interrupt-before-Completed behavior change for zero benefit. Keep the
+    // original immediate-execution path byte-for-byte in the default case.
+    const parallelToolCallsEnabled =
+      this.turnContext.getToolsConfig?.()?.parallelToolCalls === true;
+
     // Track 11: OpenAI Responses API / xAI emit N separate `function_call`
     // output items for parallel tool calls (Chat Completions providers
     // accumulate into one `message` item — handled by the orchestrator path
@@ -268,13 +276,13 @@ export class TurnManager {
               event.item.modelKey = this.turnContext.getSelectedModelKey();
             }
 
-            // Track 11: defer legacy `function_call` items so a parallel
-            // batch runs through the concurrency orchestrator at `Completed`
-            // rather than executing each one sequentially here. Non-tool
-            // items (message/reasoning/web_search) keep immediate handling.
-            // Push a placeholder now to lock the stream position; its
-            // `response` is filled when the buffer flushes at `Completed`.
-            if (event.item?.type === 'function_call') {
+            // Track 11: when enabled, defer legacy `function_call` items so a
+            // parallel batch runs through the concurrency orchestrator at
+            // `Completed` rather than executing each one sequentially here.
+            // Non-tool items (message/reasoning/web_search) keep immediate
+            // handling. Push a placeholder now to lock the stream position;
+            // its `response` is filled when the buffer flushes at `Completed`.
+            if (parallelToolCallsEnabled && event.item?.type === 'function_call') {
               const entry: ProcessedResponseItem = { item: event.item };
               processedItems.push(entry);
               bufferedToolCalls.push(event.item);

--- a/src/core/TurnManager.ts
+++ b/src/core/TurnManager.ts
@@ -232,7 +232,13 @@ export class TurnManager {
     // in handleResponseItem). Buffer the legacy items and run them through
     // Track 02's orchestrator at `Completed` instead of executing each
     // sequentially as it arrives.
+    //
+    // `bufferedEntries` are placeholder ProcessedResponseItem objects pushed
+    // into processedItems at the stream position the function_call arrived,
+    // so a non-tool item arriving between calls cannot reorder results
+    // relative to it. Responses fill in at `Completed`.
     const bufferedToolCalls: any[] = [];
+    const bufferedEntries: ProcessedResponseItem[] = [];
 
     try {
       // Process streaming response
@@ -266,8 +272,13 @@ export class TurnManager {
             // batch runs through the concurrency orchestrator at `Completed`
             // rather than executing each one sequentially here. Non-tool
             // items (message/reasoning/web_search) keep immediate handling.
+            // Push a placeholder now to lock the stream position; its
+            // `response` is filled when the buffer flushes at `Completed`.
             if (event.item?.type === 'function_call') {
+              const entry: ProcessedResponseItem = { item: event.item };
+              processedItems.push(entry);
               bufferedToolCalls.push(event.item);
+              bufferedEntries.push(entry);
               break;
             }
 
@@ -295,20 +306,20 @@ export class TurnManager {
             // Stream completed with final token usage
             totalTokenUsage = event.tokenUsage;
 
-            // Track 11: flush any buffered legacy `function_call` items
-            // through Track 02's orchestrator (safe calls concurrent,
-            // unsafe sequential, results in original order). Pushed into
-            // processedItems before the post-turn hook so the
+            // Track 11: flush buffered legacy `function_call` items through
+            // Track 02's orchestrator (safe calls concurrent, unsafe
+            // sequential, results in original call order). Results are
+            // written back into the position-preserving placeholders so
+            // ordering relative to any interleaved item is exact. The
+            // placeholders were already in processedItems, so the
             // `lastTurnHadToolCalls` detection below still sees them.
             if (bufferedToolCalls.length > 0) {
               const results = await this.executeBufferedToolCalls(bufferedToolCalls);
-              for (let i = 0; i < bufferedToolCalls.length; i++) {
-                processedItems.push({
-                  item: bufferedToolCalls[i],
-                  response: results[i],
-                });
+              for (let i = 0; i < bufferedEntries.length; i++) {
+                bufferedEntries[i]!.response = results[i];
               }
               bufferedToolCalls.length = 0;
+              bufferedEntries.length = 0;
             }
 
             // Track 05b: fire post-turn hooks before returning. Hooks are

--- a/src/core/TurnManager.ts
+++ b/src/core/TurnManager.ts
@@ -323,7 +323,11 @@ export class TurnManager {
             // `lastTurnHadToolCalls` detection below still sees them.
             if (bufferedToolCalls.length > 0) {
               const results = await this.executeBufferedToolCalls(bufferedToolCalls);
-              for (let i = 0; i < bufferedEntries.length; i++) {
+              // results, bufferedToolCalls, and bufferedEntries are
+              // index-aligned by invariant (pushed in lockstep; the
+              // orchestrator preserves input order). Drive the loop off
+              // results.length as the single source of truth.
+              for (let i = 0; i < results.length; i++) {
                 bufferedEntries[i]!.response = results[i];
               }
               bufferedToolCalls.length = 0;
@@ -971,6 +975,8 @@ export class TurnManager {
    */
   private async executeBufferedToolCalls(calls: any[]): Promise<any[]> {
     const prepared = calls.map((tc) =>
+      // tc.arguments may be a JSON string or an already-parsed object;
+      // prepareToolCall handles both shapes.
       prepareToolCall(
         { id: tc.call_id, function: { name: tc.name, arguments: tc.arguments } },
         this.toolRegistry,

--- a/src/core/__tests__/TurnManager.parallelTools.integration.test.ts
+++ b/src/core/__tests__/TurnManager.parallelTools.integration.test.ts
@@ -1,0 +1,125 @@
+// File: src/core/__tests__/TurnManager.parallelTools.integration.test.ts
+//
+// Track 11 — verifies buffered legacy `function_call` items (OpenAI
+// Responses / xAI shape) run through Track 02's concurrency orchestrator:
+// consecutive safe calls concurrently, unsafe sequentially, results in
+// original order.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TurnManager } from '../TurnManager';
+import { ToolRegistry } from '../../tools/ToolRegistry';
+
+describe('TurnManager — Track 11 buffered function_call orchestration', () => {
+  let session: any;
+  let turnContext: any;
+  let toolRegistry: ToolRegistry;
+  let turnManager: TurnManager;
+
+  beforeEach(() => {
+    session = {
+      getSessionId: vi.fn().mockReturnValue('test-session'),
+      emitEvent: vi.fn(),
+      // no getToolResultStore → maybeEnforceTier2 is a no-op
+    };
+    turnContext = {
+      getToolsConfig: vi.fn().mockReturnValue({}),
+      getModelClient: vi.fn(),
+      getModel: vi.fn().mockReturnValue('gpt-4'),
+    };
+    toolRegistry = new ToolRegistry();
+
+    // Classify: read_* safe, write_* unsafe.
+    vi.spyOn(toolRegistry, 'isConcurrencySafe').mockImplementation(
+      (toolName: string) => toolName.startsWith('read_'),
+    );
+
+    turnManager = new TurnManager(session, turnContext, toolRegistry);
+  });
+
+  it('runs consecutive safe calls concurrently and unsafe sequentially, preserving order', async () => {
+    const events: string[] = [];
+
+    // Spy executeToolCall: log start/end, simulate async work.
+    vi.spyOn(turnManager as any, 'executeToolCall').mockImplementation(
+      async (...args: unknown[]) => {
+        const name = args[0] as string;
+        const callId = args[2] as string;
+        events.push(`start:${name}`);
+        await new Promise((r) => setTimeout(r, 20));
+        events.push(`end:${name}`);
+        return { type: 'function_call_output', call_id: callId, output: `${name}-ok` };
+      },
+    );
+
+    const buffered = [
+      { type: 'function_call', name: 'read_a', arguments: '{}', call_id: 'a' },
+      { type: 'function_call', name: 'read_b', arguments: '{}', call_id: 'b' },
+      { type: 'function_call', name: 'write_c', arguments: '{}', call_id: 'c' },
+    ];
+
+    const results = await (turnManager as any).executeBufferedToolCalls(buffered);
+
+    // Results preserved in original order.
+    expect(results.map((r: any) => r.call_id)).toEqual(['a', 'b', 'c']);
+    expect(results.map((r: any) => r.output)).toEqual([
+      'read_a-ok',
+      'read_b-ok',
+      'write_c-ok',
+    ]);
+
+    // read_a and read_b are concurrency-safe → same batch, run concurrently:
+    // read_b starts before read_a ends.
+    expect(events.indexOf('start:read_b')).toBeLessThan(
+      events.indexOf('end:read_a'),
+    );
+
+    // write_c is unsafe → its own batch, starts only after BOTH safe calls end.
+    expect(events.indexOf('start:write_c')).toBeGreaterThan(
+      events.indexOf('end:read_a'),
+    );
+    expect(events.indexOf('start:write_c')).toBeGreaterThan(
+      events.indexOf('end:read_b'),
+    );
+  });
+
+  it('a single buffered call still works (default flag-off path)', async () => {
+    vi.spyOn(turnManager as any, 'executeToolCall').mockImplementation(
+      async (...args: unknown[]) => ({
+        type: 'function_call_output',
+        call_id: args[2] as string,
+        output: 'single-ok',
+      }),
+    );
+
+    const results = await (turnManager as any).executeBufferedToolCalls([
+      { type: 'function_call', name: 'read_a', arguments: '{}', call_id: 'only' },
+    ]);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].call_id).toBe('only');
+    expect(results[0].output).toBe('single-ok');
+  });
+
+  it('wraps a thrown tool error in a function_call_output envelope', async () => {
+    vi.spyOn(turnManager as any, 'executeToolCall').mockImplementation(
+      async (...args: unknown[]) => {
+        const name = args[0] as string;
+        if (name === 'write_c') throw new Error('boom');
+        return {
+          type: 'function_call_output',
+          call_id: args[2] as string,
+          output: `${name}-ok`,
+        };
+      },
+    );
+
+    const results = await (turnManager as any).executeBufferedToolCalls([
+      { type: 'function_call', name: 'read_a', arguments: '{}', call_id: 'a' },
+      { type: 'function_call', name: 'write_c', arguments: '{}', call_id: 'c' },
+    ]);
+
+    expect(results[0].output).toBe('read_a-ok');
+    expect(results[1].call_id).toBe('c');
+    expect(results[1].output).toContain('Error: boom');
+  });
+});

--- a/src/core/__tests__/TurnManager.parallelTools.integration.test.ts
+++ b/src/core/__tests__/TurnManager.parallelTools.integration.test.ts
@@ -25,7 +25,9 @@ describe('TurnManager — Track 11 buffered function_call orchestration', () => 
       // no firePostTurnHooks → post-turn hook block is skipped
     };
     turnContext = {
-      getToolsConfig: vi.fn().mockReturnValue({}),
+      // Track 11 buffering is gated on this flag; the stream-loop tests
+      // below exercise the buffered path, so enable it here.
+      getToolsConfig: vi.fn().mockReturnValue({ parallelToolCalls: true }),
       getModelClient: vi.fn(),
       getModel: vi.fn().mockReturnValue('gpt-4'),
       getSessionId: vi.fn().mockReturnValue('test-session'),
@@ -174,6 +176,35 @@ describe('TurnManager — Track 11 buffered function_call orchestration', () => 
     ).rejects.toThrow('stream closed before response.completed');
 
     expect(execSpy).not.toHaveBeenCalled();
+  });
+
+  it('stream loop: with the flag OFF, function_call executes immediately (default path unchanged)', async () => {
+    // Gemini review fix: default (flag-off) path must not buffer. A stream
+    // that ends before Completed should still have executed the tool
+    // immediately via handleResponseItem (the original behavior), in
+    // contrast to the flag-on all-or-nothing case above.
+    turnContext.getToolsConfig.mockReturnValue({ parallelToolCalls: false });
+
+    async function* stream() {
+      yield {
+        type: 'OutputItemDone',
+        item: { type: 'function_call', name: 'read_a', arguments: '{}', call_id: 'a' },
+      };
+      // No Completed.
+    }
+    turnContext.getModelClient.mockReturnValue({ stream: vi.fn(async () => stream()) });
+
+    const execSpy = vi
+      .spyOn(turnManager as any, 'executeToolCall')
+      .mockResolvedValue({ type: 'function_call_output', call_id: 'a', output: 'immediate' });
+
+    await expect(
+      (turnManager as any).tryRunTurn({ input: [], tools: [] }),
+    ).rejects.toThrow('stream closed before response.completed');
+
+    // Flag off → immediate execution path → tool ran even though the
+    // stream never reached Completed.
+    expect(execSpy).toHaveBeenCalledTimes(1);
   });
 
   it('wraps a thrown tool error in a function_call_output envelope', async () => {

--- a/src/core/__tests__/TurnManager.parallelTools.integration.test.ts
+++ b/src/core/__tests__/TurnManager.parallelTools.integration.test.ts
@@ -19,12 +19,21 @@ describe('TurnManager — Track 11 buffered function_call orchestration', () => 
     session = {
       getSessionId: vi.fn().mockReturnValue('test-session'),
       emitEvent: vi.fn(),
+      getTabId: vi.fn().mockReturnValue(-1),
+      recordTurnContext: vi.fn().mockResolvedValue(undefined),
       // no getToolResultStore → maybeEnforceTier2 is a no-op
+      // no firePostTurnHooks → post-turn hook block is skipped
     };
     turnContext = {
       getToolsConfig: vi.fn().mockReturnValue({}),
       getModelClient: vi.fn(),
       getModel: vi.fn().mockReturnValue('gpt-4'),
+      getSessionId: vi.fn().mockReturnValue('test-session'),
+      getApprovalPolicy: vi.fn().mockReturnValue('auto'),
+      getSandboxPolicy: vi.fn().mockReturnValue('read-only'),
+      getEffort: vi.fn(),
+      getSummary: vi.fn(),
+      getSelectedModelKey: vi.fn().mockReturnValue('openai:gpt-4'),
     };
     toolRegistry = new ToolRegistry();
 
@@ -98,6 +107,73 @@ describe('TurnManager — Track 11 buffered function_call orchestration', () => 
     expect(results).toHaveLength(1);
     expect(results[0].call_id).toBe('only');
     expect(results[0].output).toBe('single-ok');
+  });
+
+  it('stream loop: buffers function_call items, flushes at Completed, preserves position vs an interleaved non-tool item', async () => {
+    // Drives the real tryRunTurn stream loop (not the helper directly), so
+    // the OutputItemDone interception + Completed flush wiring is exercised.
+    async function* stream() {
+      yield {
+        type: 'OutputItemDone',
+        item: { type: 'function_call', name: 'read_a', arguments: '{}', call_id: 'a' },
+      };
+      // A non-tool item between the two function_calls. Its placeholder
+      // position must be preserved relative to the buffered results.
+      yield { type: 'OutputItemDone', item: { type: 'spacer' } };
+      yield {
+        type: 'OutputItemDone',
+        item: { type: 'function_call', name: 'read_b', arguments: '{}', call_id: 'b' },
+      };
+      yield { type: 'Completed', tokenUsage: undefined };
+    }
+
+    turnContext.getModelClient.mockReturnValue({ stream: vi.fn(async () => stream()) });
+
+    vi.spyOn(turnManager as any, 'executeToolCall').mockImplementation(
+      async (...args: unknown[]) => ({
+        type: 'function_call_output',
+        call_id: args[2] as string,
+        output: `${args[0] as string}-ok`,
+      }),
+    );
+
+    const result = await (turnManager as any).tryRunTurn({ input: [], tools: [] });
+    const items = result.processedItems;
+
+    // Order locked: fc-a (0), spacer (1), fc-b (2) — buffered results did
+    // not jump ahead of or behind the interleaved spacer.
+    expect(items).toHaveLength(3);
+    expect(items[0].item.call_id).toBe('a');
+    expect(items[0].response.output).toBe('read_a-ok');
+    expect(items[1].item.type).toBe('spacer');
+    expect(items[1].response).toBeUndefined();
+    expect(items[2].item.call_id).toBe('b');
+    expect(items[2].response.output).toBe('read_b-ok');
+  });
+
+  it('stream loop: a stream that ends before Completed executes no buffered tools (all-or-nothing)', async () => {
+    // Models the documented behavior change: an interrupted/incomplete
+    // stream that buffered a function_call but never reached Completed runs
+    // NO tools (previously the legacy path may have executed it mid-stream).
+    async function* stream() {
+      yield {
+        type: 'OutputItemDone',
+        item: { type: 'function_call', name: 'read_a', arguments: '{}', call_id: 'a' },
+      };
+      // No Completed — stream ends here.
+    }
+
+    turnContext.getModelClient.mockReturnValue({ stream: vi.fn(async () => stream()) });
+
+    const execSpy = vi
+      .spyOn(turnManager as any, 'executeToolCall')
+      .mockResolvedValue({ type: 'function_call_output', call_id: 'a', output: 'x' });
+
+    await expect(
+      (turnManager as any).tryRunTurn({ input: [], tools: [] }),
+    ).rejects.toThrow('stream closed before response.completed');
+
+    expect(execSpy).not.toHaveBeenCalled();
   });
 
   it('wraps a thrown tool error in a function_call_output envelope', async () => {

--- a/src/core/models/ModelClientFactory.ts
+++ b/src/core/models/ModelClientFactory.ts
@@ -224,7 +224,7 @@ export class ModelClientFactory {
     const apiKey = accessToken || 'backend-routed';
 
     // Track 11: resolve the parallel-tool-calls flag from tools config.
-    const parallelToolCalls = this.config?.getToolsConfig?.()?.parallelToolCalls ?? false;
+    const parallelToolCalls = this.resolveParallelToolCalls();
 
     // Get model metadata for configuration
     let modelConfig: any = undefined;
@@ -572,7 +572,7 @@ export class ModelClientFactory {
    */
   private instantiateClient(config: ModelClientConfig): ModelClient {
     // Track 11: resolve the parallel-tool-calls flag from tools config.
-    const parallelToolCalls = this.config?.getToolsConfig?.()?.parallelToolCalls ?? false;
+    const parallelToolCalls = this.resolveParallelToolCalls();
 
     // Get provider name from config
     const providerName = config.provider;
@@ -763,6 +763,16 @@ export class ModelClientFactory {
    * Get selected model from config
    * Returns the modelKey of the currently selected model
    */
+  /**
+   * Track 11: resolve the config-driven parallel-tool-calls flag.
+   * The `getToolsConfig?.()` guard is load-bearing — `this.config` may be a
+   * partial mock or an early-bootstrap config without the method. Defaults
+   * to false in that case.
+   */
+  private resolveParallelToolCalls(): boolean {
+    return this.config?.getToolsConfig?.()?.parallelToolCalls ?? false;
+  }
+
   getSelectedModel(): string {
     if (this.config) {
       // Get selectedModelKey from config

--- a/src/core/models/ModelClientFactory.ts
+++ b/src/core/models/ModelClientFactory.ts
@@ -223,6 +223,9 @@ export class ModelClientFactory {
     // Use real token if available (desktop), fall back to dummy key (extension uses cookies)
     const apiKey = accessToken || 'backend-routed';
 
+    // Track 11: resolve the parallel-tool-calls flag from tools config.
+    const parallelToolCalls = this.config?.getToolsConfig?.()?.parallelToolCalls ?? false;
+
     // Get model metadata for configuration
     let modelConfig: any = undefined;
     let supportsReasoning = false;
@@ -306,6 +309,7 @@ export class ModelClientFactory {
         reasoningEffort: reasoningEffort as any,
         reasoningSummary: supportsReasoningSummaries ? { enabled: true } : undefined,
         useCredentials: true,
+        parallelToolCalls,
       });
     }
 
@@ -318,6 +322,7 @@ export class ModelClientFactory {
       provider: backendProvider,
       modelConfig,
       useCredentials: true,
+      parallelToolCalls,
     });
   }
 
@@ -566,6 +571,9 @@ export class ModelClientFactory {
    * @returns Model client instance
    */
   private instantiateClient(config: ModelClientConfig): ModelClient {
+    // Track 11: resolve the parallel-tool-calls flag from tools config.
+    const parallelToolCalls = this.config?.getToolsConfig?.()?.parallelToolCalls ?? false;
+
     // Get provider name from config
     const providerName = config.provider;
     const baseUrl = config.options?.baseUrl;
@@ -650,6 +658,7 @@ export class ModelClientFactory {
           modelFamily,
           provider,
           modelConfig,
+          parallelToolCalls,
         });
 
       case 'together':
@@ -661,6 +670,7 @@ export class ModelClientFactory {
           modelFamily,
           provider,
           modelConfig,
+          parallelToolCalls,
         });
 
       case 'fireworks':
@@ -672,6 +682,7 @@ export class ModelClientFactory {
           modelFamily,
           provider,
           modelConfig,
+          parallelToolCalls,
         });
 
       case 'google-ai-studio':
@@ -693,6 +704,7 @@ export class ModelClientFactory {
           modelConfig,
           reasoningEffort: reasoningEffort as any,
           reasoningSummary: supportsReasoningSummaries ? { enabled: true } : undefined,
+          parallelToolCalls,
         });
 
       case 'openai':
@@ -710,6 +722,7 @@ export class ModelClientFactory {
           reasoningEffort: reasoningEffort as any,
           reasoningSummary: supportsReasoningSummaries ? { enabled: true } : undefined,
           serviceTier,
+          parallelToolCalls,
         });
     }
   }

--- a/src/core/models/__tests__/parallelToolCalls.config.test.ts
+++ b/src/core/models/__tests__/parallelToolCalls.config.test.ts
@@ -102,7 +102,7 @@ describe('Track 11 — parallel_tool_calls config plumbing', () => {
         apiKey: 'k',
         sessionId: 's',
         modelFamily,
-        provider: provider('fireworks') as any,
+        provider: provider('Fireworks AI') as any,
       });
       const payload = await payloadFor(client);
       expect(payload.parallel_tool_calls).toBe(false);
@@ -113,7 +113,7 @@ describe('Track 11 — parallel_tool_calls config plumbing', () => {
         apiKey: 'k',
         sessionId: 's',
         modelFamily,
-        provider: provider('fireworks') as any,
+        provider: provider('Fireworks AI') as any,
         parallelToolCalls: true,
       });
       const payload = await payloadFor(client);

--- a/src/core/models/__tests__/parallelToolCalls.config.test.ts
+++ b/src/core/models/__tests__/parallelToolCalls.config.test.ts
@@ -4,7 +4,7 @@
 // from client config into the built request payload across every
 // OpenAI-compatible client.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { OpenAIResponsesClient } from '../client/OpenAIResponsesClient';
 import { OpenAIChatCompletionClient } from '../client/OpenAIChatCompletionClient';
 import { GroqClient } from '../client/GroqClient';
@@ -122,25 +122,52 @@ describe('Track 11 — parallel_tool_calls config plumbing', () => {
   });
 
   describe('OpenAIChatCompletionClient (Moonshot; base for Together/Fireworks Chat)', () => {
-    it('stores the config-driven flag for the Chat Completions path', () => {
-      const off = new OpenAIChatCompletionClient({
+    // The Chat Completions payload is assembled inside
+    // makeChatCompletionsRequest and `parallel_tool_calls` is only set when
+    // the prompt has tools (it's a no-op without tools). Capture the params
+    // passed to the SDK to assert the real payload, not just the stored field.
+    const promptWithTools = {
+      input: [],
+      tools: [
+        {
+          type: 'function',
+          function: { name: 't', description: 'd', parameters: {} },
+        },
+      ],
+    } as any;
+
+    function chatClient(parallelToolCalls?: boolean) {
+      const client = new OpenAIChatCompletionClient({
         apiKey: 'k',
         sessionId: 's',
         modelFamily,
         provider: { ...provider('moonshot'), wire_api: 'Chat' } as any,
+        ...(parallelToolCalls !== undefined ? { parallelToolCalls } : {}),
       });
-      const on = new OpenAIChatCompletionClient({
-        apiKey: 'k',
-        sessionId: 's',
-        modelFamily,
-        provider: { ...provider('moonshot'), wire_api: 'Chat' } as any,
-        parallelToolCalls: true,
-      });
-      // The Chat Completions payload is assembled mid-stream; assert the
-      // plumbed value the request builder reads (set via the parent
-      // OpenAIResponsesClient constructor from config).
-      expect((off as any).parallelToolCalls).toBe(false);
-      expect((on as any).parallelToolCalls).toBe(true);
+      const captured: any = {};
+      (client as any).client = {
+        chat: {
+          completions: {
+            create: vi.fn(async (params: any) => {
+              captured.params = params;
+              return [] as any;
+            }),
+          },
+        },
+      };
+      return { client, captured };
+    }
+
+    it('emits parallel_tool_calls: false by default in the request payload', async () => {
+      const { client, captured } = chatClient();
+      await (client as any).makeChatCompletionsRequest(promptWithTools);
+      expect(captured.params.parallel_tool_calls).toBe(false);
+    });
+
+    it('emits parallel_tool_calls: true in the request payload when configured', async () => {
+      const { client, captured } = chatClient(true);
+      await (client as any).makeChatCompletionsRequest(promptWithTools);
+      expect(captured.params.parallel_tool_calls).toBe(true);
     });
   });
 });

--- a/src/core/models/__tests__/parallelToolCalls.config.test.ts
+++ b/src/core/models/__tests__/parallelToolCalls.config.test.ts
@@ -1,0 +1,146 @@
+// File: src/core/models/__tests__/parallelToolCalls.config.test.ts
+//
+// Track 11 — verifies the config-driven parallel_tool_calls flag flows
+// from client config into the built request payload across every
+// OpenAI-compatible client.
+
+import { describe, it, expect } from 'vitest';
+import { OpenAIResponsesClient } from '../client/OpenAIResponsesClient';
+import { OpenAIChatCompletionClient } from '../client/OpenAIChatCompletionClient';
+import { GroqClient } from '../client/GroqClient';
+import { FireworksClient } from '../client/FireworksClient';
+
+const modelFamily = {
+  family: 'test-model',
+  base_instructions: 'You are a helpful assistant.',
+  supports_reasoning: false,
+  supports_reasoning_summaries: false,
+  needs_special_apply_patch_instructions: false,
+};
+
+function provider(name: string) {
+  return {
+    name,
+    base_url: 'https://example.com/v1',
+    wire_api: 'Responses' as const,
+    requires_openai_auth: false,
+  };
+}
+
+const minimalPrompt = { input: [], tools: [] } as any;
+
+async function payloadFor(client: any) {
+  return client.buildRequestPayload(minimalPrompt);
+}
+
+describe('Track 11 — parallel_tool_calls config plumbing', () => {
+  describe('OpenAIResponsesClient (OpenAI / xAI)', () => {
+    it('emits parallel_tool_calls: false by default', async () => {
+      const client = new OpenAIResponsesClient({
+        apiKey: 'k',
+        sessionId: 's',
+        modelFamily,
+        provider: provider('openai') as any,
+      });
+      const payload = await payloadFor(client);
+      expect(payload.parallel_tool_calls).toBe(false);
+    });
+
+    it('emits parallel_tool_calls: true when configured', async () => {
+      const client = new OpenAIResponsesClient({
+        apiKey: 'k',
+        sessionId: 's',
+        modelFamily,
+        provider: provider('openai') as any,
+        parallelToolCalls: true,
+      });
+      const payload = await payloadFor(client);
+      expect(payload.parallel_tool_calls).toBe(true);
+    });
+
+    it('emits parallel_tool_calls: true for xAI when configured', async () => {
+      const client = new OpenAIResponsesClient({
+        apiKey: 'k',
+        sessionId: 's',
+        modelFamily,
+        provider: provider('xai') as any,
+        parallelToolCalls: true,
+      });
+      const payload = await payloadFor(client);
+      expect(payload.parallel_tool_calls).toBe(true);
+    });
+  });
+
+  describe('GroqClient', () => {
+    it('defaults to false', async () => {
+      const client = new GroqClient({
+        apiKey: 'k',
+        sessionId: 's',
+        modelFamily,
+        provider: provider('groq') as any,
+      });
+      const payload = await payloadFor(client);
+      expect(payload.parallel_tool_calls).toBe(false);
+    });
+
+    it('emits true when configured', async () => {
+      const client = new GroqClient({
+        apiKey: 'k',
+        sessionId: 's',
+        modelFamily,
+        provider: provider('groq') as any,
+        parallelToolCalls: true,
+      });
+      const payload = await payloadFor(client);
+      expect(payload.parallel_tool_calls).toBe(true);
+    });
+  });
+
+  describe('FireworksClient', () => {
+    it('defaults to false', async () => {
+      const client = new FireworksClient({
+        apiKey: 'k',
+        sessionId: 's',
+        modelFamily,
+        provider: provider('fireworks') as any,
+      });
+      const payload = await payloadFor(client);
+      expect(payload.parallel_tool_calls).toBe(false);
+    });
+
+    it('emits true when configured (no allowlist gate)', async () => {
+      const client = new FireworksClient({
+        apiKey: 'k',
+        sessionId: 's',
+        modelFamily,
+        provider: provider('fireworks') as any,
+        parallelToolCalls: true,
+      });
+      const payload = await payloadFor(client);
+      expect(payload.parallel_tool_calls).toBe(true);
+    });
+  });
+
+  describe('OpenAIChatCompletionClient (Moonshot; base for Together/Fireworks Chat)', () => {
+    it('stores the config-driven flag for the Chat Completions path', () => {
+      const off = new OpenAIChatCompletionClient({
+        apiKey: 'k',
+        sessionId: 's',
+        modelFamily,
+        provider: { ...provider('moonshot'), wire_api: 'Chat' } as any,
+      });
+      const on = new OpenAIChatCompletionClient({
+        apiKey: 'k',
+        sessionId: 's',
+        modelFamily,
+        provider: { ...provider('moonshot'), wire_api: 'Chat' } as any,
+        parallelToolCalls: true,
+      });
+      // The Chat Completions payload is assembled mid-stream; assert the
+      // plumbed value the request builder reads (set via the parent
+      // OpenAIResponsesClient constructor from config).
+      expect((off as any).parallelToolCalls).toBe(false);
+      expect((on as any).parallelToolCalls).toBe(true);
+    });
+  });
+});

--- a/src/core/models/client/FireworksClient.ts
+++ b/src/core/models/client/FireworksClient.ts
@@ -50,7 +50,7 @@ export class FireworksClient extends OpenAIResponsesClient {
       input: formattedInput,
       tools: toolsJson,
       tool_choice: 'auto',
-      parallel_tool_calls: false,
+      parallel_tool_calls: this.parallelToolCalls,
       // Fireworks-specific omissions:
       // - store: not supported (omitted entirely)
       // - include: not supported (omitted entirely)

--- a/src/core/models/client/GroqClient.ts
+++ b/src/core/models/client/GroqClient.ts
@@ -48,7 +48,7 @@ export class GroqClient extends OpenAIResponsesClient {
       input: await get_formatted_input(prompt),
       tools: toolsJson,
       tool_choice: 'auto',
-      parallel_tool_calls: false,
+      parallel_tool_calls: this.parallelToolCalls,
       // Groq-specific omissions:
       // - store: not supported (omitted entirely)
       // - include: not supported (omitted entirely)

--- a/src/core/models/client/OpenAIChatCompletionClient.ts
+++ b/src/core/models/client/OpenAIChatCompletionClient.ts
@@ -42,6 +42,8 @@ export interface OpenAIChatCompletionConfig {
   modelConfig?: IModelConfig;
   /** Use credentials (cookies) for authentication - for backend routing */
   useCredentials?: boolean;
+  /** Track 11: allow the model to emit multiple tool calls per response. Default false. */
+  parallelToolCalls?: boolean;
 }
 
 /**
@@ -85,6 +87,7 @@ export class OpenAIChatCompletionClient extends OpenAIResponsesClient {
       provider: config.provider,
       modelConfig: config.modelConfig,
       useCredentials: config.useCredentials,
+      parallelToolCalls: config.parallelToolCalls,
     }, retryConfig);
 
     // Backend routing: rewrite /chat/completions to /completions
@@ -816,7 +819,7 @@ export class OpenAIChatCompletionClient extends OpenAIResponsesClient {
         });
 
         requestParams.tool_choice = 'auto';
-        requestParams.parallel_tool_calls = false;
+        requestParams.parallel_tool_calls = this.parallelToolCalls;
       }
 
       // Use OpenAI SDK's chat completions API with streaming

--- a/src/core/models/client/OpenAIResponsesClient.ts
+++ b/src/core/models/client/OpenAIResponsesClient.ts
@@ -92,6 +92,8 @@ export interface OpenAIResponsesConfig {
   serviceTier?: 'default' | 'flex' | 'priority';
   /** Use credentials (cookies) for authentication - for backend routing */
   useCredentials?: boolean;
+  /** Track 11: allow the model to emit multiple tool calls per response. Default false. */
+  parallelToolCalls?: boolean;
 }
 
 /**
@@ -111,6 +113,8 @@ export class OpenAIResponsesClient extends ModelClient {
   protected serviceTier?: 'default' | 'flex' | 'priority';
   protected currentModel: string;
   protected useCredentials: boolean;
+  /** Track 11: emitted as `parallel_tool_calls` in the request payload. */
+  protected readonly parallelToolCalls: boolean;
 
   // OpenAI SDK client instance
   protected client: OpenAI;
@@ -127,6 +131,7 @@ export class OpenAIResponsesClient extends ModelClient {
     // This allows the model client to be created before API key is configured
 
     this.apiKey = config.apiKey;
+    this.parallelToolCalls = config.parallelToolCalls ?? false;
     this.baseUrl = config.baseUrl || 'https://api.openai.com/v1';
 
     // Validate baseUrl is a valid URL to catch configuration errors early
@@ -433,7 +438,7 @@ export class OpenAIResponsesClient extends ModelClient {
       }),
       tools: toolsJson,
       tool_choice: 'auto',
-      parallel_tool_calls: false,
+      parallel_tool_calls: this.parallelToolCalls,
       ...(storeValue !== undefined && { store: storeValue }), // Conditionally include store
       stream: true,
       ...(include !== undefined && include.length > 0 && { include }), // Conditionally include

--- a/src/core/models/types/ResponsesAPI.ts
+++ b/src/core/models/types/ResponsesAPI.ts
@@ -16,8 +16,8 @@ export interface ResponsesApiRequest {
   tools: any[];
   /** Tool selection mode - always "auto" (literal type enforced) */
   tool_choice: "auto";
-  /** Whether to allow parallel tool calls - always false (literal type enforced) */
-  parallel_tool_calls: false;
+  /** Whether to allow parallel tool calls (Track 11 — config-driven, default false). */
+  parallel_tool_calls: boolean;
   reasoning?: Reasoning;
   store: boolean;
   /** Whether to stream the response - always true (literal type enforced) */

--- a/src/extension/__tests__/BrowserAdaptations.test.ts
+++ b/src/extension/__tests__/BrowserAdaptations.test.ts
@@ -54,8 +54,9 @@ describe('Browser Adaptations Contract Compliance', () => {
     });
 
     it('should construct request body matching Rust structure', () => {
-      // Track 11: parallel_tool_calls is now config-driven (default false).
-      // This structural fixture uses the default value.
+      // Track 11: parallel_tool_calls is now config-driven (default false);
+      // this structural fixture uses the default. The provider matrix is
+      // covered by parallelToolCalls.config.test.ts.
       const requestBody = {
         model: 'gpt-4',
         instructions: 'You are helpful',
@@ -70,8 +71,6 @@ describe('Browser Adaptations Contract Compliance', () => {
 
       expect(requestBody.stream).toBe(true);
       expect(requestBody.tool_choice).toBe('auto');
-      // Default is false; Track 11's parallelToolCalls.config.test.ts covers
-      // the config-driven true/false matrix across providers.
       expect(requestBody.parallel_tool_calls).toBe(false);
     });
   });

--- a/src/extension/__tests__/BrowserAdaptations.test.ts
+++ b/src/extension/__tests__/BrowserAdaptations.test.ts
@@ -54,6 +54,8 @@ describe('Browser Adaptations Contract Compliance', () => {
     });
 
     it('should construct request body matching Rust structure', () => {
+      // Track 11: parallel_tool_calls is now config-driven (default false).
+      // This structural fixture uses the default value.
       const requestBody = {
         model: 'gpt-4',
         instructions: 'You are helpful',
@@ -68,6 +70,8 @@ describe('Browser Adaptations Contract Compliance', () => {
 
       expect(requestBody.stream).toBe(true);
       expect(requestBody.tool_choice).toBe('auto');
+      // Default is false; Track 11's parallelToolCalls.config.test.ts covers
+      // the config-driven true/false matrix across providers.
       expect(requestBody.parallel_tool_calls).toBe(false);
     });
   });


### PR DESCRIPTION
## Summary

Track 11. Lets the model emit multiple tool calls per response so Track 02's already-shipped orchestrator runs them in parallel. ~50 LOC of flag plumbing + a confirmed-required buffering addition for the OpenAI Responses / xAI path.

**Design:** [`.ai_design/agent_improvements/11_parallel_tool_calls/design.md`](../tree/agent-improvements/.ai_design/agent_improvements/11_parallel_tool_calls/design.md)

## Phase 0 verification (done by reading decode paths — no guessing)

| Provider class | Wire shape for N parallel calls | Needs |
|---|---|---|
| Chat Completions (Groq/Fireworks/Together/Moonshot/OpenAI-Chat) | ONE unified `message` item w/ `tool_calls[]` (`OpenAIChatCompletionClient.ts:600`) — already hits Track 02 orchestrator | flag only |
| OpenAI Responses + xAI | **N separate `function_call` items** (`OpenAIResponsesClient.ts:720`) — hit legacy sequential path | flag **+ buffering** |
| Gemini | native unified format | no change |

The design's conditional Phase 1.5 (buffering) is therefore **required**, not optional. Confirmed before writing code.

## What changed

### Flag plumbing
- `IToolsConfig.parallelToolCalls` (default `false` in `DEFAULT_TOOLS_CONFIG`)
- `OpenAIResponsesConfig` / `OpenAIChatCompletionConfig` carry it; `OpenAIResponsesClient` stores `this.parallelToolCalls`, read by every OpenAI-compatible request builder (Groq/Fireworks/Together/Moonshot inherit)
- `ResponsesAPI.parallel_tool_calls`: `false` literal type → `boolean`
- `ModelClientFactory` resolves the flag once per construction method from `getToolsConfig()` and injects into all OpenAI-compatible clients (Google skipped — native). **No allowlist** (prior research confirmed all providers support it).

### Buffering (Phase 1.5)
- `TurnManager` stream loop buffers legacy `function_call` items instead of executing each as it arrives; flushes the batch through Track 02's `prepareToolCall` + `partitionToolCalls` + `executeToolCallBatches` at `Completed`, then `maybeEnforceTier2` (Track 09 parity). Non-tool items keep immediate handling.
- New private `executeBufferedToolCalls` helper mirrors the unified-format path.

### Behavior change (intentional, flagged for review)
Deferring `function_call` execution to `Completed` means a cancel **before** stream completion now skips tool execution entirely (previously some tools may have already executed mid-stream). This is more correct for an interrupt, but it is a behavior change worth a reviewer's eye.

## Tests

- **`parallelToolCalls.config.test.ts`** (8): flag flows to payload for OpenAIResponses (OpenAI/xAI), Groq, Fireworks; default false; config `true` → `true` with no allowlist gate.
- **`TurnManager.parallelTools.integration.test.ts`** (3): buffered safe calls run concurrently + unsafe sequentially + original order preserved; single-call path; thrown-tool error envelope.
- Updated `BrowserAdaptations.test.ts` to note the flag is now config-driven (default `false` unchanged).
- All 4,446 core tests pass; `type-check` + `lint` clean.

## Default behavior unchanged

`parallelToolCalls` defaults to `false` — dark launch. No user-visible change until explicitly enabled. Default-on is a deliberate follow-up after manual QA (deferred per design).

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — 0 errors on changed files
- [x] `npx vitest run src/core/models/` — 1006 pass
- [x] `npx vitest run src/core/` — 4446 pass (+7 pre-existing gemini skips)
- [x] `BrowserAdaptations.test.ts` — pass
- [ ] Manual QA with `parallelToolCalls: true`: OpenAI Responses multi-tool prompt → parallel exec, results ordered
- [ ] Manual QA: Groq/Fireworks multi-tool prompt → parallel exec
- [ ] Manual QA: interrupt mid-stream → no tools execute (new behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)