### PR TITLE
feat(track-20): Managed / Policy Settings Tier — end-to-end (Phases 1–4)

### DIFF
--- a/.ai_design/agent_improvements/20_managed_policy_settings/design.md
+++ b/.ai_design/agent_improvements/20_managed_policy_settings/design.md
@@ -1,6 +1,6 @@
 # Track 20: Managed / Policy Settings Tier
 
-**Priority: P1** · **Effort: M** (full OS-MDM parity: P3/L) · **Status: READY TO IMPLEMENT (end-to-end spec)**
+**Priority: P1** · **Effort: M** (full OS-MDM parity: P3/L) · **Status: IMPLEMENTED (Phases 1–4; macOS-plist/Windows-registry = deferred P3/L)**
 
 > Source: third-pass claudy↔browserx research (2026-05-16) — full reads of claudy's
 > `services/remoteManagedSettings/` + `utils/settings/` and a full audit of browserx's

--- a/.ai_design/agent_improvements/20_managed_policy_settings/tasks.md
+++ b/.ai_design/agent_improvements/20_managed_policy_settings/tasks.md
@@ -18,6 +18,39 @@ merge point is **not** end-to-end and must not be merged.
 
 ---
 
+## IMPLEMENTATION STATUS (2026-05-16) — Phases 1–4 DONE, end-to-end
+
+Branch `feat/track-20-managed-policy-settings`. type-check clean, 0 lint errors,
+383 tests green (incl. the four-surface invariant), production build green.
+
+**Phase 0 findings (corrections vs the design's assumptions):**
+- **Track 17 diagnostics IS implemented** (the branch moved — `src/core/
+  diagnostics/` with a real `DiagnosticCheck` registry). So we shipped a real
+  `policy-origin` check registered in `registerCoreDiagnosticChecks()` — no
+  "degrade gracefully / conditional registration" was needed.
+- AgentConfig has **more** write surfaces than the 3 named (resetConfig,
+  importConfig, setSelectedModel, updateModelConfig, add/update/deleteProvider,
+  enable/disableTool, updateToolSpecificConfig, profile mutators). All now
+  re-pin or `assertWritable`-guarded — the invariant holds across every one.
+- The build copies the **root** `manifest.json` (`scripts/build.js:45`), with a
+  synced `src/extension/manifest.json`. Updated **both** + added
+  `managed-schema.json` copy.
+- **Interactive securityCheck adaptation (deliberate divergence):** a blocking
+  `ApprovalManager` modal at policy-change time has no per-turn agent context
+  and the server core ApprovalManager fail-opens — wiring it blind is unsafe.
+  Implemented instead: pure `assessPolicyChange`, server auto-apply + a
+  **redacted `emitLog` audit** (real Track-16 sink, the headless-critical
+  path), and ext/desktop a surfaced `console.warn` on weakening. Enforcement
+  never depends on the prompt; this matches the design's intent (operator/user
+  is informed) without unverifiable blind UI wiring.
+- **Phase 4 scope:** shipped the testable, dependency-free slice —
+  `ManagedDirSource` (`managed-settings.d/` drop-in dir, deterministic merge).
+  macOS-plist / Windows-registry remain the explicitly-deferred P3/L
+  subprocess tier (need a real OS + `plutil`/`reg`), per the design's own
+  "Phase 4 P3/L, separate, optional".
+
+---
+
 ## Phase 0: Pre-implementation verification (DO FIRST — gates the estimate)
 
 The design was line-level verified on branch `agent-improvements` (2026-05-16).

--- a/managed-schema.json
+++ b/managed-schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "values": {
+      "type": "object",
+      "description": "Admin-provided configuration values, keyed by namespaced dot-path (e.g. \"agent.approval.mode\"). Highest priority — overrides user/stored/default values.",
+      "additionalProperties": true
+    },
+    "lockedKeys": {
+      "type": "array",
+      "description": "Namespaced dot-paths the user/agent cannot change (e.g. \"agent.approval.mode\"). Locking an ancestor freezes the whole subtree.",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": false
+}

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
   "version": "0.0.36",
   "description": "__MSG_extension_description__",
   "default_locale": "en",
+  "managed_storage": "managed-schema.json",
   "permissions": [
     "tabs",
     "tabGroups",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -46,6 +46,12 @@ function build() {
     const manifestDest = path.join(distPath, 'manifest.json');
     fs.copyFileSync(manifestSrc, manifestDest);
 
+    // Track 20: Chrome managed_storage schema (admin enterprise policy channel)
+    const managedSchemaSrc = path.join(__dirname, '..', 'managed-schema.json');
+    if (fs.existsSync(managedSchemaSrc)) {
+      fs.copyFileSync(managedSchemaSrc, path.join(distPath, 'managed-schema.json'));
+    }
+
     // Copy and fix HTML files
     log('\n📄 Copying and fixing HTML files...', colors.yellow);
     const htmlFiles = [

--- a/src/config/AgentConfig.ts
+++ b/src/config/AgentConfig.ts
@@ -25,6 +25,7 @@ import { validateConfig, validateModelConfig, validateProviderConfig, detectProv
 import {
   applyPolicy,
   assertWritable,
+  assertWritableSubtree,
   stripLockedWrites,
   getActivePolicySync,
 } from '../core/config/policy';
@@ -140,6 +141,23 @@ export class AgentConfig implements IConfigService {
       getActivePolicySync(),
       'agent'
     );
+  }
+
+  /**
+   * Track 20: drop writes to policy-locked leaves a partial-merge mutator's
+   * `patch` touches (leaves are relative to `basePath`, e.g. `providers.openai`
+   * for updateProvider). Warns, returns the cleaned patch. Mirrors
+   * updateConfig so EVERY write surface — not just updateConfig — enforces
+   * leaf-level locks. The post-merge pin still re-asserts pinned values.
+   */
+  private stripLocked<T>(patch: T, basePath: string): T {
+    const { patch: safe, stripped } = stripLockedWrites('agent', patch, basePath);
+    if (stripped.length > 0) {
+      console.warn(
+        `[AgentConfig] Ignored write to organization-managed setting(s): ${stripped.join(', ')}`
+      );
+    }
+    return safe;
   }
 
   // Core CRUD operations
@@ -304,7 +322,17 @@ export class AgentConfig implements IConfigService {
 
   updateModelConfig(config: Partial<IModelConfig>): IModelConfig {
     this.ensureInitialized();
-    assertWritable('agent', 'selectedModelKey');
+
+    // Resolve the target model first and guard the ACTUAL write path
+    // (providers[id].models[*], not selectedModelKey) fail-closed, before any
+    // validation work. A locked provider/models subtree (or ancestor) is
+    // enforced; sibling keys like apiKey are intentionally NOT used here so an
+    // apiKey lock doesn't block unrelated model edits.
+    const modelData = this.getModelByKey(this.currentConfig.selectedModelKey);
+    if (!modelData) {
+      throw new Error('Cannot update model: selected model not found');
+    }
+    assertWritable('agent', `providers.${modelData.provider.id}.models`);
 
     const oldModel = this.getModelConfig();
     const newModel = { ...oldModel, ...config };
@@ -325,12 +353,6 @@ export class AgentConfig implements IConfigService {
       throw new Error('maxOutputTokens cannot exceed contextWindow');
     }
 
-    // Update the model in the provider's models array
-    const modelData = this.getModelByKey(this.currentConfig.selectedModelKey);
-    if (!modelData) {
-      throw new Error('Cannot update model: selected model not found');
-    }
-
     const provider = this.currentConfig.providers[modelData.provider.id];
     if (!provider || !provider.models) {
       throw new Error('Cannot update model: provider not found');
@@ -343,6 +365,8 @@ export class AgentConfig implements IConfigService {
     }
 
     provider.models[modelIndex] = newModel;
+    // Re-assert policy in case a pinned value lives under this provider.
+    this.pinPolicy();
 
     this.storage.set(extractStoredConfig(this.currentConfig)).catch(err => {
       console.error('Failed to persist config:', err);
@@ -366,7 +390,7 @@ export class AgentConfig implements IConfigService {
    */
   addProvider(provider: IProviderConfig): IProviderConfig {
     this.ensureInitialized();
-    assertWritable('agent', `providers.${provider.id}`);
+    assertWritableSubtree('agent', `providers.${provider.id}`);
 
     const validation = validateProviderConfig(provider);
     if (!validation.valid) {
@@ -378,13 +402,14 @@ export class AgentConfig implements IConfigService {
     }
 
     this.currentConfig.providers[provider.id] = provider;
+    this.pinPolicy();
     this.storage.set(extractStoredConfig(this.currentConfig)).catch(err => {
       console.error('Failed to persist config:', err);
     });
 
-    this.emitChangeEvent('provider', null, provider);
+    this.emitChangeEvent('provider', null, this.currentConfig.providers[provider.id]);
 
-    return provider;
+    return this.currentConfig.providers[provider.id];
   }
 
   /**
@@ -396,6 +421,9 @@ export class AgentConfig implements IConfigService {
   updateProvider(id: string, provider: Partial<IProviderConfig>): IProviderConfig {
     this.ensureInitialized();
 
+    // Whole-provider (or ancestor) lock → hard reject. Finer leaf locks (e.g.
+    // providers.<id>.apiKey) are stripped below so unlocked siblings still
+    // apply — consistent with updateConfig.
     assertWritable('agent', `providers.${id}`);
 
     const existing = this.currentConfig.providers[id];
@@ -403,7 +431,8 @@ export class AgentConfig implements IConfigService {
       throw new Error(`Provider not found: ${id}`);
     }
 
-    const updated = { ...existing, ...provider };
+    const safe = this.stripLocked(provider, `providers.${id}`);
+    const updated = { ...existing, ...safe };
 
     const validation = validateProviderConfig(updated);
     if (!validation.valid) {
@@ -415,18 +444,21 @@ export class AgentConfig implements IConfigService {
     }
 
     this.currentConfig.providers[id] = updated;
+    this.pinPolicy();
     this.storage.set(extractStoredConfig(this.currentConfig)).catch(err => {
       console.error('Failed to persist config:', err);
     });
 
-    this.emitChangeEvent('provider', existing, updated);
+    this.emitChangeEvent('provider', existing, this.currentConfig.providers[id]);
 
-    return updated;
+    return this.currentConfig.providers[id];
   }
 
   deleteProvider(id: string): void {
     this.ensureInitialized();
-    assertWritable('agent', `providers.${id}`);
+    // Deleting the subtree would also remove any locked descendant (e.g. a
+    // locked apiKey), so reject if the provider OR anything under it is locked.
+    assertWritableSubtree('agent', `providers.${id}`);
 
     // Check if provider hosts the currently selected model
     if (this.currentConfig.selectedModelKey.startsWith(`${id}:`)) {
@@ -435,6 +467,7 @@ export class AgentConfig implements IConfigService {
 
     const deleted = this.currentConfig.providers[id];
     delete this.currentConfig.providers[id];
+    this.pinPolicy();
     this.storage.set(extractStoredConfig(this.currentConfig)).catch(err => {
       console.error('Failed to persist config:', err);
     });
@@ -695,7 +728,7 @@ export class AgentConfig implements IConfigService {
 
   createProfile(profile: IProfileConfig): IProfileConfig {
     this.ensureInitialized();
-    assertWritable('agent', 'profiles');
+    assertWritableSubtree('agent', `profiles.${profile.name}`);
 
     if (!this.currentConfig.profiles) {
       this.currentConfig.profiles = {};
@@ -706,6 +739,7 @@ export class AgentConfig implements IConfigService {
     }
 
     this.currentConfig.profiles[profile.name] = profile;
+    this.pinPolicy();
     this.storage.set(extractStoredConfig(this.currentConfig)).catch(err => {
       console.error('Failed to persist config:', err);
     });
@@ -717,26 +751,29 @@ export class AgentConfig implements IConfigService {
 
   updateProfile(name: string, profile: Partial<IProfileConfig>): IProfileConfig {
     this.ensureInitialized();
-    assertWritable('agent', 'profiles');
+    assertWritable('agent', `profiles.${name}`);
 
     if (!this.currentConfig.profiles?.[name]) {
       throw new Error(`Profile not found: ${name}`);
     }
 
-    const updated = { ...this.currentConfig.profiles[name], ...profile };
+    const safe = this.stripLocked(profile, `profiles.${name}`);
+    const previous = this.currentConfig.profiles[name];
+    const updated = { ...previous, ...safe };
     this.currentConfig.profiles[name] = updated;
+    this.pinPolicy();
     this.storage.set(extractStoredConfig(this.currentConfig)).catch(err => {
       console.error('Failed to persist config:', err);
     });
 
-    this.emitChangeEvent('profile', this.currentConfig.profiles[name], updated);
+    this.emitChangeEvent('profile', previous, this.currentConfig.profiles[name]);
 
-    return updated;
+    return this.currentConfig.profiles[name];
   }
 
   deleteProfile(name: string): void {
     this.ensureInitialized();
-    assertWritable('agent', 'profiles');
+    assertWritableSubtree('agent', `profiles.${name}`);
 
     if (this.currentConfig.activeProfile === name) {
       throw new Error('Cannot delete active profile');
@@ -746,6 +783,7 @@ export class AgentConfig implements IConfigService {
     if (this.currentConfig.profiles) {
       delete this.currentConfig.profiles[name];
     }
+    this.pinPolicy();
     this.storage.set(extractStoredConfig(this.currentConfig)).catch(err => {
       console.error('Failed to persist config:', err);
     });
@@ -764,6 +802,7 @@ export class AgentConfig implements IConfigService {
     this.currentConfig.activeProfile = name;
     const profile = this.currentConfig.profiles[name];
     profile.lastUsed = Date.now();
+    this.pinPolicy();
 
     this.storage.set(extractStoredConfig(this.currentConfig)).catch(err => {
       console.error('Failed to persist config:', err);
@@ -820,29 +859,35 @@ export class AgentConfig implements IConfigService {
 
   updateToolsConfig(config: Partial<IToolsConfig>): IToolsConfig {
     this.ensureInitialized();
+    // Whole-tools (or ancestor) lock → hard reject. Finer leaf locks (e.g.
+    // tools.sandboxPolicy.network_access) are stripped so unlocked siblings
+    // still apply, then re-pinned — the previous coarse guard let any
+    // sub-`tools` lock through entirely.
     assertWritable('agent', 'tools');
+    const safe = this.stripLocked(config, 'tools');
 
     const oldConfig = this.currentConfig.tools;
     const newConfig = {
       ...(this.currentConfig.tools || {}),
-      ...config,
+      ...safe,
       sandboxPolicy: {
         ...(this.currentConfig.tools?.sandboxPolicy || {}),
-        ...(config.sandboxPolicy || {})
+        ...(safe.sandboxPolicy || {})
       },
       perToolConfig: {
         ...(this.currentConfig.tools?.perToolConfig || {}),
-        ...(config.perToolConfig || {})
+        ...(safe.perToolConfig || {})
       }
     };
 
     this.currentConfig.tools = newConfig as IToolsConfig;
+    this.pinPolicy();
     this.storage.set(extractStoredConfig(this.currentConfig)).catch(err => {
       console.error('Failed to persist config:', err);
     });
-    this.emitChangeEvent('tools' as any, oldConfig, newConfig);
+    this.emitChangeEvent('tools' as any, oldConfig, this.currentConfig.tools);
 
-    return newConfig as IToolsConfig;
+    return this.currentConfig.tools as IToolsConfig;
   }
 
   getEnabledTools(): string[] {
@@ -852,7 +897,11 @@ export class AgentConfig implements IConfigService {
 
   enableTool(toolName: string): void {
     this.ensureInitialized();
-    assertWritable('agent', 'tools');
+    // Writes both tools.enabled and tools.disabled — guard the exact arrays
+    // (and, via ancestor match, a whole-`tools` lock) rather than the coarse
+    // `tools` path which let a specific `tools.enabled` lock slip through.
+    assertWritable('agent', 'tools.enabled');
+    assertWritable('agent', 'tools.disabled');
 
     const tools = this.currentConfig.tools || { enabled: [], disabled: [] };
     if (!tools.enabled) tools.enabled = [];
@@ -864,15 +913,17 @@ export class AgentConfig implements IConfigService {
     tools.disabled = tools.disabled.filter(name => name !== toolName);
 
     this.currentConfig.tools = tools as IToolsConfig;
+    this.pinPolicy();
     this.storage.set(extractStoredConfig(this.currentConfig)).catch(err => {
       console.error('Failed to persist config:', err);
     });
-    this.emitChangeEvent('tools' as any, null, tools);
+    this.emitChangeEvent('tools' as any, null, this.currentConfig.tools);
   }
 
   disableTool(toolName: string): void {
     this.ensureInitialized();
-    assertWritable('agent', 'tools');
+    assertWritable('agent', 'tools.enabled');
+    assertWritable('agent', 'tools.disabled');
 
     const tools = this.currentConfig.tools || { enabled: [], disabled: [] };
     if (!tools.enabled) tools.enabled = [];
@@ -884,10 +935,11 @@ export class AgentConfig implements IConfigService {
     }
 
     this.currentConfig.tools = tools as IToolsConfig;
+    this.pinPolicy();
     this.storage.set(extractStoredConfig(this.currentConfig)).catch(err => {
       console.error('Failed to persist config:', err);
     });
-    this.emitChangeEvent('tools' as any, null, tools);
+    this.emitChangeEvent('tools' as any, null, this.currentConfig.tools);
   }
 
   getToolTimeout(): number {
@@ -911,6 +963,7 @@ export class AgentConfig implements IConfigService {
   ): void {
     this.ensureInitialized();
     assertWritable('agent', `tools.perToolConfig.${toolName}`);
+    const safe = this.stripLocked(config, `tools.perToolConfig.${toolName}`);
 
     if (!this.currentConfig.tools) {
       this.currentConfig.tools = { enabled: [], disabled: [] } as IToolsConfig;
@@ -922,8 +975,9 @@ export class AgentConfig implements IConfigService {
     const oldConfig = this.currentConfig.tools.perToolConfig[toolName];
     this.currentConfig.tools.perToolConfig[toolName] = {
       ...(oldConfig || {}),
-      ...config
+      ...safe
     };
+    this.pinPolicy();
 
     this.storage.set(extractStoredConfig(this.currentConfig)).catch(err => {
       console.error('Failed to persist config:', err);

--- a/src/config/AgentConfig.ts
+++ b/src/config/AgentConfig.ts
@@ -23,6 +23,12 @@ import {
 } from './defaults';
 import { validateConfig, validateModelConfig, validateProviderConfig, detectProviderFromKey } from './validators';
 import {
+  applyPolicy,
+  assertWritable,
+  stripLockedWrites,
+  getActivePolicySync,
+} from '../core/config/policy';
+import {
   getCredentialStore,
   isCredentialStoreInitialized,
   type CredentialStore
@@ -111,11 +117,29 @@ export class AgentConfig implements IConfigService {
       const storedConfig = await this.storage.get();
 
       // Build full runtime config by merging stored data with default.json providers/models
+      // (buildRuntimeConfig applies the Track 20 policy pin internally).
       this.currentConfig = buildRuntimeConfig(storedConfig);
+
+      // Track 20: reload() previously emitted nothing — the UI never learned a
+      // managed-policy change took effect. Emit so locked fields re-render.
+      this.emitChangeEvent('policy', null, this.currentConfig.policy ?? null);
     } catch (error) {
       console.error('Failed to reload config:', error);
       throw error;
     }
+  }
+
+  /**
+   * Track 20: re-assert admin policy onto the in-memory config. Bulk write
+   * paths (updateConfig/resetConfig/importConfig) bypass buildRuntimeConfig,
+   * so they must re-pin or a locked value would be overridable until reload.
+   */
+  private pinPolicy(): void {
+    this.currentConfig = applyPolicy(
+      this.currentConfig,
+      getActivePolicySync(),
+      'agent'
+    );
   }
 
   // Core CRUD operations
@@ -128,7 +152,17 @@ export class AgentConfig implements IConfigService {
     this.ensureInitialized();
 
     const oldConfig = { ...this.currentConfig };
-    const newConfig = { ...this.currentConfig, ...config };
+
+    // Track 20: drop writes to policy-locked paths (non-locked siblings pass
+    // through). The post-merge pin below re-asserts policy regardless — this
+    // is defense-in-depth + the signal for the UI.
+    const { patch, stripped } = stripLockedWrites('agent', config);
+    if (stripped.length > 0) {
+      console.warn(
+        `[AgentConfig] Ignored write to organization-managed setting(s): ${stripped.join(', ')}`
+      );
+    }
+    const newConfig = { ...this.currentConfig, ...patch };
 
     // Validate the new configuration
     const validation = validateConfig(newConfig);
@@ -141,6 +175,9 @@ export class AgentConfig implements IConfigService {
     }
 
     this.currentConfig = newConfig;
+    // Re-pin so a locked value is restored even if it slipped through a
+    // nested merge.
+    this.pinPolicy();
     this.storage.set(extractStoredConfig(this.currentConfig)).catch(err => {
       console.error('Failed to persist config:', err);
     });
@@ -169,6 +206,8 @@ export class AgentConfig implements IConfigService {
     }
 
     this.currentConfig = newConfig;
+    // Track 20: a reset must not clear an admin-managed value.
+    this.pinPolicy();
     this.storage.set(extractStoredConfig(this.currentConfig)).catch(err => {
       console.error('Failed to persist config:', err);
     });
@@ -216,6 +255,7 @@ export class AgentConfig implements IConfigService {
    */
   async setSelectedModel(compositeKey: string): Promise<void> {
     this.ensureInitialized();
+    assertWritable('agent', 'selectedModelKey');
 
     // Validate format
     if (!compositeKey.includes(':')) {
@@ -264,6 +304,7 @@ export class AgentConfig implements IConfigService {
 
   updateModelConfig(config: Partial<IModelConfig>): IModelConfig {
     this.ensureInitialized();
+    assertWritable('agent', 'selectedModelKey');
 
     const oldModel = this.getModelConfig();
     const newModel = { ...oldModel, ...config };
@@ -325,6 +366,7 @@ export class AgentConfig implements IConfigService {
    */
   addProvider(provider: IProviderConfig): IProviderConfig {
     this.ensureInitialized();
+    assertWritable('agent', `providers.${provider.id}`);
 
     const validation = validateProviderConfig(provider);
     if (!validation.valid) {
@@ -354,6 +396,8 @@ export class AgentConfig implements IConfigService {
   updateProvider(id: string, provider: Partial<IProviderConfig>): IProviderConfig {
     this.ensureInitialized();
 
+    assertWritable('agent', `providers.${id}`);
+
     const existing = this.currentConfig.providers[id];
     if (!existing) {
       throw new Error(`Provider not found: ${id}`);
@@ -382,6 +426,7 @@ export class AgentConfig implements IConfigService {
 
   deleteProvider(id: string): void {
     this.ensureInitialized();
+    assertWritable('agent', `providers.${id}`);
 
     // Check if provider hosts the currently selected model
     if (this.currentConfig.selectedModelKey.startsWith(`${id}:`)) {
@@ -418,6 +463,7 @@ export class AgentConfig implements IConfigService {
    */
   async setProviderApiKey(providerId: string, apiKey: string): Promise<IProviderConfig> {
     this.ensureInitialized();
+    assertWritable('agent', `providers.${providerId}.apiKey`);
 
     // Check if provider exists
     const provider = this.currentConfig.providers[providerId];
@@ -480,6 +526,7 @@ export class AgentConfig implements IConfigService {
    */
   async deleteProviderApiKey(providerId: string): Promise<void> {
     this.ensureInitialized();
+    assertWritable('agent', `providers.${providerId}.apiKey`);
 
     const provider = this.currentConfig.providers[providerId];
     if (!provider) {
@@ -648,6 +695,7 @@ export class AgentConfig implements IConfigService {
 
   createProfile(profile: IProfileConfig): IProfileConfig {
     this.ensureInitialized();
+    assertWritable('agent', 'profiles');
 
     if (!this.currentConfig.profiles) {
       this.currentConfig.profiles = {};
@@ -669,6 +717,7 @@ export class AgentConfig implements IConfigService {
 
   updateProfile(name: string, profile: Partial<IProfileConfig>): IProfileConfig {
     this.ensureInitialized();
+    assertWritable('agent', 'profiles');
 
     if (!this.currentConfig.profiles?.[name]) {
       throw new Error(`Profile not found: ${name}`);
@@ -687,6 +736,7 @@ export class AgentConfig implements IConfigService {
 
   deleteProfile(name: string): void {
     this.ensureInitialized();
+    assertWritable('agent', 'profiles');
 
     if (this.currentConfig.activeProfile === name) {
       throw new Error('Cannot delete active profile');
@@ -705,6 +755,7 @@ export class AgentConfig implements IConfigService {
 
   activateProfile(name: string): void {
     this.ensureInitialized();
+    assertWritable('agent', 'activeProfile');
 
     if (!this.currentConfig.profiles?.[name]) {
       throw new Error(`Profile not found: ${name}`);
@@ -752,6 +803,8 @@ export class AgentConfig implements IConfigService {
     }
 
     this.currentConfig = data.config;
+    // Track 20: an imported config must not override admin-managed values.
+    this.pinPolicy();
     this.storage.set(extractStoredConfig(this.currentConfig)).catch(err => {
       console.error('Failed to persist config:', err);
     });
@@ -767,6 +820,7 @@ export class AgentConfig implements IConfigService {
 
   updateToolsConfig(config: Partial<IToolsConfig>): IToolsConfig {
     this.ensureInitialized();
+    assertWritable('agent', 'tools');
 
     const oldConfig = this.currentConfig.tools;
     const newConfig = {
@@ -798,6 +852,7 @@ export class AgentConfig implements IConfigService {
 
   enableTool(toolName: string): void {
     this.ensureInitialized();
+    assertWritable('agent', 'tools');
 
     const tools = this.currentConfig.tools || { enabled: [], disabled: [] };
     if (!tools.enabled) tools.enabled = [];
@@ -817,6 +872,7 @@ export class AgentConfig implements IConfigService {
 
   disableTool(toolName: string): void {
     this.ensureInitialized();
+    assertWritable('agent', 'tools');
 
     const tools = this.currentConfig.tools || { enabled: [], disabled: [] };
     if (!tools.enabled) tools.enabled = [];
@@ -854,6 +910,7 @@ export class AgentConfig implements IConfigService {
     config: Partial<IToolSpecificConfig>
   ): void {
     this.ensureInitialized();
+    assertWritable('agent', `tools.perToolConfig.${toolName}`);
 
     if (!this.currentConfig.tools) {
       this.currentConfig.tools = { enabled: [], disabled: [] } as IToolsConfig;

--- a/src/config/__tests__/policy.integration.test.ts
+++ b/src/config/__tests__/policy.integration.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Track 20 — the crux end-to-end invariant: a locked key must survive ALL
+ * four agent-config write surfaces plus reload, and the runtime marker must
+ * never round-trip to storage.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AgentConfig } from '@/config/AgentConfig';
+import { extractStoredConfig } from '@/config/defaults';
+import { resolve as resolveConfigPath } from '@/config/configSchema';
+import { PolicyLockedError } from '@/core/config/policy';
+import {
+  registerPolicySources,
+  resolveActivePolicy,
+  __resetPolicyResolverForTests,
+} from '@/core/config/policy';
+import type { PolicySource } from '@/core/config/policy';
+import type { IConfigChangeEvent } from '@/config/types';
+
+vi.mock('@/core/storage/CredentialStore', () => ({
+  isCredentialStoreInitialized: vi.fn(() => false),
+  getCredentialStore: vi.fn(() => null),
+}));
+
+const _memStore: Record<string, unknown> = {};
+vi.mock('@/core/storage/ConfigStorageProvider', () => ({
+  isConfigStorageInitialized: vi.fn(() => true),
+  getConfigStorage: vi.fn(() => ({
+    get: async (k: string) => _memStore[k] ?? null,
+    set: async (k: string, v: unknown) => { _memStore[k] = v; },
+    remove: async (k: string) => { delete _memStore[k]; },
+    getMany: async (ks: string[]) => {
+      const r: Record<string, unknown> = {};
+      for (const k of ks) if (k in _memStore) r[k] = _memStore[k];
+      return r;
+    },
+    setMany: async (i: Record<string, unknown>) => { Object.assign(_memStore, i); },
+    removeMany: async (ks: string[]) => { for (const k of ks) delete _memStore[k]; },
+    getAll: async () => ({ ..._memStore }),
+    clear: async () => { for (const k of Object.keys(_memStore)) delete _memStore[k]; },
+    getBytesInUse: async () => null,
+  })),
+}));
+
+const lockingSource: PolicySource = {
+  origin: 'file',
+  load: async () => ({
+    values: { 'agent.approval.mode': 'yolo' },
+    lockedKeys: ['agent.approval.mode', 'agent.providers.openai.apiKey'],
+    origin: 'file',
+  }),
+};
+
+describe('Track 20 — locked key survives all four write surfaces', () => {
+  let config: AgentConfig;
+
+  beforeEach(async () => {
+    (AgentConfig as any).instance = null;
+    for (const k of Object.keys(_memStore)) delete _memStore[k];
+    __resetPolicyResolverForTests();
+    registerPolicySources([lockingSource]);
+    await resolveActivePolicy(); // BEFORE getInstance → first buildRuntimeConfig sees policy
+    config = await AgentConfig.getInstance();
+  });
+
+  afterEach(() => {
+    (AgentConfig as any).instance = null;
+    __resetPolicyResolverForTests();
+  });
+
+  it('(a) buildRuntimeConfig/reload: policy value wins', async () => {
+    expect(config.getConfig().approval?.mode).toBe('yolo');
+    await config.reload();
+    expect(config.getConfig().approval?.mode).toBe('yolo');
+  });
+
+  it('(b) updateConfig: locked write is stripped + re-pinned, non-locked passes', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    config.updateConfig({ approval: { mode: 'high_speed' } as any });
+    expect(config.getConfig().approval?.mode).toBe('yolo');
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('approval.mode')
+    );
+    config.updateConfig({ preferences: { ...config.getConfig().preferences, language: 'es' } });
+    expect(config.getConfig().preferences.language).toBe('es'); // non-locked applied
+    warn.mockRestore();
+  });
+
+  it('(c) domain mutator: locked provider apiKey write throws', async () => {
+    await expect(config.setProviderApiKey('openai', 'sk-x')).rejects.toBeInstanceOf(
+      PolicyLockedError
+    );
+  });
+
+  it('(d) LLM setting_tool: configSchema.resolve denies write, allows read', () => {
+    const w = resolveConfigPath('approval.mode', 'write');
+    expect('denied' in w && w.denied).toBe(true);
+    const r = resolveConfigPath('approval.mode', 'read');
+    expect('denied' in r).toBe(false);
+  });
+
+  it('runtime marker populated; never persisted to storage', () => {
+    const cfg = config.getConfig();
+    expect(cfg.policy).toEqual({
+      lockedKeys: ['approval.mode', 'providers.openai.apiKey'],
+      origin: 'file',
+    });
+    const stored = extractStoredConfig(cfg) as unknown as Record<string, unknown>;
+    expect('policy' in stored).toBe(false);
+  });
+
+  it('reload() emits a policy config-changed event', async () => {
+    const events: IConfigChangeEvent[] = [];
+    config.on('config-changed', (e) => events.push(e));
+    await config.reload();
+    expect(events.some((e) => e.section === 'policy')).toBe(true);
+  });
+
+  it('no active policy → no enforcement, marker cleared', async () => {
+    __resetPolicyResolverForTests();
+    (AgentConfig as any).instance = null;
+    const unmanaged = await AgentConfig.getInstance();
+    expect(unmanaged.getConfig().policy).toBeUndefined();
+    expect(() => unmanaged.updateConfig({ approval: { mode: 'high_speed' } as any })).not.toThrow();
+    expect(unmanaged.getConfig().approval?.mode).toBe('high_speed');
+  });
+});

--- a/src/config/__tests__/policy.mutators.test.ts
+++ b/src/config/__tests__/policy.mutators.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Track 20 — regression: a locked key must survive the DEDICATED domain
+ * mutators, not just updateConfig. Before the fix these guarded a coarse
+ * ancestor path (e.g. 'tools') and never re-pinned, so a lock on any leaf
+ * below it (e.g. tools.sandboxPolicy.network_access) was silently bypassable
+ * through the settings UI and only self-healed on reload.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AgentConfig } from '@/config/AgentConfig';
+import { getDefaultAgentConfig } from '@/config/defaults';
+import { PolicyLockedError } from '@/core/config/policy';
+import {
+  registerPolicySources,
+  resolveActivePolicy,
+  __resetPolicyResolverForTests,
+} from '@/core/config/policy';
+import type { PolicySource, ResolvedPolicy } from '@/core/config/policy';
+
+vi.mock('@/core/storage/CredentialStore', () => ({
+  isCredentialStoreInitialized: vi.fn(() => false),
+  getCredentialStore: vi.fn(() => null),
+}));
+
+const _memStore: Record<string, unknown> = {};
+vi.mock('@/core/storage/ConfigStorageProvider', () => ({
+  isConfigStorageInitialized: vi.fn(() => true),
+  getConfigStorage: vi.fn(() => ({
+    get: async (k: string) => _memStore[k] ?? null,
+    set: async (k: string, v: unknown) => { _memStore[k] = v; },
+    remove: async (k: string) => { delete _memStore[k]; },
+    getMany: async (ks: string[]) => {
+      const r: Record<string, unknown> = {};
+      for (const k of ks) if (k in _memStore) r[k] = _memStore[k];
+      return r;
+    },
+    setMany: async (i: Record<string, unknown>) => { Object.assign(_memStore, i); },
+    removeMany: async (ks: string[]) => { for (const k of ks) delete _memStore[k]; },
+    getAll: async () => ({ ..._memStore }),
+    clear: async () => { for (const k of Object.keys(_memStore)) delete _memStore[k]; },
+    getBytesInUse: async () => null,
+  })),
+}));
+
+function srcOf(policy: ResolvedPolicy): PolicySource {
+  return { origin: policy.origin, load: async () => policy };
+}
+
+async function managedWith(policy: ResolvedPolicy): Promise<AgentConfig> {
+  (AgentConfig as any).instance = null;
+  __resetPolicyResolverForTests();
+  registerPolicySources([srcOf(policy)]);
+  await resolveActivePolicy();
+  return AgentConfig.getInstance();
+}
+
+const firstProviderId = Object.keys(getDefaultAgentConfig().providers)[0];
+
+describe('Track 20 — domain mutators enforce leaf-level locks', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(_memStore)) delete _memStore[k];
+  });
+  afterEach(() => {
+    (AgentConfig as any).instance = null;
+    __resetPolicyResolverForTests();
+  });
+
+  it('updateToolsConfig cannot override a pinned, locked sandbox leaf', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const cfg = await managedWith({
+      values: { 'agent.tools.sandboxPolicy.network_access': false },
+      lockedKeys: ['agent.tools.sandboxPolicy.network_access'],
+      origin: 'file',
+    });
+    expect(cfg.getConfig().tools?.sandboxPolicy?.network_access).toBe(false);
+
+    cfg.updateToolsConfig({ sandboxPolicy: { network_access: true } as any });
+
+    expect(cfg.getToolSandboxPolicy().network_access).toBe(false);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('tools.sandboxPolicy.network_access')
+    );
+    // A non-locked tools sibling still applies.
+    cfg.updateToolsConfig({ dom_tool: false } as any);
+    expect(cfg.getToolsConfig().dom_tool).toBe(false);
+    warn.mockRestore();
+  });
+
+  it('updateToolsConfig honors a lock-only key (no pinned value)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const cfg = await managedWith({
+      values: {}, // lock with NO value → pin can't restore; strip must hold
+      lockedKeys: ['agent.tools.execCommand'],
+      origin: 'file',
+    });
+    cfg.updateToolsConfig({ execCommand: true } as any);
+    expect(cfg.getToolsConfig().execCommand).not.toBe(true);
+    warn.mockRestore();
+  });
+
+  it('updateProvider: locked apiKey leaf is stripped + re-pinned, sibling applies', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const cfg = await managedWith({
+      values: { [`agent.providers.${firstProviderId}.apiKey`]: 'PINNED' },
+      lockedKeys: [`agent.providers.${firstProviderId}.apiKey`],
+      origin: 'file',
+    });
+    cfg.updateProvider(firstProviderId, { apiKey: 'attacker-key' } as any);
+    expect(cfg.getProvider(firstProviderId)?.apiKey).toBe('PINNED');
+    warn.mockRestore();
+  });
+
+  it('updateProvider: a whole-provider lock hard-rejects', async () => {
+    const cfg = await managedWith({
+      values: {},
+      lockedKeys: [`agent.providers.${firstProviderId}`],
+      origin: 'file',
+    });
+    expect(() =>
+      cfg.updateProvider(firstProviderId, { baseUrl: 'http://x' } as any)
+    ).toThrow(PolicyLockedError);
+  });
+
+  it('updateModelConfig: a locked provider.models subtree hard-rejects', async () => {
+    // Pick a provider/model that definitely exists, select it (unmanaged),
+    // then lock that provider's models on a fresh managed instance.
+    (AgentConfig as any).instance = null;
+    __resetPolicyResolverForTests();
+    const unmanaged = await AgentConfig.getInstance();
+    const m = unmanaged.getAllModels()[0];
+    await unmanaged.setSelectedModel(`${m.providerId}:${m.model.modelKey}`);
+
+    const cfg = await managedWith({
+      values: {},
+      lockedKeys: [`agent.providers.${m.providerId}.models`],
+      origin: 'file',
+    });
+    expect(() => cfg.updateModelConfig({})).toThrow(PolicyLockedError);
+  });
+
+  it('enableTool/disableTool reject a specific tools.enabled lock and a whole-tools lock', async () => {
+    const a = await managedWith({
+      values: {},
+      lockedKeys: ['agent.tools.enabled'],
+      origin: 'file',
+    });
+    expect(() => a.enableTool('dom_tool')).toThrow(PolicyLockedError);
+    expect(() => a.disableTool('dom_tool')).toThrow(PolicyLockedError);
+
+    const b = await managedWith({
+      values: {},
+      lockedKeys: ['agent.tools'],
+      origin: 'file',
+    });
+    expect(() => b.enableTool('dom_tool')).toThrow(PolicyLockedError);
+  });
+
+  it('createProfile is rejected when profiles are locked', async () => {
+    const cfg = await managedWith({
+      values: {},
+      lockedKeys: ['agent.profiles'],
+      origin: 'file',
+    });
+    expect(() =>
+      cfg.createProfile({ name: 'p1', settings: {} } as any)
+    ).toThrow(PolicyLockedError);
+  });
+
+  it('no active policy → mutators behave exactly as before', async () => {
+    (AgentConfig as any).instance = null;
+    __resetPolicyResolverForTests();
+    const cfg = await AgentConfig.getInstance();
+    expect(() =>
+      cfg.updateToolsConfig({ sandboxPolicy: { network_access: false } as any })
+    ).not.toThrow();
+    expect(cfg.getToolSandboxPolicy().network_access).toBe(false);
+  });
+});

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -9,6 +9,7 @@
  */
 
 import { z } from 'zod';
+import { isKeyLocked } from '../core/config/policy';
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -266,15 +267,29 @@ export type ResolveResult = ResolvedField | DeniedField;
  * Also checks aliases: if direct lookup fails, tries alias resolution.
  */
 export function resolve(path: string, action: 'read' | 'write'): ResolveResult {
-  // Try direct resolution first
-  const direct = resolveDirectPath(path, action);
-  if (direct) return direct;
+  // Try direct resolution first, then alias resolution.
+  const result =
+    resolveDirectPath(path, action) ??
+    resolveByAlias(path, action) ?? {
+      denied: true as const,
+      reason: `Path "${path}" is not accessible`,
+    };
 
-  // Fall back to alias resolution
-  const aliased = resolveByAlias(path, action);
-  if (aliased) return aliased;
+  // Track 20: the LLM setting_tool is the third config write surface. Deny
+  // writes to organization-managed (locked) paths using the resolver's
+  // canonical path (covers alias resolution too).
+  if (
+    action === 'write' &&
+    !('denied' in result) &&
+    isKeyLocked('agent', result.path)
+  ) {
+    return {
+      denied: true,
+      reason: `Field "${result.path}" is managed by your organization and cannot be changed.`,
+    };
+  }
 
-  return { denied: true, reason: `Path "${path}" is not accessible` };
+  return result;
 }
 
 function resolveDirectPath(path: string, action: 'read' | 'write'): ResolveResult | null {

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -5,6 +5,7 @@
 import type { IAgentConfig, IUserPreferences, ICacheSettings, IExtensionSettings, IPermissionSettings, IToolsConfig, IStorageConfig, IStoredConfig, IProviderConfig } from './types';
 import { DEFAULT_APPROVAL_CONFIG } from '../core/approval/types';
 import defaultProviders from '../core/models/providers/default.json';
+import { applyPolicy, getActivePolicySync } from '../core/config/policy';
 
 export const DEFAULT_USER_PREFERENCES: IUserPreferences = {
   autoSync: true,
@@ -352,7 +353,8 @@ export function buildRuntimeConfig(stored: IStoredConfig | null): IAgentConfig {
   const defaults = getDefaultAgentConfig();
 
   if (!stored) {
-    return defaults;
+    // Track 20: pin admin policy post-merge (no-op until a source is resolved).
+    return applyPolicy(defaults, getActivePolicySync(), 'agent');
   }
 
   // Get fresh providers from default.json
@@ -391,7 +393,7 @@ export function buildRuntimeConfig(stored: IStoredConfig | null): IAgentConfig {
     }
   }
 
-  return {
+  const merged: IAgentConfig = {
     version: stored.version || defaults.version,
     selectedModelKey,
     providers,
@@ -439,6 +441,10 @@ export function buildRuntimeConfig(stored: IStoredConfig | null): IAgentConfig {
       }
     }
   };
+
+  // Track 20: pin admin policy AFTER all merging so the one-level merges above
+  // cannot defeat a nested managed value. No-op until a source is resolved.
+  return applyPolicy(merged, getActivePolicySync(), 'agent');
 }
 
 /**

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -51,6 +51,17 @@ export interface IAgentConfig {
   storage?: IStorageConfig;
   approval?: IApprovalConfig;
   hooks?: HooksConfig;
+
+  /**
+   * Track 20: runtime-only managed-policy marker. Populated by the policy
+   * resolver post-merge. NOT persisted (absent from {@link IStoredConfig} and
+   * {@link extractStoredConfig}). `lockedKeys` are namespace-relative agent
+   * dot-paths the UI renders non-editable; `origin` identifies the source.
+   */
+  policy?: {
+    lockedKeys: string[];
+    origin: 'chrome-managed' | 'file' | 'remote' | 'env' | null;
+  };
 }
 
 // Model pricing information
@@ -585,7 +596,7 @@ export interface IExportData {
 // Event interfaces for config changes
 export interface IConfigChangeEvent {
   type: 'config-changed';
-  section: 'model' | 'provider' | 'profile' | 'preferences' | 'cache' | 'extension' | 'security' | 'approval' | 'hooks';
+  section: 'model' | 'provider' | 'profile' | 'preferences' | 'cache' | 'extension' | 'security' | 'approval' | 'hooks' | 'policy';
   oldValue?: any;
   newValue: any;
   timestamp: number;

--- a/src/core/config/policy/ManagedDirSource.ts
+++ b/src/core/config/policy/ManagedDirSource.ts
@@ -1,0 +1,80 @@
+/**
+ * ManagedDirSource — `managed-settings.d/` drop-in directory (Track 20, Phase 4).
+ *
+ * The OS-MDM matrix's testable, dependency-free slice: a directory of
+ * `*.json` policy fragments merged in deterministic (sorted filename) order —
+ * later files override earlier `values`; `lockedKeys` is the union. The
+ * macOS-plist / Windows-registry sources are the remaining P3/L subprocess
+ * tier (they need a real OS + `plutil`/`reg`), tracked separately; this source
+ * lands the Linux/admin-drop-in form behind the same {@link PolicySource}
+ * interface with zero contract changes to Phases 1–3.
+ *
+ * Fail-open: a missing dir, no fragments, or unreadable/invalid files yield
+ * no policy (never a hard-deny). `node:fs` is imported lazily so this module
+ * is safe to load in any context.
+ *
+ * @module core/config/policy/ManagedDirSource
+ */
+
+import type { PolicySource, ResolvedPolicy } from './types';
+
+export function defaultManagedDirPath(): string {
+  const plat = (globalThis as { process?: { platform?: string } }).process
+    ?.platform;
+  if (plat === 'darwin') {
+    return '/Library/Application Support/ApplePi/managed-settings.d';
+  }
+  if (plat === 'win32') {
+    const programData =
+      (globalThis as { process?: { env?: Record<string, string | undefined> } })
+        .process?.env?.ProgramData ?? 'C:\\ProgramData';
+    return `${programData}\\ApplePi\\managed-settings.d`;
+  }
+  return '/etc/applepi/managed-settings.d';
+}
+
+export class ManagedDirSource implements PolicySource {
+  readonly origin = 'file' as const;
+  private readonly dirPath: string;
+
+  constructor(dirPath?: string) {
+    this.dirPath = dirPath ?? defaultManagedDirPath();
+  }
+
+  async load(): Promise<ResolvedPolicy | null> {
+    try {
+      const fs = await import('node:fs/promises');
+      const path = await import('node:path');
+      const entries = (await fs.readdir(this.dirPath))
+        .filter((f) => f.toLowerCase().endsWith('.json'))
+        .sort(); // deterministic merge order
+
+      const values: Record<string, unknown> = {};
+      const lockedKeys = new Set<string>();
+      for (const name of entries) {
+        try {
+          const raw = JSON.parse(
+            await fs.readFile(path.join(this.dirPath, name), 'utf-8')
+          ) as Record<string, unknown>;
+          if (raw && typeof raw.values === 'object' && !Array.isArray(raw.values)) {
+            Object.assign(values, raw.values);
+          }
+          if (Array.isArray(raw?.lockedKeys)) {
+            for (const k of raw.lockedKeys) {
+              if (typeof k === 'string') lockedKeys.add(k);
+            }
+          }
+        } catch {
+          /* skip a single bad fragment — fail open */
+        }
+      }
+
+      if (Object.keys(values).length === 0 && lockedKeys.size === 0) {
+        return null;
+      }
+      return { values, lockedKeys: [...lockedKeys], origin: 'file' };
+    } catch {
+      return null; // no dir / no node:fs — fail open
+    }
+  }
+}

--- a/src/core/config/policy/ManagedFileSource.ts
+++ b/src/core/config/policy/ManagedFileSource.ts
@@ -1,0 +1,91 @@
+/**
+ * ManagedFileSource — admin policy from an OS-protected JSON file (Track 20).
+ *
+ * The desktop/server analog of the extension's `chrome.storage.managed`. The
+ * file is a `{ values, lockedKeys }` document at an OS well-known path the
+ * user cannot normally write to. Fail-open: a missing/invalid/unreadable file
+ * yields no policy (never a hard-deny).
+ *
+ * `node:fs` is imported lazily so this module is safe to load in any context
+ * (a webview without `node:fs` simply yields no policy).
+ *
+ * @module core/config/policy/ManagedFileSource
+ */
+
+import type { PolicySource, ResolvedPolicy } from './types';
+
+/** OS well-known managed-settings path per platform. */
+export function defaultManagedFilePath(): string {
+  const plat = (globalThis as { process?: { platform?: string } }).process
+    ?.platform;
+  if (plat === 'darwin') {
+    return '/Library/Application Support/ApplePi/managed-settings.json';
+  }
+  if (plat === 'win32') {
+    const programData =
+      (globalThis as { process?: { env?: Record<string, string | undefined> } })
+        .process?.env?.ProgramData ?? 'C:\\ProgramData';
+    return `${programData}\\ApplePi\\managed-settings.json`;
+  }
+  return '/etc/applepi/managed-settings.json';
+}
+
+function coerce(raw: unknown, origin: 'file'): ResolvedPolicy | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  const values =
+    obj.values && typeof obj.values === 'object' && !Array.isArray(obj.values)
+      ? (obj.values as Record<string, unknown>)
+      : {};
+  const lockedKeys = Array.isArray(obj.lockedKeys)
+    ? obj.lockedKeys.filter((k): k is string => typeof k === 'string')
+    : [];
+  if (Object.keys(values).length === 0 && lockedKeys.length === 0) return null;
+  return { values, lockedKeys, origin };
+}
+
+export class ManagedFileSource implements PolicySource {
+  readonly origin = 'file' as const;
+  private readonly filePath: string;
+
+  constructor(filePath?: string) {
+    this.filePath = filePath ?? defaultManagedFilePath();
+  }
+
+  async load(): Promise<ResolvedPolicy | null> {
+    try {
+      const fs = await import('node:fs/promises');
+      const text = await fs.readFile(this.filePath, 'utf-8');
+      return coerce(JSON.parse(text), 'file');
+    } catch {
+      // Missing file, parse error, or no node:fs (webview) — fail open.
+      return null;
+    }
+  }
+
+  /**
+   * Watch the file for changes. Uses `node:fs.watch` when available; callers
+   * that already own a reload seam (the server's `onConfigReload`) need not
+   * use this. Returns a no-op unsubscribe if watching is unavailable.
+   */
+  subscribe(onChange: () => void): () => void {
+    let watcher: { close(): void } | undefined;
+    void (async () => {
+      try {
+        const fs = await import('node:fs');
+        watcher = fs.watch(this.filePath, { persistent: false }, () =>
+          onChange()
+        );
+      } catch {
+        /* no fs / no file — rely on the platform's own reload seam */
+      }
+    })();
+    return () => {
+      try {
+        watcher?.close();
+      } catch {
+        /* ignore */
+      }
+    };
+  }
+}

--- a/src/core/config/policy/PolicyResolver.ts
+++ b/src/core/config/policy/PolicyResolver.ts
@@ -1,0 +1,165 @@
+/**
+ * PolicyResolver — the shared, platform-agnostic resolver (Track 20).
+ *
+ * Module singleton (mirrors the `core/*` singleton pattern). Platform
+ * bootstraps register ordered {@link PolicySource}s; the resolver picks the
+ * first non-empty one ("first source wins"), caches it in-memory, and exposes
+ * a synchronous accessor so the sync `buildRuntimeConfig` / `loadServerConfig`
+ * pin sites can read it without going async.
+ *
+ * No I/O here — sources do the I/O. This file only orders, selects, caches,
+ * and notifies.
+ *
+ * @module core/config/policy/PolicyResolver
+ */
+
+import type {
+  PolicyNamespace,
+  PolicyOrigin,
+  PolicySource,
+  PolicySummary,
+  ResolvedPolicy,
+} from './types';
+import { isPathLockedBy } from './pathUtils';
+
+let _sources: PolicySource[] = [];
+let _active: ResolvedPolicy | null = null;
+let _unsubscribes: Array<() => void> = [];
+const _listeners = new Set<(p: ResolvedPolicy | null) => void>();
+
+function isNonEmpty(p: ResolvedPolicy | null | undefined): p is ResolvedPolicy {
+  return (
+    !!p &&
+    (Object.keys(p.values).length > 0 || p.lockedKeys.length > 0)
+  );
+}
+
+function notify(): void {
+  for (const cb of _listeners) {
+    try {
+      cb(_active);
+    } catch (err) {
+      console.error('[PolicyResolver] listener error:', err);
+    }
+  }
+}
+
+/**
+ * Register ordered policy sources (highest priority first). Wires each
+ * source's optional `subscribe()` so a platform-native change re-resolves and
+ * notifies. Replaces any previously registered sources.
+ */
+export function registerPolicySources(sources: PolicySource[]): void {
+  for (const u of _unsubscribes) {
+    try {
+      u();
+    } catch {
+      /* ignore */
+    }
+  }
+  _unsubscribes = [];
+  _sources = sources.slice();
+  for (const s of _sources) {
+    if (typeof s.subscribe === 'function') {
+      try {
+        _unsubscribes.push(
+          s.subscribe(() => {
+            void resolveActivePolicy();
+          })
+        );
+      } catch (err) {
+        console.warn('[PolicyResolver] source.subscribe failed:', err);
+      }
+    }
+  }
+}
+
+/**
+ * Resolve the active policy: first source whose `load()` yields a non-empty
+ * policy wins entirely (sources are NOT merged with each other). Caches the
+ * result and notifies listeners if it changed. Fail-soft: a source that
+ * throws is skipped (never hard-deny on a policy source error).
+ */
+export async function resolveActivePolicy(): Promise<ResolvedPolicy | null> {
+  let next: ResolvedPolicy | null = null;
+  for (const source of _sources) {
+    let loaded: ResolvedPolicy | null = null;
+    try {
+      loaded = await source.load();
+    } catch (err) {
+      console.warn(
+        `[PolicyResolver] source "${source.origin}" load failed (skipping):`,
+        err
+      );
+      continue;
+    }
+    if (isNonEmpty(loaded)) {
+      next = loaded;
+      break;
+    }
+  }
+
+  const changed = JSON.stringify(next) !== JSON.stringify(_active);
+  _active = next;
+  if (changed) notify();
+  return _active;
+}
+
+/** Last resolved policy (synchronous — for the pin sites). */
+export function getActivePolicySync(): ResolvedPolicy | null {
+  return _active;
+}
+
+/** Subscribe to resolved-policy changes. Returns an unsubscribe function. */
+export function onPolicyChanged(
+  cb: (p: ResolvedPolicy | null) => void
+): () => void {
+  _listeners.add(cb);
+  return () => _listeners.delete(cb);
+}
+
+/** Active policy origin, or `null` when no managed policy is in effect. */
+export function getPolicyOrigin(): PolicyOrigin {
+  return _active?.origin ?? null;
+}
+
+/**
+ * Locked dot-paths for a namespace, with the `agent.`/`server.` prefix
+ * stripped (so callers compare against their own config paths).
+ */
+export function getLockedKeys(ns: PolicyNamespace): string[] {
+  if (!_active) return [];
+  const prefix = ns + '.';
+  return _active.lockedKeys
+    .filter((k) => k.startsWith(prefix))
+    .map((k) => k.slice(prefix.length));
+}
+
+/** True when `localPath` (already namespace-relative) is locked for `ns`. */
+export function isLockedFor(ns: PolicyNamespace, localPath: string): boolean {
+  return isPathLockedBy(getLockedKeys(ns), localPath);
+}
+
+/** Redaction-safe summary for diagnostics. Never returns values. */
+export function getActivePolicySummary(): PolicySummary {
+  return {
+    origin: _active?.origin ?? null,
+    lockedKeys: _active ? _active.lockedKeys.slice() : [],
+    valueCount: _active ? Object.keys(_active.values).length : 0,
+  };
+}
+
+/** Test-only: clear all resolver state. */
+export function __resetPolicyResolverForTests(): void {
+  for (const u of _unsubscribes) {
+    try {
+      u();
+    } catch {
+      /* ignore */
+    }
+  }
+  _sources = [];
+  _active = null;
+  _unsubscribes = [];
+  _listeners.clear();
+}

--- a/src/core/config/policy/__tests__/ManagedDirSource.test.ts
+++ b/src/core/config/policy/__tests__/ManagedDirSource.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { ManagedDirSource } from '../ManagedDirSource';
+
+let dir: string;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mds-'));
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe('ManagedDirSource', () => {
+  it('merges fragments in sorted filename order; later wins; lockedKeys union', async () => {
+    fs.writeFileSync(
+      path.join(dir, '10-base.json'),
+      JSON.stringify({ values: { 'agent.a': 1, 'agent.b': 1 }, lockedKeys: ['agent.a'] })
+    );
+    fs.writeFileSync(
+      path.join(dir, '20-override.json'),
+      JSON.stringify({ values: { 'agent.b': 2 }, lockedKeys: ['agent.b'] })
+    );
+    const p = await new ManagedDirSource(dir).load();
+    expect(p?.values).toEqual({ 'agent.a': 1, 'agent.b': 2 });
+    expect(p?.lockedKeys.sort()).toEqual(['agent.a', 'agent.b']);
+    expect(p?.origin).toBe('file');
+  });
+
+  it('skips a single bad fragment, ignores non-json', async () => {
+    fs.writeFileSync(path.join(dir, 'bad.json'), '{ not json');
+    fs.writeFileSync(path.join(dir, 'note.txt'), 'ignored');
+    fs.writeFileSync(
+      path.join(dir, 'ok.json'),
+      JSON.stringify({ lockedKeys: ['agent.x'] })
+    );
+    const p = await new ManagedDirSource(dir).load();
+    expect(p?.lockedKeys).toEqual(['agent.x']);
+  });
+
+  it('fails open on a missing directory and on an empty one', async () => {
+    expect(await new ManagedDirSource(path.join(dir, 'nope')).load()).toBeNull();
+    expect(await new ManagedDirSource(dir).load()).toBeNull();
+  });
+});

--- a/src/core/config/policy/__tests__/ManagedFileSource.test.ts
+++ b/src/core/config/policy/__tests__/ManagedFileSource.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { ManagedFileSource } from '../ManagedFileSource';
+
+let dir: string;
+let file: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mfs-'));
+  file = path.join(dir, 'managed-settings.json');
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe('ManagedFileSource', () => {
+  it('loads a { values, lockedKeys } document', async () => {
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        values: { 'agent.approval.mode': 'yolo' },
+        lockedKeys: ['agent.approval.mode'],
+      })
+    );
+    const p = await new ManagedFileSource(file).load();
+    expect(p).toEqual({
+      values: { 'agent.approval.mode': 'yolo' },
+      lockedKeys: ['agent.approval.mode'],
+      origin: 'file',
+    });
+  });
+
+  it('fails open on a missing file', async () => {
+    expect(await new ManagedFileSource(file).load()).toBeNull();
+  });
+
+  it('fails open on invalid JSON', async () => {
+    fs.writeFileSync(file, '{ not json');
+    expect(await new ManagedFileSource(file).load()).toBeNull();
+  });
+
+  it('returns null for an empty policy document', async () => {
+    fs.writeFileSync(file, JSON.stringify({ values: {}, lockedKeys: [] }));
+    expect(await new ManagedFileSource(file).load()).toBeNull();
+  });
+
+  it('subscribe returns a no-throw unsubscribe', async () => {
+    fs.writeFileSync(file, JSON.stringify({ lockedKeys: ['agent.x'] }));
+    const src = new ManagedFileSource(file);
+    const unsub = src.subscribe(() => {});
+    expect(() => unsub()).not.toThrow();
+  });
+});

--- a/src/core/config/policy/__tests__/PolicyResolver.test.ts
+++ b/src/core/config/policy/__tests__/PolicyResolver.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  registerPolicySources,
+  resolveActivePolicy,
+  getActivePolicySync,
+  getPolicyOrigin,
+  getLockedKeys,
+  getActivePolicySummary,
+  onPolicyChanged,
+  __resetPolicyResolverForTests,
+} from '../PolicyResolver';
+import type { PolicySource, ResolvedPolicy } from '../types';
+
+function stub(
+  origin: PolicySource['origin'],
+  policy: ResolvedPolicy | null
+): PolicySource {
+  return { origin, load: async () => policy };
+}
+
+describe('PolicyResolver', () => {
+  beforeEach(() => __resetPolicyResolverForTests());
+
+  it('returns null when no source carries a policy', async () => {
+    registerPolicySources([stub('file', null), stub('remote', { values: {}, lockedKeys: [], origin: 'remote' })]);
+    expect(await resolveActivePolicy()).toBeNull();
+    expect(getPolicyOrigin()).toBeNull();
+  });
+
+  it('first non-empty source wins; lower sources ignored', async () => {
+    registerPolicySources([
+      stub('remote', null),
+      stub('file', { values: { 'agent.x': 1 }, lockedKeys: ['agent.x'], origin: 'file' }),
+      stub('env', { values: { 'agent.x': 999 }, lockedKeys: [], origin: 'env' }),
+    ]);
+    const active = await resolveActivePolicy();
+    expect(active?.origin).toBe('file');
+    expect(active?.values).toEqual({ 'agent.x': 1 });
+    expect(getActivePolicySync()).toBe(active);
+  });
+
+  it('a throwing source is skipped (fail-soft)', async () => {
+    const boom: PolicySource = {
+      origin: 'remote',
+      load: async () => {
+        throw new Error('network down');
+      },
+    };
+    registerPolicySources([
+      boom,
+      stub('file', { values: { 'agent.y': 2 }, lockedKeys: [], origin: 'file' }),
+    ]);
+    const active = await resolveActivePolicy();
+    expect(active?.origin).toBe('file');
+  });
+
+  it('getLockedKeys strips the namespace prefix and filters', async () => {
+    registerPolicySources([
+      stub('file', {
+        values: {},
+        lockedKeys: ['agent.approval.mode', 'server.exec.approvalPolicy'],
+        origin: 'file',
+      }),
+    ]);
+    await resolveActivePolicy();
+    expect(getLockedKeys('agent')).toEqual(['approval.mode']);
+    expect(getLockedKeys('server')).toEqual(['exec.approvalPolicy']);
+  });
+
+  it('notifies listeners only when the resolved policy changes', async () => {
+    const seen: Array<string | null> = [];
+    onPolicyChanged((p) => seen.push(p ? p.origin : null));
+    registerPolicySources([stub('file', { values: { 'agent.a': 1 }, lockedKeys: [], origin: 'file' })]);
+    await resolveActivePolicy();
+    await resolveActivePolicy(); // unchanged — no second notify
+    expect(seen).toEqual(['file']);
+  });
+
+  it('summary never exposes values', async () => {
+    registerPolicySources([
+      stub('file', {
+        values: { 'agent.providers.openai.apiKey': 'sk-secret' },
+        lockedKeys: ['agent.providers.openai'],
+        origin: 'file',
+      }),
+    ]);
+    await resolveActivePolicy();
+    const s = getActivePolicySummary();
+    expect(s).toEqual({
+      origin: 'file',
+      lockedKeys: ['agent.providers.openai'],
+      valueCount: 1,
+    });
+    expect(JSON.stringify(s)).not.toContain('sk-secret');
+  });
+});

--- a/src/core/config/policy/__tests__/applyPolicy.test.ts
+++ b/src/core/config/policy/__tests__/applyPolicy.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { applyPolicy } from '../applyPolicy';
+import type { ResolvedPolicy } from '../types';
+
+const policy = (
+  values: Record<string, unknown>,
+  lockedKeys: string[] = []
+): ResolvedPolicy => ({ values, lockedKeys, origin: 'file' });
+
+describe('applyPolicy', () => {
+  it('deep-sets a nested value, defeating a one-level merge', () => {
+    // Mimics the shape buildRuntimeConfig produces (one-level merged).
+    const merged = {
+      tools: { sandboxPolicy: { mode: 'workspace-write', network_access: true } },
+    };
+    applyPolicy(merged, policy({ 'agent.tools.sandboxPolicy.network_access': false }), 'agent');
+    expect(merged.tools.sandboxPolicy.network_access).toBe(false);
+    expect(merged.tools.sandboxPolicy.mode).toBe('workspace-write'); // sibling intact
+  });
+
+  it('replaces arrays (org allowlist is exactly the admin list)', () => {
+    const merged = { approval: { trustedDomains: ['user.com'] } };
+    applyPolicy(
+      merged,
+      policy({ 'agent.approval.trustedDomains': ['corp.com'] }),
+      'agent'
+    );
+    expect(merged.approval.trustedDomains).toEqual(['corp.com']);
+  });
+
+  it('filters by namespace', () => {
+    const target = { a: 1 };
+    applyPolicy(
+      target,
+      policy({ 'server.a': 2, 'agent.a': 3 }),
+      'agent'
+    );
+    expect(target.a).toBe(3); // only agent.* applied
+  });
+
+  it('stamps the runtime policy marker for the agent namespace', () => {
+    const t: Record<string, unknown> = {};
+    applyPolicy(
+      t,
+      policy({ 'agent.approval.mode': 'yolo' }, ['agent.approval.mode']),
+      'agent'
+    );
+    expect(t.policy).toEqual({ lockedKeys: ['approval.mode'], origin: 'file' });
+  });
+
+  it('clears the marker when no policy is active', () => {
+    const t: Record<string, unknown> = { policy: { lockedKeys: ['x'], origin: 'file' } };
+    applyPolicy(t, null, 'agent');
+    expect(t.policy).toBeUndefined();
+  });
+
+  it('does not stamp a marker for the server namespace', () => {
+    const t: Record<string, unknown> = {};
+    applyPolicy(t, policy({ 'server.port': 1 }, ['server.port']), 'server');
+    expect(t.policy).toBeUndefined();
+  });
+});

--- a/src/core/config/policy/__tests__/pathUtils.test.ts
+++ b/src/core/config/policy/__tests__/pathUtils.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import {
+  setByPath,
+  getByPath,
+  deleteByPath,
+  isPathLockedBy,
+  flattenLeafPaths,
+  deepClone,
+} from '../pathUtils';
+
+describe('pathUtils', () => {
+  it('setByPath creates intermediates and replaces (arrays too)', () => {
+    const o: Record<string, unknown> = { a: { b: { c: 1 } } };
+    setByPath(o, 'a.b.c', 2);
+    expect((o.a as any).b.c).toBe(2);
+    setByPath(o, 'x.y.z', 'v');
+    expect((o.x as any).y.z).toBe('v');
+    setByPath(o, 'list', [1, 2]);
+    setByPath(o, 'list', [9]);
+    expect(o.list).toEqual([9]); // replace, not concat
+  });
+
+  it('setByPath overwrites a non-object segment with an object', () => {
+    const o: Record<string, unknown> = { a: 5 };
+    setByPath(o, 'a.b', 1);
+    expect(o.a).toEqual({ b: 1 });
+  });
+
+  it('getByPath returns undefined for missing segments', () => {
+    expect(getByPath({ a: { b: 1 } }, 'a.b')).toBe(1);
+    expect(getByPath({ a: 1 }, 'a.b.c')).toBeUndefined();
+    expect(getByPath(null, 'a')).toBeUndefined();
+  });
+
+  it('deleteByPath removes the leaf and prunes empty parents', () => {
+    const o: Record<string, unknown> = { a: { b: { c: 1 }, d: 2 } };
+    deleteByPath(o, 'a.b.c');
+    expect(o).toEqual({ a: { d: 2 } }); // empty a.b pruned
+    deleteByPath(o, 'a.d');
+    expect(o).toEqual({}); // empty a pruned too
+  });
+
+  it('isPathLockedBy matches exact and descendant of a locked ancestor', () => {
+    const locked = ['agent.providers.openai', 'agent.approval.mode'];
+    expect(isPathLockedBy(locked, 'agent.approval.mode')).toBe(true);
+    expect(isPathLockedBy(locked, 'agent.providers.openai.apiKey')).toBe(true);
+    expect(isPathLockedBy(locked, 'agent.providers.xai.apiKey')).toBe(false);
+    expect(isPathLockedBy(locked, 'agent.approval.modeX')).toBe(false);
+  });
+
+  it('flattenLeafPaths treats arrays as leaves', () => {
+    expect(
+      flattenLeafPaths({ a: { b: 1, c: [1, 2] }, d: 'x' }).sort()
+    ).toEqual(['a.b', 'a.c', 'd']);
+  });
+
+  it('deepClone is independent of the source', () => {
+    const src = { a: { b: [1] } };
+    const c = deepClone(src);
+    c.a.b.push(2);
+    expect(src.a.b).toEqual([1]);
+  });
+});

--- a/src/core/config/policy/__tests__/securityCheck.test.ts
+++ b/src/core/config/policy/__tests__/securityCheck.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  assessPolicyChange,
+  assessAndRecord,
+  redactSecrets,
+  __resetSecurityCheckForTests,
+} from '../securityCheck';
+import type { ResolvedPolicy } from '../types';
+
+const pol = (values: Record<string, unknown>): ResolvedPolicy => ({
+  values,
+  lockedKeys: [],
+  origin: 'remote',
+});
+
+describe('assessPolicyChange', () => {
+  it('flags approval mode set to yolo', () => {
+    const a = assessPolicyChange(
+      pol({ 'agent.approval.mode': 'balanced' }),
+      pol({ 'agent.approval.mode': 'yolo' })
+    );
+    expect(a.weakened).toBe(true);
+    expect(a.changedKeys).toContain('agent.approval.mode');
+    expect(a.reasons.join()).toMatch(/yolo/);
+  });
+
+  it('flags a widened trusted-domain allowlist', () => {
+    const a = assessPolicyChange(
+      pol({ 'agent.approval.trustedDomains': ['a.com'] }),
+      pol({ 'agent.approval.trustedDomains': ['a.com', 'b.com'] })
+    );
+    expect(a.weakened).toBe(true);
+  });
+
+  it('flags a risky tool being enabled and sandbox network opening', () => {
+    expect(
+      assessPolicyChange(null, pol({ 'agent.tools.execCommand': true })).weakened
+    ).toBe(true);
+    expect(
+      assessPolicyChange(
+        null,
+        pol({ 'agent.tools.sandboxPolicy.network_access': true })
+      ).weakened
+    ).toBe(true);
+  });
+
+  it('does not flag a neutral/strengthening change', () => {
+    const a = assessPolicyChange(
+      pol({ 'agent.approval.mode': 'yolo' }),
+      pol({ 'agent.approval.mode': 'balanced' })
+    );
+    expect(a.weakened).toBe(false);
+    expect(a.changedKeys).toContain('agent.approval.mode');
+  });
+
+  it('assessAndRecord is stateful across calls', () => {
+    __resetSecurityCheckForTests();
+    expect(assessAndRecord(pol({ 'agent.approval.mode': 'balanced' })).weakened).toBe(
+      false
+    );
+    expect(assessAndRecord(pol({ 'agent.approval.mode': 'yolo' })).weakened).toBe(
+      true
+    );
+  });
+});
+
+describe('redactSecrets', () => {
+  beforeEach(() => __resetSecurityCheckForTests());
+
+  it('redacts secret-bearing strings recursively', () => {
+    const out = redactSecrets({
+      a: 'sk-abcdefghijklmnopqrstuvwxyz',
+      b: { c: 'Bearer tok_123', d: 'safe-value' },
+      e: ['token: hunter2hunter2'],
+    });
+    expect(JSON.stringify(out)).not.toContain('sk-abcdefghijkl');
+    expect(JSON.stringify(out)).not.toContain('hunter2');
+    expect((out as any).b.d).toBe('safe-value');
+  });
+});

--- a/src/core/config/policy/applyPolicy.ts
+++ b/src/core/config/policy/applyPolicy.ts
@@ -1,0 +1,62 @@
+/**
+ * applyPolicy — the post-merge pin (Track 20).
+ *
+ * Called AFTER all normal merging in both config systems
+ * (`buildRuntimeConfig` for the agent config, `loadServerConfig` for the
+ * server config). It overlays every admin-provided value at its dot-path
+ * using a deep set, so the one-level merges in `buildRuntimeConfig` cannot
+ * defeat a nested managed value (e.g. `tools.sandboxPolicy.network_access`).
+ *
+ * This is the single guarantee the whole track rests on. Pure and
+ * synchronous so the sync hydrators stay sync.
+ *
+ * @module core/config/policy/applyPolicy
+ */
+
+import type { PolicyNamespace, ResolvedPolicy } from './types';
+import { deepClone, setByPath } from './pathUtils';
+
+/**
+ * Overlay `policy` onto `target` for namespace `ns` and stamp the runtime
+ * policy marker (agent namespace only). Mutates and returns `target`.
+ *
+ * - Filters `policy.values` / `policy.lockedKeys` to the `${ns}.` prefix.
+ * - Deep-sets each value at its namespace-relative path (arrays replace).
+ * - For the `agent` namespace, sets `target.policy = { lockedKeys, origin }`
+ *   so consumers/UI can render locked fields non-editable. Cleared when no
+ *   policy is active.
+ */
+export function applyPolicy<T>(
+  target: T,
+  policy: ResolvedPolicy | null,
+  ns: PolicyNamespace
+): T {
+  const rec = target as unknown as Record<string, unknown>;
+  if (!policy) {
+    if (ns === 'agent') {
+      delete rec.policy;
+    }
+    return target;
+  }
+
+  const prefix = ns + '.';
+
+  for (const [key, value] of Object.entries(policy.values)) {
+    if (!key.startsWith(prefix)) continue;
+    const local = key.slice(prefix.length);
+    if (local.length === 0) continue;
+    setByPath(rec, local, deepClone(value));
+  }
+
+  if (ns === 'agent') {
+    const lockedKeys = policy.lockedKeys
+      .filter((k) => k.startsWith(prefix))
+      .map((k) => k.slice(prefix.length));
+    rec.policy = {
+      lockedKeys,
+      origin: policy.origin,
+    };
+  }
+
+  return target;
+}

--- a/src/core/config/policy/guards.ts
+++ b/src/core/config/policy/guards.ts
@@ -41,28 +41,60 @@ export function assertWritable(ns: PolicyNamespace, localPath: string): void {
 }
 
 /**
+ * Throw {@link PolicyLockedError} if a write at `localPath` would touch ANY
+ * locked key: `localPath` itself is locked, lies under a locked ancestor, OR
+ * is an ancestor of a locked key (a coarse create/delete that would clobber a
+ * locked descendant). Unlike {@link assertWritable}, this also rejects the
+ * ancestor case — use it for whole-subtree create/delete/activate ops where
+ * there are no unlocked siblings within the same call to preserve. For
+ * partial-merge writes prefer {@link stripLockedWrites} so unlocked siblings
+ * still apply.
+ */
+export function assertWritableSubtree(
+  ns: PolicyNamespace,
+  localPath: string
+): void {
+  for (const k of lockedKeysFor(ns)) {
+    if (
+      localPath === k ||
+      localPath.startsWith(k + '.') ||
+      k.startsWith(localPath + '.')
+    ) {
+      throw new PolicyLockedError(`${ns}.${localPath}`);
+    }
+  }
+}
+
+/**
  * Remove only the exact locked leaf paths a partial write `patch` touches
  * (deep clone in, original untouched). Non-locked siblings are preserved, so
  * a bulk update still applies its allowed parts. Returns the cleaned patch
  * and the stripped paths so a caller can surface "ignored — managed by your
  * organization". The post-merge pin still re-asserts policy values regardless,
  * so this is defense-in-depth + a UX signal, not the sole guarantee.
+ *
+ * `basePath` namespaces a patch whose leaves are relative to a subtree (e.g.
+ * `updateProvider`'s patch is relative to `providers.<id>`). It is prepended
+ * before the lock check and to the returned `stripped` paths, but NOT used
+ * for the in-patch `deleteByPath` (the patch object itself stays relative).
  */
 export function stripLockedWrites<T>(
   ns: PolicyNamespace,
-  patch: T
+  patch: T,
+  basePath = ''
 ): { patch: T; stripped: string[] } {
   const locked = lockedKeysFor(ns);
   if (locked.length === 0) return { patch, stripped: [] };
 
-  const stripped = flattenLeafPaths(patch).filter((leaf) =>
-    isPathLockedBy(locked, leaf)
+  const prefix = basePath ? basePath + '.' : '';
+  const relStripped = flattenLeafPaths(patch).filter((leaf) =>
+    isPathLockedBy(locked, prefix + leaf)
   );
-  if (stripped.length === 0) return { patch, stripped: [] };
+  if (relStripped.length === 0) return { patch, stripped: [] };
 
   const out = deepClone(patch);
-  for (const leaf of stripped) {
+  for (const leaf of relStripped) {
     deleteByPath(out as unknown as Record<string, unknown>, leaf);
   }
-  return { patch: out, stripped };
+  return { patch: out, stripped: relStripped.map((l) => prefix + l) };
 }

--- a/src/core/config/policy/guards.ts
+++ b/src/core/config/policy/guards.ts
@@ -1,0 +1,68 @@
+/**
+ * Write-surface guards (Track 20).
+ *
+ * The post-merge pin protects the read/reload path, but the agent config has
+ * three independent write surfaces (`updateConfig`, the domain mutators, and
+ * the LLM `setting_tool`) that mutate state AFTER the merge. Without guards a
+ * locked value is silently overridable until the next reload. These helpers
+ * are the second half of the end-to-end guarantee.
+ *
+ * @module core/config/policy/guards
+ */
+
+import type { PolicyNamespace } from './types';
+import { PolicyLockedError } from './types';
+import { getActivePolicySync } from './PolicyResolver';
+import { deepClone, deleteByPath, flattenLeafPaths, isPathLockedBy } from './pathUtils';
+
+function lockedKeysFor(ns: PolicyNamespace): string[] {
+  const active = getActivePolicySync();
+  if (!active) return [];
+  const prefix = ns + '.';
+  return active.lockedKeys
+    .filter((k) => k.startsWith(prefix))
+    .map((k) => k.slice(prefix.length));
+}
+
+/**
+ * True when `localPath` (namespace-relative, e.g. `approval.mode`,
+ * `providers.openai.apiKey`) is locked — exact match or under a locked
+ * ancestor.
+ */
+export function isKeyLocked(ns: PolicyNamespace, localPath: string): boolean {
+  return isPathLockedBy(lockedKeysFor(ns), localPath);
+}
+
+/** Throw {@link PolicyLockedError} if `localPath` is locked for `ns`. */
+export function assertWritable(ns: PolicyNamespace, localPath: string): void {
+  if (isKeyLocked(ns, localPath)) {
+    throw new PolicyLockedError(`${ns}.${localPath}`);
+  }
+}
+
+/**
+ * Remove only the exact locked leaf paths a partial write `patch` touches
+ * (deep clone in, original untouched). Non-locked siblings are preserved, so
+ * a bulk update still applies its allowed parts. Returns the cleaned patch
+ * and the stripped paths so a caller can surface "ignored — managed by your
+ * organization". The post-merge pin still re-asserts policy values regardless,
+ * so this is defense-in-depth + a UX signal, not the sole guarantee.
+ */
+export function stripLockedWrites<T>(
+  ns: PolicyNamespace,
+  patch: T
+): { patch: T; stripped: string[] } {
+  const locked = lockedKeysFor(ns);
+  if (locked.length === 0) return { patch, stripped: [] };
+
+  const stripped = flattenLeafPaths(patch).filter((leaf) =>
+    isPathLockedBy(locked, leaf)
+  );
+  if (stripped.length === 0) return { patch, stripped: [] };
+
+  const out = deepClone(patch);
+  for (const leaf of stripped) {
+    deleteByPath(out as unknown as Record<string, unknown>, leaf);
+  }
+  return { patch: out, stripped };
+}

--- a/src/core/config/policy/index.ts
+++ b/src/core/config/policy/index.ts
@@ -32,8 +32,27 @@ export {
 export { applyPolicy } from './applyPolicy';
 
 export { ManagedFileSource, defaultManagedFilePath } from './ManagedFileSource';
+export { ManagedDirSource, defaultManagedDirPath } from './ManagedDirSource';
 
 export { isKeyLocked, assertWritable, stripLockedWrites } from './guards';
+
+export {
+  assessPolicyChange,
+  assessAndRecord,
+  redactSecrets,
+  __resetSecurityCheckForTests,
+} from './securityCheck';
+export type { PolicyChangeAssessment } from './securityCheck';
+
+export { RemotePolicySource } from '../remotePolicy/RemotePolicySource';
+export type { RemotePolicySourceOptions } from '../remotePolicy/RemotePolicySource';
+export {
+  fetchRemotePolicy,
+  computePolicyChecksum,
+  startPolicyPoll,
+  stopPolicyPoll,
+} from '../remotePolicy/RemotePolicyFetcher';
+export type { RemoteFetchResult } from '../remotePolicy/RemotePolicyFetcher';
 
 export {
   deepClone,

--- a/src/core/config/policy/index.ts
+++ b/src/core/config/policy/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Managed / Policy Settings Tier (Track 20) — public barrel.
+ *
+ * One shared resolver feeds both BrowserX config systems via the post-merge
+ * pin ({@link applyPolicy}) and the write-surface guards. Platform-native
+ * sources live with their platform; this barrel exposes the shared core.
+ *
+ * @module core/config/policy
+ */
+
+export type {
+  PolicyOrigin,
+  PolicyNamespace,
+  ResolvedPolicy,
+  PolicySource,
+  PolicySummary,
+} from './types';
+export { PolicyLockedError } from './types';
+
+export {
+  registerPolicySources,
+  resolveActivePolicy,
+  getActivePolicySync,
+  onPolicyChanged,
+  getPolicyOrigin,
+  getLockedKeys,
+  isLockedFor,
+  getActivePolicySummary,
+  __resetPolicyResolverForTests,
+} from './PolicyResolver';
+
+export { applyPolicy } from './applyPolicy';
+
+export { isKeyLocked, assertWritable, stripLockedWrites } from './guards';
+
+export {
+  deepClone,
+  getByPath,
+  setByPath,
+  deleteByPath,
+  isPathLockedBy,
+  flattenLeafPaths,
+} from './pathUtils';

--- a/src/core/config/policy/index.ts
+++ b/src/core/config/policy/index.ts
@@ -31,6 +31,8 @@ export {
 
 export { applyPolicy } from './applyPolicy';
 
+export { ManagedFileSource, defaultManagedFilePath } from './ManagedFileSource';
+
 export { isKeyLocked, assertWritable, stripLockedWrites } from './guards';
 
 export {

--- a/src/core/config/policy/index.ts
+++ b/src/core/config/policy/index.ts
@@ -34,7 +34,12 @@ export { applyPolicy } from './applyPolicy';
 export { ManagedFileSource, defaultManagedFilePath } from './ManagedFileSource';
 export { ManagedDirSource, defaultManagedDirPath } from './ManagedDirSource';
 
-export { isKeyLocked, assertWritable, stripLockedWrites } from './guards';
+export {
+  isKeyLocked,
+  assertWritable,
+  assertWritableSubtree,
+  stripLockedWrites,
+} from './guards';
 
 export {
   assessPolicyChange,

--- a/src/core/config/policy/pathUtils.ts
+++ b/src/core/config/policy/pathUtils.ts
@@ -1,0 +1,122 @@
+/**
+ * Dot-path get/set + deep clone — dependency-free.
+ *
+ * BrowserX has no lodash; the policy resolver needs deterministic deep
+ * set-by-path so the post-merge pin can defeat the one-level merges in
+ * `buildRuntimeConfig`. Arrays are **replaced**, never concatenated — an
+ * org allowlist must be exactly the admin's list.
+ *
+ * @module core/config/policy/pathUtils
+ */
+
+/** Structured deep clone with a JSON fallback for old runtimes. */
+export function deepClone<T>(value: T): T {
+  if (value === null || typeof value !== 'object') return value;
+  const sc = (globalThis as { structuredClone?: <V>(v: V) => V }).structuredClone;
+  if (typeof sc === 'function') {
+    try {
+      return sc(value);
+    } catch {
+      /* fall through to JSON */
+    }
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/** Split a dot-path into segments. Empty string → []. */
+export function splitPath(path: string): string[] {
+  return path.length === 0 ? [] : path.split('.');
+}
+
+/**
+ * Set `value` at `path` on `target`, creating intermediate plain objects as
+ * needed. Replaces whatever is there (arrays included). Mutates and returns
+ * `target`. A zero-segment path is a no-op.
+ */
+export function setByPath<T extends Record<string, unknown>>(
+  target: T,
+  path: string,
+  value: unknown
+): T {
+  const parts = splitPath(path);
+  if (parts.length === 0) return target;
+  let node: Record<string, unknown> = target;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const key = parts[i];
+    const next = node[key];
+    if (next === null || typeof next !== 'object' || Array.isArray(next)) {
+      node[key] = {};
+    }
+    node = node[key] as Record<string, unknown>;
+  }
+  node[parts[parts.length - 1]] = value;
+  return target;
+}
+
+/**
+ * Delete the leaf at `path`, pruning now-empty parent objects. Mutates and
+ * returns `target`. Missing paths are a no-op.
+ */
+export function deleteByPath<T extends Record<string, unknown>>(
+  target: T,
+  path: string
+): T {
+  const parts = splitPath(path);
+  if (parts.length === 0) return target;
+  const chain: Array<Record<string, unknown>> = [target];
+  let node: Record<string, unknown> = target;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const next = node[parts[i]];
+    if (next === null || typeof next !== 'object' || Array.isArray(next)) {
+      return target; // path doesn't exist
+    }
+    node = next as Record<string, unknown>;
+    chain.push(node);
+  }
+  delete node[parts[parts.length - 1]];
+  // Prune empty ancestors.
+  for (let i = chain.length - 1; i > 0; i--) {
+    if (Object.keys(chain[i]).length === 0) {
+      delete chain[i - 1][parts[i - 1]];
+    } else break;
+  }
+  return target;
+}
+
+/** Read the value at `path`, or `undefined` if any segment is missing. */
+export function getByPath(source: unknown, path: string): unknown {
+  const parts = splitPath(path);
+  let node: unknown = source;
+  for (const key of parts) {
+    if (node === null || typeof node !== 'object') return undefined;
+    node = (node as Record<string, unknown>)[key];
+  }
+  return node;
+}
+
+/**
+ * True when `path` is locked by `lockedKeys` — either an exact match OR a
+ * descendant of a locked ancestor (locking `a.b` locks `a.b.c`).
+ */
+export function isPathLockedBy(lockedKeys: readonly string[], path: string): boolean {
+  for (const locked of lockedKeys) {
+    if (path === locked || path.startsWith(locked + '.')) return true;
+  }
+  return false;
+}
+
+/**
+ * Flatten an object into leaf dot-paths (arrays are leaves). Used to detect
+ * which paths a partial write patch touches.
+ */
+export function flattenLeafPaths(obj: unknown, prefix = ''): string[] {
+  if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
+    return prefix ? [prefix] : [];
+  }
+  const out: string[] = [];
+  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+    const next = prefix ? `${prefix}.${k}` : k;
+    out.push(...flattenLeafPaths(v, next));
+  }
+  return out;
+}

--- a/src/core/config/policy/securityCheck.ts
+++ b/src/core/config/policy/securityCheck.ts
@@ -1,0 +1,119 @@
+/**
+ * securityCheck — dangerous managed-change assessment (Track 20).
+ *
+ * Pure, platform-agnostic. Detects when a *newly applied* policy WEAKENS
+ * security vs the previously applied one (BrowserX-domain: approvals relaxed,
+ * risky tools enabled, allowlist widened, sandbox opened). Interactive
+ * runtimes warn the user; the headless server auto-applies + emits a redacted
+ * audit (the emit lives in the server bootstrap — core must not import the
+ * server log sink). An improvement over claudy's silent-headless behavior.
+ *
+ * @module core/config/policy/securityCheck
+ */
+
+import type { ResolvedPolicy } from './types';
+
+export interface PolicyChangeAssessment {
+  weakened: boolean;
+  changedKeys: string[];
+  reasons: string[];
+}
+
+const RISKY_TOOL_KEYS = [
+  'agent.tools.execCommand',
+  'agent.tools.fileOperations',
+  'agent.tools.network_intercept_tool',
+  'agent.tools.web_scraping_tool',
+  'agent.tools.enable_all_tools',
+];
+
+function val(p: ResolvedPolicy | null, key: string): unknown {
+  return p?.values?.[key];
+}
+
+/** Assess whether `next` weakens security relative to `prev`. */
+export function assessPolicyChange(
+  prev: ResolvedPolicy | null,
+  next: ResolvedPolicy | null
+): PolicyChangeAssessment {
+  const reasons: string[] = [];
+  const changedKeys: string[] = [];
+
+  const keys = new Set<string>([
+    ...Object.keys(prev?.values ?? {}),
+    ...Object.keys(next?.values ?? {}),
+  ]);
+  for (const k of keys) {
+    if (JSON.stringify(val(prev, k)) !== JSON.stringify(val(next, k))) {
+      changedKeys.push(k);
+    }
+  }
+
+  // Approvals relaxed.
+  const nextMode = val(next, 'agent.approval.mode');
+  if (nextMode === 'yolo' && val(prev, 'agent.approval.mode') !== 'yolo') {
+    reasons.push('approval mode set to "yolo" (auto-approves all tool calls)');
+  }
+
+  // Trusted-domain allowlist widened.
+  const prevTrusted = (val(prev, 'agent.approval.trustedDomains') as unknown[]) ?? [];
+  const nextTrusted = (val(next, 'agent.approval.trustedDomains') as unknown[]) ?? [];
+  if (Array.isArray(nextTrusted) && nextTrusted.length > prevTrusted.length) {
+    reasons.push('trusted-domain allowlist widened');
+  }
+
+  // Risky tools enabled.
+  for (const tk of RISKY_TOOL_KEYS) {
+    if (val(next, tk) === true && val(prev, tk) !== true) {
+      reasons.push(`risky tool enabled: ${tk}`);
+    }
+  }
+
+  // Sandbox network opened.
+  if (
+    val(next, 'agent.tools.sandboxPolicy.network_access') === true &&
+    val(prev, 'agent.tools.sandboxPolicy.network_access') !== true
+  ) {
+    reasons.push('sandbox network access enabled');
+  }
+
+  return { weakened: reasons.length > 0, changedKeys, reasons };
+}
+
+// Stateful tracker for change listeners (which only receive the new policy).
+let _lastSeen: ResolvedPolicy | null = null;
+
+/** Assess `next` vs the last recorded policy, then record `next`. */
+export function assessAndRecord(
+  next: ResolvedPolicy | null
+): PolicyChangeAssessment {
+  const a = assessPolicyChange(_lastSeen, next);
+  _lastSeen = next;
+  return a;
+}
+
+/** Test-only reset. */
+export function __resetSecurityCheckForTests(): void {
+  _lastSeen = null;
+}
+
+const SECRET_RE =
+  /(sk-[A-Za-z0-9_-]{12,}|Bearer\s+\S+|eyJ[\w-]+\.[\w-]+\.[\w-]+|(api[-_]?key|token|secret|password)["':=\s]+\S+|:\/\/[^/\s]+:[^@\s]+@)/gi;
+
+/** Deny-by-shape redaction of secret-bearing values for audit logging. */
+export function redactSecrets<T>(value: T): T {
+  if (typeof value === 'string') {
+    return value.replace(SECRET_RE, '***') as unknown as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => redactSecrets(v)) as unknown as T;
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = redactSecrets(v);
+    }
+    return out as unknown as T;
+  }
+  return value;
+}

--- a/src/core/config/policy/types.ts
+++ b/src/core/config/policy/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Managed / Policy Settings — shared types (Track 20).
+ *
+ * A single admin-controlled configuration tier that sits ABOVE every existing
+ * config layer in BOTH of BrowserX's independent config systems (the agent
+ * config and the server config). Platform-native {@link PolicySource}s feed a
+ * shared resolver; the resolved policy is overlaid post-merge and a declared
+ * subset of keys is frozen against every write surface.
+ *
+ * Namespacing: BrowserX has two config systems, so a single policy document
+ * uses fully-qualified dot-paths prefixed by namespace — `agent.*` for the
+ * agent config (extension/desktop/server) and `server.*` for the headless
+ * server config. {@link applyPolicy} filters to its namespace before applying.
+ *
+ * @module core/config/policy/types
+ */
+
+export type PolicyOrigin = 'chrome-managed' | 'file' | 'remote' | 'env' | null;
+
+export type PolicyNamespace = 'agent' | 'server';
+
+/**
+ * A resolved policy document. `values` and `lockedKeys` use namespaced
+ * dot-paths (e.g. `agent.approval.mode`, `server.exec.approvalPolicy`).
+ *
+ * - `values`: admin-provided values. Overlaid post-merge as the highest
+ *   priority — they win over user/stored/default values.
+ * - `lockedKeys`: the subset additionally *frozen* — rejected at every write
+ *   surface and rendered non-editable in the UI. Locking an ancestor path
+ *   (e.g. `agent.providers.openai`) freezes the whole subtree.
+ */
+export interface ResolvedPolicy {
+  values: Record<string, unknown>;
+  lockedKeys: string[];
+  origin: Exclude<PolicyOrigin, null>;
+}
+
+/**
+ * A platform-native policy source. Sources are consulted in registration
+ * order; the first whose `load()` returns a non-empty policy wins entirely
+ * ("first source wins" — sources are NOT merged with each other).
+ */
+export interface PolicySource {
+  readonly origin: Exclude<PolicyOrigin, null>;
+  /** Return the policy this source carries, or `null` if it carries none. */
+  load(): Promise<ResolvedPolicy | null>;
+  /**
+   * Optional platform-native change hook (e.g. `chrome.storage.onChanged`,
+   * an fs watch, the server config reload seam, or the remote poll). The
+   * returned function unsubscribes.
+   */
+  subscribe?(onChange: () => void): () => void;
+}
+
+/** Thrown when a write targets a policy-locked path. */
+export class PolicyLockedError extends Error {
+  readonly lockedPath: string;
+  constructor(lockedPath: string) {
+    super(
+      `Configuration "${lockedPath}" is managed by your organization and cannot be changed.`
+    );
+    this.name = 'PolicyLockedError';
+    this.lockedPath = lockedPath;
+  }
+}
+
+/** Compact, redaction-safe summary for diagnostics. Never includes values. */
+export interface PolicySummary {
+  origin: PolicyOrigin;
+  lockedKeys: string[];
+  /** Number of admin-provided values (count only — never the values). */
+  valueCount: number;
+}

--- a/src/core/config/remotePolicy/RemotePolicyFetcher.ts
+++ b/src/core/config/remotePolicy/RemotePolicyFetcher.ts
@@ -1,0 +1,147 @@
+/**
+ * RemotePolicyFetcher — the shared fleet remote-policy fetcher (Track 20).
+ *
+ * Net-new (no existing remote-fetch primitive in the codebase). Conditional
+ * GET with an SHA-256 `If-None-Match` checksum, hard timeout, and fail-open
+ * semantics ported faithfully from claudy's remoteManagedSettings. Caching is
+ * done via the existing `ConfigStorageProvider` (not a bespoke disk path) so
+ * it works the same on server and desktop.
+ *
+ * Tracks 12/16 consume the *config keys* a resolved remote policy sets — they
+ * do NOT call this API.
+ *
+ * @module core/config/remotePolicy/RemotePolicyFetcher
+ */
+
+import type { ResolvedPolicy } from '../policy/types';
+
+export interface RemoteFetchResult {
+  /** `updated`: new policy; `unchanged`: 304 (keep cache); `cleared`:
+   *  204/404 (managed policy removed → drop cache); `error`: fail-open. */
+  status: 'updated' | 'unchanged' | 'cleared' | 'error';
+  policy?: ResolvedPolicy;
+  /** Auth-class error — caller should not retry on a tight loop. */
+  skipRetry?: boolean;
+}
+
+export interface FetchOptions {
+  endpoint: string;
+  authHeaders?: Record<string, string>;
+  cachedChecksum?: string;
+  timeoutMs?: number;
+  /** Injectable for tests; defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+/** Recursively sort object keys for a stable serialization. */
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+      out[k] = sortKeysDeep((value as Record<string, unknown>)[k]);
+    }
+    return out;
+  }
+  return value;
+}
+
+async function sha256Hex(text: string): Promise<string> {
+  const subtle = (globalThis as { crypto?: { subtle?: SubtleCrypto } }).crypto
+    ?.subtle;
+  if (subtle) {
+    const buf = await subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode(text)
+    );
+    return Array.from(new Uint8Array(buf))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+  const nodeCrypto = await import('node:crypto');
+  return nodeCrypto.createHash('sha256').update(text).digest('hex');
+}
+
+/** Stable `sha256:<hex>` checksum of a policy document. */
+export async function computePolicyChecksum(p: unknown): Promise<string> {
+  return `sha256:${await sha256Hex(JSON.stringify(sortKeysDeep(p)))}`;
+}
+
+function coercePolicy(raw: unknown): ResolvedPolicy | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  const values =
+    obj.values && typeof obj.values === 'object' && !Array.isArray(obj.values)
+      ? (obj.values as Record<string, unknown>)
+      : {};
+  const lockedKeys = Array.isArray(obj.lockedKeys)
+    ? (obj.lockedKeys as unknown[]).filter(
+        (k): k is string => typeof k === 'string'
+      )
+    : [];
+  if (Object.keys(values).length === 0 && lockedKeys.length === 0) return null;
+  return { values, lockedKeys, origin: 'remote' };
+}
+
+/**
+ * Conditional GET. Never throws — every failure path returns
+ * `{ status: 'error' }` (fail-open is the caller's job, using stale cache).
+ */
+export async function fetchRemotePolicy(
+  opts: FetchOptions
+): Promise<RemoteFetchResult> {
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  if (!fetchImpl || !opts.endpoint) return { status: 'error' };
+
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(),
+    opts.timeoutMs ?? 10_000
+  );
+  try {
+    const headers: Record<string, string> = { ...(opts.authHeaders ?? {}) };
+    if (opts.cachedChecksum) {
+      headers['If-None-Match'] = `"${opts.cachedChecksum}"`;
+    }
+    const res = await fetchImpl(opts.endpoint, {
+      method: 'GET',
+      headers,
+      signal: controller.signal,
+    });
+
+    if (res.status === 304) return { status: 'unchanged' };
+    if (res.status === 204 || res.status === 404) return { status: 'cleared' };
+    if (res.status === 401 || res.status === 403) {
+      return { status: 'error', skipRetry: true };
+    }
+    if (!res.ok) return { status: 'error' };
+
+    const body = (await res.json()) as unknown;
+    const policy = coercePolicy(body);
+    if (!policy) return { status: 'cleared' }; // valid-but-empty == removed
+    return { status: 'updated', policy };
+  } catch {
+    return { status: 'error' }; // timeout / network / parse — fail open
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── Background poll ────────────────────────────────────────────────────────
+
+let _pollTimer: ReturnType<typeof setInterval> | null = null;
+
+/** Start a single background poll. Idempotent. */
+export function startPolicyPoll(tick: () => void, intervalMs = 3_600_000): void {
+  if (_pollTimer) return;
+  _pollTimer = setInterval(tick, intervalMs);
+  // Don't keep a process alive just for the poll (Node).
+  (_pollTimer as unknown as { unref?: () => void }).unref?.();
+}
+
+export function stopPolicyPoll(): void {
+  if (_pollTimer) {
+    clearInterval(_pollTimer);
+    _pollTimer = null;
+  }
+}

--- a/src/core/config/remotePolicy/RemotePolicySource.ts
+++ b/src/core/config/remotePolicy/RemotePolicySource.ts
@@ -1,0 +1,109 @@
+/**
+ * RemotePolicySource — the fleet remote-policy {@link PolicySource}.
+ *
+ * Highest-precedence server/desktop source. Wraps {@link fetchRemotePolicy}
+ * with cache-via-ConfigStorageProvider + fail-open (stale cache on error,
+ * never hard-deny) + a 1h background poll. Eligibility = "endpoint
+ * configured" (BrowserX has no Anthropic-subscription analog). No remote
+ * fetcher on the extension — Chrome managed storage is its channel.
+ *
+ * @module core/config/remotePolicy/RemotePolicySource
+ */
+
+import type { PolicySource, ResolvedPolicy } from '../policy/types';
+import {
+  fetchRemotePolicy,
+  computePolicyChecksum,
+  startPolicyPoll,
+  stopPolicyPoll,
+} from './RemotePolicyFetcher';
+
+const CACHE_KEY = 'policy_cache';
+
+interface CacheRecord {
+  policy: ResolvedPolicy;
+  checksum: string;
+}
+
+export interface RemotePolicySourceOptions {
+  endpoint?: string;
+  authHeaders?: Record<string, string>;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+export class RemotePolicySource implements PolicySource {
+  readonly origin = 'remote' as const;
+  private readonly opts: RemotePolicySourceOptions;
+
+  constructor(opts: RemotePolicySourceOptions = {}) {
+    this.opts = opts;
+  }
+
+  private get endpoint(): string | undefined {
+    return this.opts.endpoint ?? process.env.APPLEPI_POLICY_ENDPOINT;
+  }
+
+  private async readCache(): Promise<CacheRecord | null> {
+    try {
+      const { isConfigStorageInitialized, getConfigStorage } = await import(
+        '@/core/storage/ConfigStorageProvider'
+      );
+      if (!isConfigStorageInitialized()) return null;
+      return (await getConfigStorage().get<CacheRecord>(CACHE_KEY)) ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async writeCache(rec: CacheRecord | null): Promise<void> {
+    try {
+      const { isConfigStorageInitialized, getConfigStorage } = await import(
+        '@/core/storage/ConfigStorageProvider'
+      );
+      if (!isConfigStorageInitialized()) return;
+      const storage = getConfigStorage();
+      if (rec) await storage.set(CACHE_KEY, rec);
+      else await storage.remove(CACHE_KEY);
+    } catch {
+      /* fail open — cache is best-effort */
+    }
+  }
+
+  async load(): Promise<ResolvedPolicy | null> {
+    const endpoint = this.endpoint;
+    if (!endpoint) return null; // not eligible — no endpoint configured
+
+    const cached = await this.readCache();
+    const result = await fetchRemotePolicy({
+      endpoint,
+      authHeaders: this.opts.authHeaders,
+      cachedChecksum: cached?.checksum,
+      timeoutMs: this.opts.timeoutMs,
+      fetchImpl: this.opts.fetchImpl,
+    });
+
+    switch (result.status) {
+      case 'updated': {
+        const checksum = await computePolicyChecksum(result.policy);
+        await this.writeCache({ policy: result.policy!, checksum });
+        return result.policy!;
+      }
+      case 'unchanged':
+        return cached?.policy ?? null;
+      case 'cleared':
+        await this.writeCache(null);
+        return null;
+      case 'error':
+      default:
+        // Fail-open: keep running on the last good policy, or none.
+        return cached?.policy ?? null;
+    }
+  }
+
+  subscribe(onChange: () => void): () => void {
+    startPolicyPoll(onChange, this.opts.pollIntervalMs);
+    return () => stopPolicyPoll();
+  }
+}

--- a/src/core/config/remotePolicy/__tests__/RemotePolicyFetcher.test.ts
+++ b/src/core/config/remotePolicy/__tests__/RemotePolicyFetcher.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+  fetchRemotePolicy,
+  computePolicyChecksum,
+} from '../RemotePolicyFetcher';
+
+function res(status: number, body?: unknown): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const policyBody = {
+  values: { 'agent.approval.mode': 'yolo' },
+  lockedKeys: ['agent.approval.mode'],
+};
+
+describe('RemotePolicyFetcher', () => {
+  it('200 → updated with a remote-origin policy', async () => {
+    const r = await fetchRemotePolicy({
+      endpoint: 'https://x/policy',
+      fetchImpl: async () => res(200, policyBody),
+    });
+    expect(r.status).toBe('updated');
+    expect(r.policy).toEqual({ ...policyBody, origin: 'remote' });
+  });
+
+  it('304 → unchanged', async () => {
+    const r = await fetchRemotePolicy({
+      endpoint: 'https://x',
+      cachedChecksum: 'sha256:abc',
+      fetchImpl: async (_u, init) => {
+        expect((init?.headers as Record<string, string>)['If-None-Match']).toBe(
+          '"sha256:abc"'
+        );
+        return res(304);
+      },
+    });
+    expect(r.status).toBe('unchanged');
+  });
+
+  it('204 and 404 → cleared (managed policy removed)', async () => {
+    expect(
+      (await fetchRemotePolicy({ endpoint: 'x', fetchImpl: async () => res(204) }))
+        .status
+    ).toBe('cleared');
+    expect(
+      (await fetchRemotePolicy({ endpoint: 'x', fetchImpl: async () => res(404) }))
+        .status
+    ).toBe('cleared');
+  });
+
+  it('empty-but-valid body → cleared', async () => {
+    const r = await fetchRemotePolicy({
+      endpoint: 'x',
+      fetchImpl: async () => res(200, { values: {}, lockedKeys: [] }),
+    });
+    expect(r.status).toBe('cleared');
+  });
+
+  it('401/403 → error skipRetry; 500 → error; throw → error', async () => {
+    expect(
+      await fetchRemotePolicy({ endpoint: 'x', fetchImpl: async () => res(401) })
+    ).toEqual({ status: 'error', skipRetry: true });
+    expect(
+      (await fetchRemotePolicy({ endpoint: 'x', fetchImpl: async () => res(500) }))
+        .status
+    ).toBe('error');
+    expect(
+      (
+        await fetchRemotePolicy({
+          endpoint: 'x',
+          fetchImpl: async () => {
+            throw new Error('network');
+          },
+        })
+      ).status
+    ).toBe('error');
+  });
+
+  it('no endpoint / no fetch → error (never throws)', async () => {
+    expect((await fetchRemotePolicy({ endpoint: '' })).status).toBe('error');
+  });
+
+  it('checksum is stable under key reordering', async () => {
+    const a = await computePolicyChecksum({ a: 1, b: { c: 2, d: 3 } });
+    const b = await computePolicyChecksum({ b: { d: 3, c: 2 }, a: 1 });
+    expect(a).toBe(b);
+    expect(a.startsWith('sha256:')).toBe(true);
+  });
+});

--- a/src/core/config/remotePolicy/__tests__/RemotePolicySource.test.ts
+++ b/src/core/config/remotePolicy/__tests__/RemotePolicySource.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { RemotePolicySource } from '../RemotePolicySource';
+
+const _mem: Record<string, unknown> = {};
+vi.mock('@/core/storage/ConfigStorageProvider', () => ({
+  isConfigStorageInitialized: () => true,
+  getConfigStorage: () => ({
+    get: async (k: string) => _mem[k] ?? null,
+    set: async (k: string, v: unknown) => {
+      _mem[k] = v;
+    },
+    remove: async (k: string) => {
+      delete _mem[k];
+    },
+  }),
+}));
+
+const body = {
+  values: { 'agent.approval.mode': 'yolo' },
+  lockedKeys: ['agent.approval.mode'],
+};
+const res = (status: number, b?: unknown) =>
+  ({ status, ok: status >= 200 && status < 300, json: async () => b } as unknown as Response);
+
+describe('RemotePolicySource', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(_mem)) delete _mem[k];
+  });
+
+  it('no endpoint → not eligible, returns null', async () => {
+    const src = new RemotePolicySource({});
+    expect(await src.load()).toBeNull();
+  });
+
+  it('updated → caches policy + checksum and returns it', async () => {
+    const src = new RemotePolicySource({
+      endpoint: 'https://x',
+      fetchImpl: async () => res(200, body),
+    });
+    const p = await src.load();
+    expect(p).toEqual({ ...body, origin: 'remote' });
+    expect((_mem['policy_cache'] as any).policy).toEqual({
+      ...body,
+      origin: 'remote',
+    });
+    expect((_mem['policy_cache'] as any).checksum).toMatch(/^sha256:/);
+  });
+
+  it('unchanged (304) → returns the cached policy', async () => {
+    _mem['policy_cache'] = {
+      policy: { ...body, origin: 'remote' },
+      checksum: 'sha256:x',
+    };
+    const src = new RemotePolicySource({
+      endpoint: 'https://x',
+      fetchImpl: async () => res(304),
+    });
+    expect(await src.load()).toEqual({ ...body, origin: 'remote' });
+  });
+
+  it('error → fail-open with stale cache', async () => {
+    _mem['policy_cache'] = {
+      policy: { ...body, origin: 'remote' },
+      checksum: 'sha256:x',
+    };
+    const src = new RemotePolicySource({
+      endpoint: 'https://x',
+      fetchImpl: async () => {
+        throw new Error('down');
+      },
+    });
+    expect(await src.load()).toEqual({ ...body, origin: 'remote' });
+  });
+
+  it('cleared (204) → drops cache and returns null', async () => {
+    _mem['policy_cache'] = {
+      policy: { ...body, origin: 'remote' },
+      checksum: 'sha256:x',
+    };
+    const src = new RemotePolicySource({
+      endpoint: 'https://x',
+      fetchImpl: async () => res(204),
+    });
+    expect(await src.load()).toBeNull();
+    expect(_mem['policy_cache']).toBeUndefined();
+  });
+});

--- a/src/core/diagnostics/checks/policy-origin.ts
+++ b/src/core/diagnostics/checks/policy-origin.ts
@@ -1,0 +1,38 @@
+/**
+ * Check: which managed-policy source (if any) is in effect, and how many
+ * keys it locks. Informational — a managed policy is healthy, not a fault.
+ *
+ * Reads the shared {@link getActivePolicySummary} (never the values, so the
+ * result is redaction-safe by construction).
+ *
+ * @module core/diagnostics/checks/policy-origin
+ */
+
+import type { DiagnosticCheck, DiagnosticResult } from '../types';
+import { getActivePolicySummary } from '@/core/config/policy';
+
+export const policyOriginCheck: DiagnosticCheck = {
+  id: 'policy-origin',
+  title: 'Managed policy',
+  platforms: ['extension', 'desktop', 'server'],
+  async run(): Promise<DiagnosticResult> {
+    const { origin, lockedKeys, valueCount } = getActivePolicySummary();
+
+    if (!origin) {
+      return {
+        id: 'policy-origin',
+        title: 'Managed policy',
+        status: 'pass',
+        detail: 'No managed policy in effect (unmanaged install).',
+      };
+    }
+
+    return {
+      id: 'policy-origin',
+      title: 'Managed policy',
+      status: 'pass',
+      detail: `Managed policy active (source: ${origin}; ${lockedKeys.length} locked key(s), ${valueCount} managed value(s)).`,
+      data: { origin, lockedKeyCount: lockedKeys.length, valueCount },
+    };
+  },
+};

--- a/src/core/diagnostics/index.ts
+++ b/src/core/diagnostics/index.ts
@@ -11,6 +11,7 @@ import { channelsReachableCheck } from './checks/channels-reachable';
 import { mcpConnectedCheck } from './checks/mcp-connected';
 import { skillsLoadedCheck } from './checks/skills-loaded';
 import { schedulerHealthCheck } from './checks/scheduler-health';
+import { policyOriginCheck } from './checks/policy-origin';
 
 export type {
   DiagnosticStatus,
@@ -45,4 +46,5 @@ export function registerCoreDiagnosticChecks(): void {
   registerDiagnosticCheck(mcpConnectedCheck);
   registerDiagnosticCheck(skillsLoadedCheck);
   registerDiagnosticCheck(schedulerHealthCheck);
+  registerDiagnosticCheck(policyOriginCheck);
 }

--- a/src/desktop/agent/DesktopAgentBootstrap.ts
+++ b/src/desktop/agent/DesktopAgentBootstrap.ts
@@ -30,6 +30,12 @@ import { SensitivePathEnhancer } from '@/core/approval/enhancers/SensitivePathEn
 import { ApprovalConfigStorage } from '@/core/approval/ApprovalConfigStorage';
 import { getConfigStorage } from '@/core/storage/ConfigStorageProvider';
 import { AgentConfig } from '@/config/AgentConfig';
+import {
+  ManagedFileSource,
+  registerPolicySources,
+  resolveActivePolicy,
+  onPolicyChanged,
+} from '@/core/config/policy';
 import { configurePromptComposer, registerPromptExtension } from '@/core/PromptLoader';
 import type { RuntimeContext } from '@/prompts/PromptComposer';
 import { SkillRegistry } from '@/core/skills/SkillRegistry';
@@ -77,6 +83,7 @@ export class DesktopAgentBootstrap {
   private runningJobStartTime: number = 0;
   private initialized = false;
   private isUpdatingConfig = false;
+  private policyPollTimer: ReturnType<typeof setInterval> | null = null;
 
   /**
    * Initialize the desktop agent system
@@ -90,6 +97,29 @@ export class DesktopAgentBootstrap {
     console.log('[DesktopAgentBootstrap] Initializing...');
 
     try {
+      // 0. Track 20: register the managed-file policy source and resolve it
+      // BEFORE AgentConfig.getInstance() so the first buildRuntimeConfig sees
+      // admin policy. Desktop has no config watcher, so reload is a net-new
+      // 60s poll (the design's explicit desktop choice). Fail-open.
+      try {
+        registerPolicySources([
+          new ManagedFileSource(process.env.APPLEPI_POLICY_PATH),
+        ]);
+        await resolveActivePolicy();
+        onPolicyChanged(() => {
+          AgentConfig.getInstance()
+            .then((c) => c.reload())
+            .catch((err) =>
+              console.warn('[DesktopAgentBootstrap] policy reload failed:', err)
+            );
+        });
+        this.policyPollTimer = setInterval(() => {
+          void resolveActivePolicy();
+        }, 60_000);
+      } catch (error) {
+        console.warn('[DesktopAgentBootstrap] Managed policy resolution failed (non-fatal):', error);
+      }
+
       // 1. Get agent config
       const config = await AgentConfig.getInstance();
 
@@ -989,6 +1019,12 @@ export class DesktopAgentBootstrap {
    */
   async shutdown(): Promise<void> {
     console.log('[DesktopAgentBootstrap] Shutting down...');
+
+    // Track 20: stop the managed-policy poll
+    if (this.policyPollTimer) {
+      clearInterval(this.policyPollTimer);
+      this.policyPollTimer = null;
+    }
 
     // Dispose scheduler
     this.schedulerDeepLinkHandler?.dispose();

--- a/src/desktop/agent/DesktopAgentBootstrap.ts
+++ b/src/desktop/agent/DesktopAgentBootstrap.ts
@@ -32,9 +32,11 @@ import { getConfigStorage } from '@/core/storage/ConfigStorageProvider';
 import { AgentConfig } from '@/config/AgentConfig';
 import {
   ManagedFileSource,
+  ManagedDirSource,
   registerPolicySources,
   resolveActivePolicy,
   onPolicyChanged,
+  assessAndRecord,
 } from '@/core/config/policy';
 import { configurePromptComposer, registerPromptExtension } from '@/core/PromptLoader';
 import type { RuntimeContext } from '@/prompts/PromptComposer';
@@ -104,9 +106,17 @@ export class DesktopAgentBootstrap {
       try {
         registerPolicySources([
           new ManagedFileSource(process.env.APPLEPI_POLICY_PATH),
+          new ManagedDirSource(),
         ]);
         await resolveActivePolicy();
-        onPolicyChanged(() => {
+        onPolicyChanged((p) => {
+          const a = assessAndRecord(p);
+          if (a.weakened) {
+            console.warn(
+              '[DesktopAgentBootstrap] Organization applied a managed policy that weakens security:',
+              a.reasons.join('; ')
+            );
+          }
           AgentConfig.getInstance()
             .then((c) => c.reload())
             .catch((err) =>

--- a/src/extension/background/service-worker.ts
+++ b/src/extension/background/service-worker.ts
@@ -53,6 +53,12 @@ import { setConfigStorage } from '../../core/storage/ConfigStorageProvider';
 import { setCredentialStore } from '../../core/storage/CredentialStore';
 import { setStorageProvider, isStorageProviderInitialized } from '../../core/storage';
 import { ChromeConfigStorage } from '../../extension/storage/ChromeConfigStorage';
+import { ChromeManagedConfigSource } from '../../extension/storage/ChromeManagedConfigSource';
+import {
+  registerPolicySources,
+  resolveActivePolicy,
+  onPolicyChanged,
+} from '../../core/config/policy';
 import { ChromeCredentialStore } from '../../extension/storage/ChromeCredentialStore';
 import * as VaultManager from '../../core/crypto/VaultManager';
 // Modules previously loaded via dynamic import() — must be static in service workers
@@ -197,6 +203,17 @@ async function doInitialize(): Promise<void> {
     console.warn('[ServiceWorker] Failed to initialize credential store:', error);
   }
 
+  // Track 20: register the Chrome-native managed-policy source and resolve it
+  // BEFORE AgentConfig.getInstance() so the first buildRuntimeConfig already
+  // sees admin policy. Fail-open: no managed storage → no policy.
+  try {
+    registerPolicySources([new ChromeManagedConfigSource()]);
+    await resolveActivePolicy();
+    console.log('[ServiceWorker] Managed policy resolved (early)');
+  } catch (error) {
+    console.warn('[ServiceWorker] Managed policy resolution failed:', error);
+  }
+
   // Inject RolloutRecorder provider before any session creation triggers it.
   // Direct instantiation avoids dynamic import() which is banned in service workers.
   try {
@@ -209,6 +226,17 @@ async function doInitialize(): Promise<void> {
 
   // Initialize configuration singleton first
   agentConfig = await AgentConfig.getInstance();
+
+  // Track 20: when admin pushes a managed-policy change (chrome.storage
+  // managed area, auto-wired via the source's subscribe), re-hydrate so the
+  // pin re-applies and the UI re-renders locked fields.
+  onPolicyChanged(() => {
+    AgentConfig.getInstance()
+      .then((c) => c.reload())
+      .catch((err) =>
+        console.warn('[ServiceWorker] policy reload failed:', err)
+      );
+  });
 
   // Initialize ONLY StorageProvider early — PlanningTool requires it via getTaskStore()
   // during tool registration in registry.createSession().

--- a/src/extension/background/service-worker.ts
+++ b/src/extension/background/service-worker.ts
@@ -58,6 +58,7 @@ import {
   registerPolicySources,
   resolveActivePolicy,
   onPolicyChanged,
+  assessAndRecord,
 } from '../../core/config/policy';
 import { ChromeCredentialStore } from '../../extension/storage/ChromeCredentialStore';
 import * as VaultManager from '../../core/crypto/VaultManager';
@@ -230,7 +231,14 @@ async function doInitialize(): Promise<void> {
   // Track 20: when admin pushes a managed-policy change (chrome.storage
   // managed area, auto-wired via the source's subscribe), re-hydrate so the
   // pin re-applies and the UI re-renders locked fields.
-  onPolicyChanged(() => {
+  onPolicyChanged((p) => {
+    const a = assessAndRecord(p);
+    if (a.weakened) {
+      console.warn(
+        '[ServiceWorker] Organization applied a managed policy that weakens security:',
+        a.reasons.join('; ')
+      );
+    }
     AgentConfig.getInstance()
       .then((c) => c.reload())
       .catch((err) =>

--- a/src/extension/manifest.json
+++ b/src/extension/manifest.json
@@ -4,6 +4,7 @@
   "version": "0.0.36",
   "description": "__MSG_extension_description__",
   "default_locale": "en",
+  "managed_storage": "managed-schema.json",
   "permissions": [
     "tabs",
     "tabGroups",

--- a/src/extension/storage/ChromeManagedConfigSource.ts
+++ b/src/extension/storage/ChromeManagedConfigSource.ts
@@ -1,0 +1,67 @@
+/**
+ * ChromeManagedConfigSource — admin policy from Chrome enterprise policy.
+ *
+ * The extension's native managed tier (Track 20). Admins push policy via
+ * GPO / Jamf / Workspace / Intune; it arrives read-only in
+ * `chrome.storage.managed` per the `managed_storage` manifest schema. This is
+ * the browser-extension analog of claudy's HKLM/plist.
+ *
+ * Fail-open: no managed storage, an empty policy, or a read error yields no
+ * policy (never a hard-deny). Reload rides `chrome.storage.onChanged` filtered
+ * to the `managed` area — the extension's existing reactive channel.
+ *
+ * @module extension/storage/ChromeManagedConfigSource
+ */
+
+import type { PolicySource, ResolvedPolicy } from '@/core/config/policy';
+
+export class ChromeManagedConfigSource implements PolicySource {
+  readonly origin = 'chrome-managed' as const;
+
+  async load(): Promise<ResolvedPolicy | null> {
+    try {
+      const managed = (
+        chrome as unknown as {
+          storage?: { managed?: { get(keys: string[]): Promise<Record<string, unknown>> } };
+        }
+      ).storage?.managed;
+      if (!managed) return null;
+      const res = await managed.get(['values', 'lockedKeys']);
+      const values =
+        res.values && typeof res.values === 'object' && !Array.isArray(res.values)
+          ? (res.values as Record<string, unknown>)
+          : {};
+      const lockedKeys = Array.isArray(res.lockedKeys)
+        ? (res.lockedKeys as unknown[]).filter(
+            (k): k is string => typeof k === 'string'
+          )
+        : [];
+      if (Object.keys(values).length === 0 && lockedKeys.length === 0) {
+        return null;
+      }
+      return { values, lockedKeys, origin: 'chrome-managed' };
+    } catch (err) {
+      console.warn('[ChromeManagedConfigSource] managed read failed:', err);
+      return null;
+    }
+  }
+
+  subscribe(onChange: () => void): () => void {
+    const onChanged = (
+      chrome as unknown as {
+        storage?: {
+          onChanged?: {
+            addListener(cb: (changes: unknown, area: string) => void): void;
+            removeListener(cb: (changes: unknown, area: string) => void): void;
+          };
+        };
+      }
+    ).storage?.onChanged;
+    if (!onChanged) return () => {};
+    const handler = (_changes: unknown, area: string) => {
+      if (area === 'managed') onChange();
+    };
+    onChanged.addListener(handler);
+    return () => onChanged.removeListener(handler);
+  }
+}

--- a/src/extension/storage/__tests__/ChromeManagedConfigSource.test.ts
+++ b/src/extension/storage/__tests__/ChromeManagedConfigSource.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ChromeManagedConfigSource } from '../ChromeManagedConfigSource';
+
+const realChrome = (globalThis as any).chrome;
+
+afterEach(() => {
+  (globalThis as any).chrome = realChrome;
+});
+
+describe('ChromeManagedConfigSource', () => {
+  it('builds a policy from chrome.storage.managed', async () => {
+    (globalThis as any).chrome = {
+      storage: {
+        managed: {
+          get: async (_keys: string[]) => ({
+            values: { 'agent.approval.mode': 'yolo' },
+            lockedKeys: ['agent.approval.mode'],
+          }),
+        },
+      },
+    };
+    const p = await new ChromeManagedConfigSource().load();
+    expect(p).toEqual({
+      values: { 'agent.approval.mode': 'yolo' },
+      lockedKeys: ['agent.approval.mode'],
+      origin: 'chrome-managed',
+    });
+  });
+
+  it('fails open when managed storage is unavailable', async () => {
+    (globalThis as any).chrome = { storage: {} };
+    expect(await new ChromeManagedConfigSource().load()).toBeNull();
+  });
+
+  it('returns null for an empty managed policy', async () => {
+    (globalThis as any).chrome = {
+      storage: { managed: { get: async () => ({}) } },
+    };
+    expect(await new ChromeManagedConfigSource().load()).toBeNull();
+  });
+
+  it('subscribe fires only for the managed area', () => {
+    let handler: ((c: unknown, area: string) => void) | undefined;
+    (globalThis as any).chrome = {
+      storage: {
+        onChanged: {
+          addListener: (cb: (c: unknown, a: string) => void) => {
+            handler = cb;
+          },
+          removeListener: vi.fn(),
+        },
+      },
+    };
+    const onChange = vi.fn();
+    const unsub = new ChromeManagedConfigSource().subscribe(onChange);
+    handler?.({}, 'local');
+    expect(onChange).not.toHaveBeenCalled();
+    handler?.({}, 'managed');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(() => unsub()).not.toThrow();
+  });
+});

--- a/src/server/agent/ServerAgentBootstrap.ts
+++ b/src/server/agent/ServerAgentBootstrap.ts
@@ -25,6 +25,12 @@ import { deriveInputOrigin } from '@/core/input/types';
 import type { EventMsg } from '@/core/protocol/events';
 
 import { getServerConfig, watchConfig, stopWatchingConfig, onConfigReload } from '../config/server-config';
+import {
+  ManagedFileSource,
+  registerPolicySources,
+  resolveActivePolicy,
+  onPolicyChanged,
+} from '@/core/config/policy';
 import { SessionIndex } from '../persistence/SessionIndex';
 import { TranscriptStore } from '../persistence/TranscriptStore';
 import { BackupManager } from '../persistence/backup';
@@ -145,6 +151,20 @@ export class ServerAgentBootstrap {
 
       // 1. Initialize config storage (must happen before AgentConfig)
       setConfigStorage(new FileConfigStorageProvider(dataDir));
+
+      // 1b. Track 20: register the managed-file policy source (fleet policy is
+      // mounted via ConfigMap/Secret at APPLEPI_POLICY_PATH) and resolve it
+      // BEFORE AgentConfig.getInstance() / loadServerConfig() so both config
+      // systems' first hydration already sees admin policy. Fail-open.
+      try {
+        registerPolicySources([
+          new ManagedFileSource(process.env.APPLEPI_POLICY_PATH),
+        ]);
+        await resolveActivePolicy();
+        console.log('[ServerAgentBootstrap] Managed policy resolved');
+      } catch (error) {
+        console.warn('[ServerAgentBootstrap] Managed policy resolution failed (non-fatal):', error);
+      }
 
       // 2. Get agent config
       const agentConfig = await AgentConfig.getInstance();
@@ -336,6 +356,15 @@ export class ServerAgentBootstrap {
         // Hot-reload: iterate all sessions for refreshModelClient
         this.handleConfigUpdate().catch((err) => {
           console.error('[ServerAgentBootstrap] Failed to handle config update:', err);
+        });
+      });
+
+      // Track 20: a managed-file policy change (auto-wired fs.watch on the
+      // source) re-resolves the policy; re-hydrate the agent config so the
+      // pin re-applies fleet-wide without a restart.
+      onPolicyChanged(() => {
+        this.handleConfigUpdate().catch((err) => {
+          console.error('[ServerAgentBootstrap] Failed to apply policy change:', err);
         });
       });
 

--- a/src/server/agent/ServerAgentBootstrap.ts
+++ b/src/server/agent/ServerAgentBootstrap.ts
@@ -24,7 +24,7 @@ import type { SubmissionContext } from '@/core/channels/types';
 import { deriveInputOrigin } from '@/core/input/types';
 import type { EventMsg } from '@/core/protocol/events';
 
-import { getServerConfig, watchConfig, stopWatchingConfig, onConfigReload } from '../config/server-config';
+import { getServerConfig, loadServerConfig, watchConfig, stopWatchingConfig, onConfigReload } from '../config/server-config';
 import {
   ManagedFileSource,
   ManagedDirSource,
@@ -121,7 +121,9 @@ export class ServerAgentBootstrap {
     }
 
     console.log('[ServerAgentBootstrap] Initializing...');
-    const config = getServerConfig();
+    // NOTE: getServerConfig() is intentionally deferred until AFTER the
+    // Track 20 policy block below. The first call memoizes the pinned config,
+    // so calling it here would cache a config with NO admin policy applied.
     const dataDir = process.env.APPLEPI_DATA_DIR ??
       `${process.env.HOME ?? process.env.USERPROFILE ?? '/tmp'}/.applepi-server/data`;
 
@@ -159,8 +161,8 @@ export class ServerAgentBootstrap {
 
       // 1b. Track 20: register the managed-file policy source (fleet policy is
       // mounted via ConfigMap/Secret at APPLEPI_POLICY_PATH) and resolve it
-      // BEFORE AgentConfig.getInstance() / loadServerConfig() so both config
-      // systems' first hydration already sees admin policy. Fail-open.
+      // BEFORE the first getServerConfig() / AgentConfig.getInstance() so both
+      // config systems' first hydration already sees admin policy. Fail-open.
       try {
         registerPolicySources([
           // Fleet remote path is highest precedence (first-wins), then the
@@ -174,6 +176,10 @@ export class ServerAgentBootstrap {
       } catch (error) {
         console.warn('[ServerAgentBootstrap] Managed policy resolution failed (non-fatal):', error);
       }
+
+      // 1c. First server-config read — now memoizes the policy-pinned config
+      // (server.* tier). Must come after the policy block above.
+      const config = getServerConfig();
 
       // 2. Get agent config
       const agentConfig = await AgentConfig.getInstance();
@@ -386,6 +392,14 @@ export class ServerAgentBootstrap {
             reasons: a.reasons,
           })
         );
+        // Re-pin the server.* tier: AgentConfig.reload() (in handleConfigUpdate)
+        // only re-hydrates the agent.* config. Without this, a post-boot policy
+        // change would never reach the memoized server config.
+        try {
+          loadServerConfig();
+        } catch (err) {
+          console.error('[ServerAgentBootstrap] Failed to re-pin server config on policy change:', err);
+        }
         this.handleConfigUpdate().catch((err) => {
           console.error('[ServerAgentBootstrap] Failed to apply policy change:', err);
         });

--- a/src/server/agent/ServerAgentBootstrap.ts
+++ b/src/server/agent/ServerAgentBootstrap.ts
@@ -27,10 +27,15 @@ import type { EventMsg } from '@/core/protocol/events';
 import { getServerConfig, watchConfig, stopWatchingConfig, onConfigReload } from '../config/server-config';
 import {
   ManagedFileSource,
+  ManagedDirSource,
+  RemotePolicySource,
   registerPolicySources,
   resolveActivePolicy,
   onPolicyChanged,
+  assessAndRecord,
+  redactSecrets,
 } from '@/core/config/policy';
+import { emitLog } from '../handlers/logs';
 import { SessionIndex } from '../persistence/SessionIndex';
 import { TranscriptStore } from '../persistence/TranscriptStore';
 import { BackupManager } from '../persistence/backup';
@@ -158,7 +163,11 @@ export class ServerAgentBootstrap {
       // systems' first hydration already sees admin policy. Fail-open.
       try {
         registerPolicySources([
+          // Fleet remote path is highest precedence (first-wins), then the
+          // ConfigMap/Secret-mounted managed file.
+          new RemotePolicySource(),
           new ManagedFileSource(process.env.APPLEPI_POLICY_PATH),
+          new ManagedDirSource(),
         ]);
         await resolveActivePolicy();
         console.log('[ServerAgentBootstrap] Managed policy resolved');
@@ -359,10 +368,24 @@ export class ServerAgentBootstrap {
         });
       });
 
-      // Track 20: a managed-file policy change (auto-wired fs.watch on the
-      // source) re-resolves the policy; re-hydrate the agent config so the
-      // pin re-applies fleet-wide without a restart.
-      onPolicyChanged(() => {
+      // Track 20: a remote/managed-file policy change re-resolves the policy.
+      // Headless server has no interactive user — auto-apply, but emit a
+      // REDACTED audit (warn if it weakens security) so operators see it in
+      // the logs.tail stream they already watch. Then re-hydrate so the pin
+      // re-applies fleet-wide without a restart.
+      onPolicyChanged((p) => {
+        const a = assessAndRecord(p);
+        emitLog(
+          a.weakened ? 'warn' : 'info',
+          'managed policy applied',
+          redactSecrets({
+            origin: p?.origin ?? null,
+            lockedKeys: p?.lockedKeys ?? [],
+            changedKeys: a.changedKeys,
+            weakened: a.weakened,
+            reasons: a.reasons,
+          })
+        );
         this.handleConfigUpdate().catch((err) => {
           console.error('[ServerAgentBootstrap] Failed to apply policy change:', err);
         });

--- a/src/server/config/__tests__/server-config.policy.test.ts
+++ b/src/server/config/__tests__/server-config.policy.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Track 20 — the server config is the second config system. A locked
+ * `server.*` key must survive `loadServerConfig()` and beat the env override
+ * (env stays an admin lever, but `lockedKeys` pins the resolved value).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const ENV_KEYS = ['APPLEPI_CONFIG_PATH', 'APPLEPI_DATA_DIR', 'APPLEPI_SERVER_PORT'];
+const saved: Record<string, string | undefined> = {};
+
+let loadServerConfig: typeof import('../server-config').loadServerConfig;
+let registerPolicySources: typeof import('@/core/config/policy').registerPolicySources;
+let resolveActivePolicy: typeof import('@/core/config/policy').resolveActivePolicy;
+
+beforeEach(async () => {
+  for (const k of ENV_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+  vi.resetModules();
+  // Import both from the SAME fresh module graph so the resolver singleton
+  // server-config reads is the one we register sources on.
+  const policy = await import('@/core/config/policy');
+  registerPolicySources = policy.registerPolicySources;
+  resolveActivePolicy = policy.resolveActivePolicy;
+  policy.__resetPolicyResolverForTests();
+  loadServerConfig = (await import('../server-config')).loadServerConfig;
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] !== undefined) process.env[k] = saved[k];
+    else delete process.env[k];
+  }
+});
+
+describe('Track 20 — server-config policy pin', () => {
+  it('no policy → env override wins as before', async () => {
+    process.env.APPLEPI_SERVER_PORT = '1234';
+    const cfg = loadServerConfig();
+    expect(cfg.server.port).toBe(1234);
+  });
+
+  it('locked server.port beats the env override', async () => {
+    registerPolicySources([
+      {
+        origin: 'file',
+        load: async () => ({
+          values: { 'server.server.port': 9999 },
+          lockedKeys: ['server.server.port'],
+          origin: 'file',
+        }),
+      },
+    ]);
+    await resolveActivePolicy();
+    process.env.APPLEPI_SERVER_PORT = '1234';
+    const cfg = loadServerConfig();
+    expect(cfg.server.port).toBe(9999); // policy > env > file > defaults
+  });
+
+  it('agent-namespaced policy does not leak into server config', async () => {
+    registerPolicySources([
+      {
+        origin: 'file',
+        load: async () => ({
+          values: { 'agent.selectedModelKey': 'x:y' },
+          lockedKeys: ['agent.selectedModelKey'],
+          origin: 'file',
+        }),
+      },
+    ]);
+    await resolveActivePolicy();
+    const cfg = loadServerConfig() as Record<string, unknown>;
+    expect('selectedModelKey' in cfg).toBe(false);
+    expect((cfg as any).server.port).toBe(18100); // untouched default
+  });
+});

--- a/src/server/config/__tests__/server-config.policy.test.ts
+++ b/src/server/config/__tests__/server-config.policy.test.ts
@@ -4,6 +4,7 @@
  * (env stays an admin lever, but `lockedKeys` pins the resolved value).
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { ResolvedPolicy } from '@/core/config/policy';
 
 const ENV_KEYS = ['APPLEPI_CONFIG_PATH', 'APPLEPI_DATA_DIR', 'APPLEPI_SERVER_PORT'];
 const saved: Record<string, string | undefined> = {};
@@ -56,6 +57,24 @@ describe('Track 20 — server-config policy pin', () => {
     process.env.APPLEPI_SERVER_PORT = '1234';
     const cfg = loadServerConfig();
     expect(cfg.server.port).toBe(9999); // policy > env > file > defaults
+  });
+
+  it('a post-boot policy change is re-pinned by a second loadServerConfig()', async () => {
+    // Mirrors the ServerAgentBootstrap onPolicyChanged handler, which now
+    // re-runs loadServerConfig() so the server.* tier re-pins without a
+    // restart (AgentConfig.reload() only re-hydrates the agent.* tier).
+    let current: ResolvedPolicy | null = null;
+    registerPolicySources([{ origin: 'file', load: async () => current }]);
+    await resolveActivePolicy();
+    expect(loadServerConfig().server.port).toBe(18100); // no policy yet
+
+    current = {
+      values: { 'server.server.port': 7777 },
+      lockedKeys: ['server.server.port'],
+      origin: 'file',
+    };
+    await resolveActivePolicy();
+    expect(loadServerConfig().server.port).toBe(7777); // re-pinned
   });
 
   it('agent-namespaced policy does not leak into server config', async () => {

--- a/src/server/config/server-config.ts
+++ b/src/server/config/server-config.ts
@@ -10,6 +10,7 @@
 import { z } from 'zod';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { applyPolicy, getActivePolicySync } from '@/core/config/policy';
 
 // ─────────────────────────────────────────────────────────────────────────
 // Configuration schema
@@ -141,8 +142,14 @@ export function loadServerConfig(): ServerConfig {
   const merged = applyEnvOverrides(fileConfig);
   const parsed = ServerConfigSchema.parse(merged);
 
-  _config = parsed;
-  return parsed;
+  // Track 20: pin admin policy as the highest-priority tier, AFTER
+  // env>file>defaults resolution. No-op until a policy source is resolved.
+  // The existing onConfigReload callbacks deliver this pinned object, so
+  // hot-reload re-applies policy with no new seam.
+  const resolved = applyPolicy(parsed, getActivePolicySync(), 'server');
+
+  _config = resolved;
+  return resolved;
 }
 
 /**

--- a/src/webfront/components/common/ManagedBadge.svelte
+++ b/src/webfront/components/common/ManagedBadge.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  // Track 20: "Managed by your organization" affordance for policy-locked
+  // settings. Render next to a disabled control when `locked` is true.
+  let {
+    locked = false,
+    tooltip = 'Managed by your organization — contact your administrator to change this.',
+  }: {
+    locked?: boolean;
+    tooltip?: string;
+  } = $props();
+</script>
+
+{#if locked}
+  <span
+    class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-800 align-middle"
+    title={tooltip}
+    data-testid="managed-badge"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      class="h-3 w-3"
+      aria-hidden="true"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M10 1a4.5 4.5 0 0 0-4.5 4.5V9H5a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2h-.5V5.5A4.5 4.5 0 0 0 10 1Zm3 8V5.5a3 3 0 1 0-6 0V9h6Z"
+        clip-rule="evenodd"
+      />
+    </svg>
+    Managed by your organization
+  </span>
+{/if}

--- a/src/webfront/settings/ApprovalSettings.svelte
+++ b/src/webfront/settings/ApprovalSettings.svelte
@@ -11,6 +11,8 @@
   import { getInitializedUIClient } from '@/core/messaging';
   import { t, _t } from '../lib/i18n';
   import { highlightSetting } from './utils/highlightSetting';
+  import { isPolicyLocked, managedTooltip } from './utils/policyLock';
+  import ManagedBadge from '../components/common/ManagedBadge.svelte';
   import './utils/highlight-pulse.css';
 
   let {
@@ -104,7 +106,15 @@
     }
   }
 
+  // Track 20: approval mode is a prime org-lockable control.
+  const approvalModeLocked = isPolicyLocked(
+    settingsConfig.getConfig(),
+    'approval.mode'
+  );
+  const managedHint = managedTooltip(settingsConfig.getConfig());
+
   function handleModeChange(mode: ApprovalMode) {
+    if (approvalModeLocked) return; // enforced server-side too; UI guard
     config.mode = mode;
     isDirty = true;
   }
@@ -153,10 +163,13 @@
     <div class="settings-body">
       <!-- Approval Mode -->
       <section class="setting-section" data-setting-id="approval-mode">
-        <h4 class="subsection-title">{$_t("Approval Mode")}</h4>
+        <h4 class="subsection-title">
+          {$_t("Approval Mode")}
+          <ManagedBadge locked={approvalModeLocked} tooltip={managedHint} />
+        </h4>
         <p class="subsection-description">{$_t("Controls how aggressively the agent asks for approval.")}</p>
 
-        <div class="mode-options">
+        <div class="mode-options" class:policy-locked={approvalModeLocked}>
           {#each APPROVAL_MODES as mode}
             <label class="mode-option" class:selected={config.mode === mode}>
               <input
@@ -164,6 +177,7 @@
                 name="approval-mode"
                 value={mode}
                 checked={config.mode === mode}
+                disabled={approvalModeLocked}
                 onchange={() => handleModeChange(mode)}
               />
               <div class="mode-content">
@@ -317,6 +331,12 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+  }
+
+  /* Track 20: org-managed (policy-locked) control */
+  .mode-options.policy-locked {
+    opacity: 0.6;
+    pointer-events: none;
   }
 
   .mode-option {

--- a/src/webfront/settings/utils/__tests__/policyLock.test.ts
+++ b/src/webfront/settings/utils/__tests__/policyLock.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { isPolicyLocked, policyOrigin, managedTooltip } from '../policyLock';
+import type { IAgentConfig } from '@/config/types';
+
+const cfg = (lockedKeys: string[], origin: any = 'file') =>
+  ({ policy: { lockedKeys, origin } } as Pick<IAgentConfig, 'policy'>);
+
+describe('policyLock UI helper', () => {
+  it('exact and ancestor matches are locked', () => {
+    const c = cfg(['approval.mode', 'providers.openai']);
+    expect(isPolicyLocked(c, 'approval.mode')).toBe(true);
+    expect(isPolicyLocked(c, 'providers.openai.apiKey')).toBe(true);
+    expect(isPolicyLocked(c, 'providers.xai.apiKey')).toBe(false);
+  });
+
+  it('no policy → nothing locked', () => {
+    expect(isPolicyLocked(undefined, 'approval.mode')).toBe(false);
+    expect(isPolicyLocked({ policy: undefined }, 'approval.mode')).toBe(false);
+    expect(isPolicyLocked(cfg([]), 'approval.mode')).toBe(false);
+  });
+
+  it('origin + tooltip reflect the source', () => {
+    expect(policyOrigin(cfg([], 'chrome-managed'))).toBe('chrome-managed');
+    expect(managedTooltip(cfg([], 'file'))).toContain('source: file');
+    expect(managedTooltip(undefined)).toContain('Managed by your organization');
+  });
+});

--- a/src/webfront/settings/utils/policyLock.ts
+++ b/src/webfront/settings/utils/policyLock.ts
@@ -1,0 +1,47 @@
+/**
+ * UI managed-lock helper (Track 20).
+ *
+ * Generalises claudy's ad-hoc per-feature "is this configured by policy?"
+ * checks into one reusable predicate, bound to the runtime
+ * `IAgentConfig.policy.lockedKeys` the resolver stamps. Settings components
+ * use it to disable inputs and show a "Managed by your organization" badge.
+ *
+ * Enforcement does NOT depend on this — the write guards already reject locked
+ * writes. This is the visibility affordance.
+ *
+ * @module webfront/settings/utils/policyLock
+ */
+
+import type { IAgentConfig } from '@/config/types';
+import { isPathLockedBy } from '@/core/config/policy';
+
+/**
+ * True when `path` (agent namespace-relative dot-path, e.g. `approval.mode`,
+ * `providers.openai.apiKey`, `tools`) is policy-locked — exact match or under
+ * a locked ancestor.
+ */
+export function isPolicyLocked(
+  config: Pick<IAgentConfig, 'policy'> | null | undefined,
+  path: string
+): boolean {
+  const locked = config?.policy?.lockedKeys;
+  if (!locked || locked.length === 0) return false;
+  return isPathLockedBy(locked, path);
+}
+
+/** The origin label for tooltips, or null when unmanaged. */
+export function policyOrigin(
+  config: Pick<IAgentConfig, 'policy'> | null | undefined
+): string | null {
+  return config?.policy?.origin ?? null;
+}
+
+/** Human tooltip for a locked control. */
+export function managedTooltip(
+  config: Pick<IAgentConfig, 'policy'> | null | undefined
+): string {
+  const origin = policyOrigin(config);
+  return origin
+    ? `Managed by your organization (source: ${origin}) — contact your administrator to change this.`
+    : 'Managed by your organization — contact your administrator to change this.';
+}


### PR DESCRIPTION
## Summary

Implements **Track 20: Managed / Policy Settings Tier** end-to-end — an
admin-controlled, highest-priority configuration tier with an explicit
`lockedKeys` set that users and the agent cannot override, wired into **both**
of BrowserX's independent config systems via one shared resolver, fed by the
right native policy channel per platform.

Design + tasks: `.ai_design/agent_improvements/20_managed_policy_settings/`
(rewritten earlier on `agent-improvements`; status updated here).

### Phase 1 — enforcement core (the guarantee)
- Net-new `src/core/config/policy/`: `PolicyResolver` (first-source-wins,
  cached, sync accessor), `applyPolicy` deep post-merge pin (defeats the
  one-level `buildRuntimeConfig` merges), write guards, dot-path utils.
- Pin wired into `buildRuntimeConfig` (agent) **and** `loadServerConfig`
  (server). Guards on **all** agent write surfaces: `updateConfig`
  (strip+re-pin), every domain mutator (`assertWritable`), and the LLM
  `setting_tool` (`configSchema.resolve` deny). Runtime-only
  `IAgentConfig.policy` marker (never persisted); `reload()` now emits a
  `policy` config-changed event.

### Phase 2 — platform sources + reload + UI
- `ChromeManagedConfigSource` (`chrome.storage.managed` + `onChanged`) with a
  `managed_storage` manifest schema (both manifests + build copy).
- Shared `ManagedFileSource` (lazy `node:fs` → safe in webview).
- Registered + resolved **before** `AgentConfig.getInstance()` in all three
  bootstraps; reload via `onChanged` (ext), 60s poll (desktop, net-new),
  `onConfigReload` bridge (server).
- `policyLock` helper + `ManagedBadge`, integrated into `ApprovalSettings`
  (reference) — locked controls render disabled + "Managed by your
  organization".

### Phase 3 — remote fetcher + securityCheck
- Net-new `src/core/config/remotePolicy/`: conditional-GET SHA-256
  `If-None-Match` fetcher, fail-open stale cache via `ConfigStorageProvider`,
  `204/404` clears, 1h `.unref` poll. `RemotePolicySource` registered
  highest-precedence on server/desktop.
- `securityCheck`: pure `assessPolicyChange` + `redactSecrets`; **server**
  auto-applies with a **redacted `emitLog` audit** (warn on weakening) —
  ext/desktop surface a console warning.

### Phase 4 — OS-MDM (testable slice)
- `ManagedDirSource` (`managed-settings.d/` drop-in, deterministic merge).
  macOS-plist / Windows-registry remain the explicitly-deferred P3/L
  subprocess tier per the approved design.

## Notable corrections discovered during implementation
- **Track 17 diagnostics is implemented** (branch moved) — shipped a real
  `policy-origin` `DiagnosticCheck`, no degradation needed.
- AgentConfig has more write surfaces than the 3 named; all are now
  guarded/re-pinned — the four-surface invariant holds across every one.
- Interactive securityCheck is a surfaced warning + audit (not a blind
  blocking modal) — a deliberate, documented divergence; enforcement never
  depends on the prompt. See `tasks.md` "Implementation status".

## Test plan
- [x] `npm run type-check` — clean (0 errors)
- [x] `npm run lint` — 0 errors (warnings are codebase-consistent `no-explicit-any`)
- [x] `npm test` (affected) — 383 passed, incl. the four-surface invariant
      (`src/config/__tests__/policy.integration.test.ts`), resolver, fetcher
      status matrix, fail-open, securityCheck, per-platform sources, UI helper
- [x] `npm run build` — production build green (Svelte + all 3 bootstraps)
- [ ] Manual: push a Chrome managed policy / drop a managed-settings.json and
      confirm locked fields render disabled + reload works (needs a managed
      Chrome / OS env — not exercisable in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)