### PR TITLE
Track 22: compile-time feature flags + lazy loading

### DIFF
--- a/.ai_design/agent_improvements/22_feature_flags_lazy_loading/phase0-sw-strip-decision.md
+++ b/.ai_design/agent_improvements/22_feature_flags_lazy_loading/phase0-sw-strip-decision.md
@@ -1,0 +1,60 @@
+# Track 22 — Phase 0 Decision: SW strip mechanism
+
+**Status: RESOLVED — GO.** Date: 2026-05-16. Empirical, not assumed.
+
+## Question 1 — can the extension service worker strip a feature-gated subsystem?
+
+**Yes, via dynamic `import()` behind the feature-gate constant.** The
+`service-worker.ts:49-51` comment ("dynamic import() banned in MV3 service
+workers") is **stale**: it cites a 2018 spec issue that predates Chrome's
+module service workers. Ground truth already contradicted it (`:992-994` ships a
+live `await import()` in this SW). Confirmed empirically here — `vite.config.mjs`
+code-splits the gated `await import('../../core/mcp/MCPManager')` into a chunk;
+when the gate constant folds to `false`, the branch is DCE'd and **the chunk is
+never emitted**. Both OFF and ON builds compile and succeed.
+
+**Mechanism chosen:** dynamic `import()` inside `if (MCP)` / `if (A2A)`, with
+the manager classes + tool adapters as `import type` only at top level. This is
+strictly better than the static-import + side-effect-free tree-shake fallback
+the design hedged on: removal is guaranteed by chunk non-emission, not
+contingent on the module graph being side-effect-free.
+
+## Question 2 — does `core/mcp` / `core/a2a` actually leave the bundle?
+
+**Yes.** Controlled A/B, identical source, only `APPLEPI_FEATURE_*` differs
+(`npx vite build`, `vite.config.mjs`):
+
+| Artifact | OFF (MCP=A2A=false) | ON (default) | Δ removed when OFF |
+|---|--:|--:|--:|
+| `background.js` | 799,254 B | 803,835 B | ~4.5 KB |
+| `chunks/*.js` total | 4,162,880 B | 4,493,699 B | **~323 KB** |
+| **combined** | | | **~335 KB raw** |
+
+String evidence: in the OFF build `core/mcp`, `core/a2a`, `MCPToolAdapter`,
+`A2AToolAdapter`, `registerMCPTools` are **absent** from all emitted `.js`; in
+the ON build `MCPToolAdapter` (×7) and `A2AToolAdapter` (×3) reappear. The lone
+`McpSlotLoader-*.js` chunk is the plugin-slot loader, which references
+`@/core/mcp/types` **type-only** (erased) — not a runtime leak.
+
+## Required refactors
+
+**None.** No side-effect pinning was observed; `core/mcp` / `core/a2a` tree-shake
+cleanly once their only references are behind a dead gate. The design's
+contingency ("if side effects pin it, refactor `core/mcp` to be import-pure")
+did not materialize.
+
+## Decision
+
+GO. Phase 2 is implemented with the dynamic-import-behind-gate mechanism.
+Defaults are MCP=ON / A2A=ON on every platform that ships them today, so this
+change is **behavior-preserving for users** — the OFF path (the ~335 KB win) is
+a build-time capability proven by forced-OFF builds, available for future
+product-tiering, not a default behavior change in this PR.
+
+Caveat (honestly scoped): correctness was verified at **build/bundle** level
+(chunk emission, string absence, byte delta) and via the unit + regression
+tests. Runtime behavior in a packaged extension loaded in live Chrome MV3 was
+not exercised in this environment; the dynamic-import path is identical in shape
+to the already-shipping `service-worker.ts:992-994` import, so the residual risk
+is low but not zero — a manual smoke of an MCP-enabled packaged build is
+recommended before relying on the OFF default for any platform.

--- a/src/core/features/__tests__/__fixtures__/entry-fixture.ts
+++ b/src/core/features/__tests__/__fixtures__/entry-fixture.ts
@@ -1,0 +1,11 @@
+// Track 22 regression fixture — the gate call site, mirroring the real
+// `if (MCP) { ... }` pattern in service-worker.ts.
+import { TESTGATE } from './feature-fixture';
+import { HEAVY_MARKER } from './heavy-fixture';
+
+export function run(): string {
+  if (TESTGATE) {
+    return HEAVY_MARKER;
+  }
+  return 'off';
+}

--- a/src/core/features/__tests__/__fixtures__/feature-fixture.ts
+++ b/src/core/features/__tests__/__fixtures__/feature-fixture.ts
@@ -1,0 +1,7 @@
+// Track 22 regression fixture — mirrors src/core/features/feature.ts exactly:
+// a bare typed injected constant (NOT an indexed feature('X') function).
+// If anyone changes the real feature.ts to a form that does not constant-fold,
+// the matching change here would make the dead-code test fail.
+declare const __FEATURE_TESTGATE__: boolean;
+export const TESTGATE =
+  typeof __FEATURE_TESTGATE__ !== 'undefined' && __FEATURE_TESTGATE__;

--- a/src/core/features/__tests__/__fixtures__/heavy-fixture.ts
+++ b/src/core/features/__tests__/__fixtures__/heavy-fixture.ts
@@ -1,0 +1,3 @@
+// Track 22 regression fixture — a stand-in "heavy subsystem". Its unique
+// marker must vanish from the bundle when the gate flag is OFF.
+export const HEAVY_MARKER = 'HEAVY_MODULE_a1b2c3d4_PRESENT_IN_BUNDLE';

--- a/src/core/features/__tests__/feature.deadcode.test.ts
+++ b/src/core/features/__tests__/feature.deadcode.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+/**
+ * Track 22 — DCE regression guard (Phase 3 / Risk: "feature.ts must stay a
+ * bare typed export").
+ *
+ * Bundles the fixture through Vite's real `build()` (Rollup + `define` +
+ * esbuild minify — the exact production pipeline, which is what gives the
+ * cross-module constant propagation that Phase 0 measured) and asserts the
+ * gated "heavy" module's unique marker:
+ *   - is ABSENT when the flag is defined false  (dead-code eliminated)
+ *   - is PRESENT when the flag is defined true   (positive control)
+ *
+ * If anyone reverts feature.ts to a string-keyed indexed `feature('X')`
+ * function, the equivalent fixture change stops constant-folding and the
+ * "absent when false" assertion fails — loudly, in CI.
+ */
+import { describe, it, expect } from 'vitest';
+import { build } from 'vite';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const entry = resolve(here, '__fixtures__/entry-fixture.ts');
+const MARKER = 'HEAVY_MODULE_a1b2c3d4_PRESENT_IN_BUNDLE';
+
+async function bundleWith(flag: 'true' | 'false'): Promise<string> {
+  const result = (await build({
+    configFile: false,
+    logLevel: 'silent',
+    define: { __FEATURE_TESTGATE__: flag },
+    build: {
+      write: false,
+      minify: true,
+      lib: { entry, formats: ['es'], fileName: 'out' },
+    },
+  })) as Array<{ output: Array<{ type: string; code?: string }> }>;
+  // `write:false` lib build → RollupOutput[]; concat every emitted chunk.
+  const outputs = Array.isArray(result) ? result : [result];
+  return outputs
+    .flatMap((o) => o.output)
+    .map((c) => ('code' in c && c.code ? c.code : ''))
+    .join('\n');
+}
+
+describe('Track 22 — compile-time gate is dead-code-eliminable', () => {
+  it('flag OFF: gated heavy module is stripped from the bundle', async () => {
+    const out = await bundleWith('false');
+    expect(out).not.toContain(MARKER);
+  });
+
+  it('flag ON: gated heavy module is present (positive control)', async () => {
+    const out = await bundleWith('true');
+    expect(out).toContain(MARKER);
+  });
+});

--- a/src/core/features/__tests__/feature.test.ts
+++ b/src/core/features/__tests__/feature.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Track 22 — Phase 1 substrate tests.
+ *
+ * Under vitest there is no Vite `define`, so `__FEATURE_*__` is undefined and
+ * every flag must resolve to `false` purely via the `typeof` guard — with no
+ * throw and no dependence on process.env. This pins the "test/ts-node
+ * fallback is inert and safe" contract.
+ */
+import { describe, it, expect } from 'vitest';
+import { MCP, A2A, REMOTE_BRIDGE, X402, VOICE, FLAG_SNAPSHOT } from '../feature';
+// Dependency-free .mjs matrix (repo root) — must be importable here too.
+import {
+  featureDefine,
+  FLAG_NAMES,
+  FLAG_DEFAULTS,
+  // @ts-ignore - plain .mjs data module, no types by design
+} from '../../../../vite.featureFlags.mjs';
+
+describe('feature.ts (no Vite define — vitest)', () => {
+  it('every flag is false via the typeof guard, no throw', () => {
+    expect(MCP).toBe(false);
+    expect(A2A).toBe(false);
+    expect(REMOTE_BRIDGE).toBe(false);
+    expect(X402).toBe(false);
+    expect(VOICE).toBe(false);
+  });
+
+  it('does not depend on process.env (delete it, still false)', () => {
+    const saved = process.env.APPLEPI_FEATURE_MCP;
+    delete process.env.APPLEPI_FEATURE_MCP;
+    process.env.APPLEPI_FEATURE_A2A = 'true'; // must NOT leak into compiled const
+    expect(MCP).toBe(false);
+    expect(A2A).toBe(false);
+    if (saved !== undefined) process.env.APPLEPI_FEATURE_MCP = saved;
+    delete process.env.APPLEPI_FEATURE_A2A;
+  });
+
+  it('FLAG_SNAPSHOT keys exactly match the canonical registry', () => {
+    expect(Object.keys(FLAG_SNAPSHOT).sort()).toEqual([...FLAG_NAMES].sort());
+    expect(Object.values(FLAG_SNAPSHOT).every((v) => v === false)).toBe(true);
+  });
+});
+
+describe('vite.featureFlags.mjs', () => {
+  it('FLAG_NAMES matches every per-platform default map', () => {
+    for (const platform of Object.keys(FLAG_DEFAULTS)) {
+      expect(Object.keys(FLAG_DEFAULTS[platform]).sort()).toEqual(
+        [...FLAG_NAMES].sort()
+      );
+    }
+  });
+
+  it('featureDefine emits JSON-stringified booleans keyed __FEATURE_<NAME>__', () => {
+    const d = featureDefine('extension', {});
+    expect(d).toEqual({
+      __FEATURE_MCP__: 'true',
+      __FEATURE_A2A__: 'true',
+      __FEATURE_REMOTE_BRIDGE__: 'false',
+      __FEATURE_X402__: 'false',
+      __FEATURE_VOICE__: 'false',
+    });
+  });
+
+  it('APPLEPI_FEATURE_<NAME> overrides exactly one flag at build time', () => {
+    const d = featureDefine('extension', { APPLEPI_FEATURE_X402: '1' });
+    expect(d.__FEATURE_X402__).toBe('true');
+    expect(d.__FEATURE_MCP__).toBe('true'); // unchanged default
+    expect(d.__FEATURE_VOICE__).toBe('false'); // unchanged default
+    const d2 = featureDefine('desktop', { APPLEPI_FEATURE_VOICE: 'false' });
+    expect(d2.__FEATURE_VOICE__).toBe('false'); // desktop default true -> overridden
+  });
+
+  it('desktop/server defaults differ from extension (per-platform matrix)', () => {
+    expect(featureDefine('extension', {}).__FEATURE_REMOTE_BRIDGE__).toBe('false');
+    expect(featureDefine('desktop', {}).__FEATURE_REMOTE_BRIDGE__).toBe('true');
+    expect(featureDefine('server', {}).__FEATURE_A2A__).toBe('false');
+  });
+
+  it('throws on an unknown platform', () => {
+    expect(() => featureDefine('mobile', {})).toThrow(/unknown platform/);
+  });
+});

--- a/src/core/features/feature.ts
+++ b/src/core/features/feature.ts
@@ -1,0 +1,96 @@
+/**
+ * Track 22 — compile-time feature flags.
+ *
+ * The ONLY module app code imports for compile-time feature gating.
+ *
+ * Mechanism (diverges from claudy on purpose):
+ *   claudy's `feature('X')` folds only because Bun macro-inlines the call.
+ *   Vite `define` is textual identifier substitution and cannot fold an
+ *   object-indexed function return, so we mirror browserx's proven house
+ *   pattern instead: ONE bare typed injected constant per flag (exactly how
+ *   the 80 `__BUILD_MODE__` sites work, e.g. src/config/AgentConfig.ts:76).
+ *
+ *   Each `export const` collapses to a literal after Vite `define` replaces
+ *   `__FEATURE_<NAME>__`, so `if (FLAG) { ... }` is dead-code-eliminated and
+ *   the gated module is tree-shaken. The `typeof ... !== 'undefined'` guard
+ *   only matters under vitest/ts-node where `define` is absent — it is NOT a
+ *   production runtime override (the constant is baked at build time).
+ *
+ *   Do NOT reintroduce a string-keyed `feature(name)` indexed function: it
+ *   defeats both DCE (the headline failure mode) and type-safety. See the
+ *   regression test in feature.deadcode.test.ts.
+ *
+ * Three distinct layers — never conflate (design.md "Two layers"):
+ *   1. COMPILE-TIME — this file. Code physically absent when OFF. Flip = rebuild.
+ *   2. RUNTIME — SessionServices.FeatureFlagRecorder + Track 20 managed policy.
+ *      Code present but inert; flips WITHOUT a rebuild. The fleet/rollout lever.
+ *   3. PLATFORM — __BUILD_MODE__ ('extension' | 'desktop' | 'server'). Which
+ *      product, not which feature.
+ *
+ * ── Flag registry (single source of truth; keep in sync with
+ *    vite.featureFlags.mjs FLAG_NAMES). Every experimental flag MUST carry an
+ *    owning track + remove-by condition: ───────────────────────────────────
+ *   MCP           — existing subsystem; gate is permanent (product tiering).
+ *   A2A           — existing subsystem; gate is permanent (product tiering).
+ *   REMOTE_BRIDGE — Track 21; remove the gate once relay GAs on all targets.
+ *   X402          — Track 23; remove the gate once agentic payments GA.
+ *   VOICE         — voice mode; remove the gate once voice GAs.
+ */
+
+declare const __FEATURE_MCP__: boolean;
+declare const __FEATURE_A2A__: boolean;
+declare const __FEATURE_REMOTE_BRIDGE__: boolean;
+declare const __FEATURE_X402__: boolean;
+declare const __FEATURE_VOICE__: boolean;
+
+/** MCP (Model Context Protocol) bridge subsystem. */
+export const MCP = typeof __FEATURE_MCP__ !== 'undefined' && __FEATURE_MCP__;
+
+/** A2A (agent-to-agent) bridge subsystem. */
+export const A2A = typeof __FEATURE_A2A__ !== 'undefined' && __FEATURE_A2A__;
+
+/** Track 21 — remote bridge / relay host. */
+export const REMOTE_BRIDGE =
+  typeof __FEATURE_REMOTE_BRIDGE__ !== 'undefined' && __FEATURE_REMOTE_BRIDGE__;
+
+/** Track 23 — agentic payments (x402). */
+export const X402 = typeof __FEATURE_X402__ !== 'undefined' && __FEATURE_X402__;
+
+/** Voice mode. */
+export const VOICE = typeof __FEATURE_VOICE__ !== 'undefined' && __FEATURE_VOICE__;
+
+/** Canonical flag name union — the single registry at the type level. */
+export type FlagName = 'MCP' | 'A2A' | 'REMOTE_BRIDGE' | 'X402' | 'VOICE';
+
+/**
+ * Snapshot of every flag's compile-time value. Use ONLY for runtime
+ * attribution (reporting into FeatureFlagRecorder) — never gate on
+ * `FLAG_SNAPSHOT[name]`, that is an indexed lookup that does not DCE. Gate on
+ * the bare `MCP` / `A2A` / ... consts above.
+ */
+export const FLAG_SNAPSHOT: Readonly<Record<FlagName, boolean>> = {
+  MCP,
+  A2A,
+  REMOTE_BRIDGE,
+  X402,
+  VOICE,
+};
+
+/**
+ * Runtime-attribution bridge (layer 2). Reports every compile-time flag's
+ * baked value into a FeatureFlagRecorder when one is present. Structural
+ * param type (not an import of SessionServices) to avoid an import cycle.
+ * No-op when no recorder is supplied (prod default — SessionServices.ts:142).
+ *
+ * This is attribution only: it records what the build baked. It does NOT
+ * gate anything and is NOT the rebuild-free rollout lever (that is the
+ * recorder/Track 20 managed policy deciding a flag's runtime treatment).
+ */
+export function reportFeatureFlags(
+  recorder?: { record(feature: string, enabled: boolean): void }
+): void {
+  if (!recorder) return;
+  for (const name of Object.keys(FLAG_SNAPSHOT) as FlagName[]) {
+    recorder.record(name, FLAG_SNAPSHOT[name]);
+  }
+}

--- a/src/core/session/state/SessionServices.ts
+++ b/src/core/session/state/SessionServices.ts
@@ -6,6 +6,9 @@
 
 import type { RolloutRecorder as StorageRolloutRecorder } from '../../../storage/rollout';
 import type { SessionCacheManager } from '../../../storage/SessionCacheManager';
+// Track 22: compile-time flag values are reported into the recorder here for
+// runtime attribution (layer 2). No-op when no recorder (prod default).
+import { reportFeatureFlags } from '../../features/feature';
 
 /**
  * User notification service interface
@@ -140,6 +143,10 @@ export async function createSessionServices(
 
   // Create default feature flag recorder if not provided
   const featureFlagRecorder = config.featureFlagRecorder ?? (isTest ? new InMemoryFeatureFlagRecorder() : undefined);
+
+  // Track 22: attribute the build's compile-time flag values into the
+  // recorder when one exists (no-op in prod where recorder is undefined).
+  reportFeatureFlags(featureFlagRecorder);
 
   return {
     rollout: config.rollout ?? null, // RolloutRecorder will be initialized by Session

--- a/src/extension/background/service-worker.ts
+++ b/src/extension/background/service-worker.ts
@@ -28,12 +28,16 @@ import { STORAGE_KEYS } from '../../config/defaults';
 import { DEFAULT_APPROVAL_CONFIG } from '../../core/approval/types';
 import { TabManager } from '../../core/TabManager';
 import { LLM_API_URL } from '../../config/constants';
-import { MCPManager } from '../../core/mcp/MCPManager';
-import { registerMCPTools, unregisterMCPTools } from '../../core/mcp/MCPToolAdapter';
+// Track 22: MCP/A2A are gated behind compile-time feature flags. Manager
+// classes and tool-adapter helpers load via dynamic import() inside the
+// feature-gated init blocks, so an OFF build tree-shakes core/mcp +
+// core/a2a out of the extension bundle entirely. Only type-only imports
+// remain at top level (erased at compile time — zero bundle cost).
+import type { MCPManager as MCPManagerT } from '../../core/mcp/MCPManager';
 import type { MCPManagerEvent } from '../../core/mcp/types';
-import { A2AManager } from '../../core/a2a/A2AManager';
-import { registerA2ASkills, unregisterA2ASkills } from '../../core/a2a/A2AToolAdapter';
+import type { A2AManager as A2AManagerT } from '../../core/a2a/A2AManager';
 import type { A2AManagerEvent } from '../../core/a2a/types';
+import { MCP, A2A } from '../../core/features/feature';
 
 // Skills imports
 import { SkillRegistry } from '../../core/skills';
@@ -83,8 +87,8 @@ let registry: AgentRegistry | null = null;
 let cacheManager: CacheManager | null = null;
 let storageQuotaManager: StorageQuotaManager | null = null;
 let agentConfig: AgentConfig | null = null;
-let mcpManager: MCPManager | null = null; // MCP server connection manager
-let a2aManager: A2AManager | null = null; // A2A agent connection manager
+let mcpManager: MCPManagerT | null = null; // MCP server connection manager
+let a2aManager: A2AManagerT | null = null; // A2A agent connection manager
 let currentAuthManager: AuthManager | null = null; // Preserve auth state across agent recreation
 let scheduler: Scheduler | null = null; // Job scheduler
 let schedulerAlarms: SchedulerAlarms | null = null;
@@ -322,26 +326,36 @@ async function doInitialize(): Promise<void> {
   // This ensures backend routing is set up correctly on service worker startup
   await initializeAuthFromConfig();
 
-  // Initialize MCP manager
-  mcpManager = await MCPManager.getInstance();
+  // Track 22: MCP gated behind the MCP compile-time flag. When OFF this
+  // whole block is dead-code-eliminated and the dynamic import() chunk is
+  // never emitted, so core/mcp leaves the extension bundle.
+  if (MCP) {
+    // Initialize MCP manager
+    const { MCPManager } = await import('../../core/mcp/MCPManager');
+    mcpManager = await MCPManager.getInstance();
 
-  // Subscribe to MCP events for tool registration/unregistration
-  setupMCPToolRegistration();
+    // Subscribe to MCP events for tool registration/unregistration
+    await setupMCPToolRegistration();
 
-  // Auto-connect enabled MCP servers (T064: service worker lifecycle handling)
-  await autoConnectEnabledMCPServers();
+    // Auto-connect enabled MCP servers (T064: service worker lifecycle handling)
+    await autoConnectEnabledMCPServers();
+  }
 
   // Setup message handlers
   setupMessageHandlers();
 
-  // Initialize A2A manager
-  a2aManager = await A2AManager.getInstance();
+  // Track 22: A2A gated behind the A2A compile-time flag (same DCE rationale).
+  if (A2A) {
+    // Initialize A2A manager
+    const { A2AManager } = await import('../../core/a2a/A2AManager');
+    a2aManager = await A2AManager.getInstance();
 
-  // Subscribe to A2A events for tool registration/unregistration
-  setupA2AToolRegistration();
+    // Subscribe to A2A events for tool registration/unregistration
+    await setupA2AToolRegistration();
 
-  // Auto-connect enabled A2A agents
-  await autoConnectEnabledA2AAgents();
+    // Auto-connect enabled A2A agents
+    await autoConnectEnabledA2AAgents();
+  }
 
   // Initialize Skills
   await initializeSkills();
@@ -840,11 +854,15 @@ async function autoConnectEnabledMCPServers(): Promise<void> {
  * Registers/unregisters MCP tools with ToolRegistry when connections change
  * Applies to all active sessions' tool registries.
  */
-function setupMCPToolRegistration(): void {
+async function setupMCPToolRegistration(): Promise<void> {
   if (!mcpManager || !registry) {
     console.warn('[ServiceWorker] Cannot setup MCP tool registration - manager or registry not ready');
     return;
   }
+
+  // Track 22: only reached when the MCP flag is ON (caller is gated), so this
+  // dynamic import keeps core/mcp/MCPToolAdapter out of OFF builds.
+  const { registerMCPTools } = await import('../../core/mcp/MCPToolAdapter');
 
   /** Get tool registries from all active sessions */
   function getAllToolRegistries() {
@@ -936,11 +954,15 @@ function setupMCPToolRegistration(): void {
  * Registers/unregisters A2A skills with ToolRegistry when connections change.
  * Mirrors the setupMCPToolRegistration() pattern.
  */
-function setupA2AToolRegistration(): void {
+async function setupA2AToolRegistration(): Promise<void> {
   if (!a2aManager || !registry) {
     console.warn('[ServiceWorker] Cannot setup A2A tool registration - manager or registry not ready');
     return;
   }
+
+  // Track 22: only reached when the A2A flag is ON (caller is gated), so this
+  // dynamic import keeps core/a2a/A2AToolAdapter out of OFF builds.
+  const { registerA2ASkills } = await import('../../core/a2a/A2AToolAdapter');
 
   /** Get tool registries from all active sessions */
   function getAllToolRegistries() {

--- a/src/extension/background/service-worker.ts
+++ b/src/extension/background/service-worker.ts
@@ -335,7 +335,8 @@ async function doInitialize(): Promise<void> {
     mcpManager = await MCPManager.getInstance();
 
     // Subscribe to MCP events for tool registration/unregistration
-    await setupMCPToolRegistration();
+    // (sync — handler attaches immediately, before any auto-connect)
+    setupMCPToolRegistration();
 
     // Auto-connect enabled MCP servers (T064: service worker lifecycle handling)
     await autoConnectEnabledMCPServers();
@@ -351,7 +352,8 @@ async function doInitialize(): Promise<void> {
     a2aManager = await A2AManager.getInstance();
 
     // Subscribe to A2A events for tool registration/unregistration
-    await setupA2AToolRegistration();
+    // (sync — handler attaches immediately, before any auto-connect)
+    setupA2AToolRegistration();
 
     // Auto-connect enabled A2A agents
     await autoConnectEnabledA2AAgents();
@@ -854,15 +856,11 @@ async function autoConnectEnabledMCPServers(): Promise<void> {
  * Registers/unregisters MCP tools with ToolRegistry when connections change
  * Applies to all active sessions' tool registries.
  */
-async function setupMCPToolRegistration(): Promise<void> {
+function setupMCPToolRegistration(): void {
   if (!mcpManager || !registry) {
     console.warn('[ServiceWorker] Cannot setup MCP tool registration - manager or registry not ready');
     return;
   }
-
-  // Track 22: only reached when the MCP flag is ON (caller is gated), so this
-  // dynamic import keeps core/mcp/MCPToolAdapter out of OFF builds.
-  const { registerMCPTools } = await import('../../core/mcp/MCPToolAdapter');
 
   /** Get tool registries from all active sessions */
   function getAllToolRegistries() {
@@ -905,6 +903,11 @@ async function setupMCPToolRegistration(): Promise<void> {
 
         // Register new tools on all sessions
         try {
+          // Track 22: lazy adapter import — keeps core/mcp/MCPToolAdapter out
+          // of OFF builds (this whole function is unreferenced when MCP is
+          // off, so it tree-shakes), without delaying the .on() subscription
+          // above. import() is cached after the first event.
+          const { registerMCPTools } = await import('../../core/mcp/MCPToolAdapter');
           for (const tr of getAllToolRegistries()) {
             await registerMCPTools(mcpManager!, serverName, tools, tr);
           }
@@ -954,15 +957,11 @@ async function setupMCPToolRegistration(): Promise<void> {
  * Registers/unregisters A2A skills with ToolRegistry when connections change.
  * Mirrors the setupMCPToolRegistration() pattern.
  */
-async function setupA2AToolRegistration(): Promise<void> {
+function setupA2AToolRegistration(): void {
   if (!a2aManager || !registry) {
     console.warn('[ServiceWorker] Cannot setup A2A tool registration - manager or registry not ready');
     return;
   }
-
-  // Track 22: only reached when the A2A flag is ON (caller is gated), so this
-  // dynamic import keeps core/a2a/A2AToolAdapter out of OFF builds.
-  const { registerA2ASkills } = await import('../../core/a2a/A2AToolAdapter');
 
   /** Get tool registries from all active sessions */
   function getAllToolRegistries() {
@@ -1001,6 +1000,11 @@ async function setupA2AToolRegistration(): Promise<void> {
 
         // Register new skills on all sessions
         try {
+          // Track 22: lazy adapter import — keeps core/a2a/A2AToolAdapter out
+          // of OFF builds (this whole function is unreferenced when A2A is
+          // off, so it tree-shakes), without delaying the .on() subscription
+          // above. import() is cached after the first event.
+          const { registerA2ASkills } = await import('../../core/a2a/A2AToolAdapter');
           for (const tr of getAllToolRegistries()) {
             await registerA2ASkills(a2aManager!, agentName, skills, tr, a2aAgentConfig.trusted);
           }

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -14,10 +14,27 @@
 declare const __BUILD_MODE__: 'extension' | 'desktop' | 'server' | 'mobile';
 
 /**
+ * Track 22 — compile-time feature flags, injected by Vite `define` from
+ * vite.featureFlags.mjs. Bare constants so they constant-fold + tree-shake
+ * exactly like __BUILD_MODE__. App code reads them via src/core/features/feature.ts,
+ * not these globals directly.
+ */
+declare const __FEATURE_MCP__: boolean;
+declare const __FEATURE_A2A__: boolean;
+declare const __FEATURE_REMOTE_BRIDGE__: boolean;
+declare const __FEATURE_X402__: boolean;
+declare const __FEATURE_VOICE__: boolean;
+
+/**
  * Augment the global scope
  */
 declare global {
   const __BUILD_MODE__: 'extension' | 'desktop' | 'server' | 'mobile';
+  const __FEATURE_MCP__: boolean;
+  const __FEATURE_A2A__: boolean;
+  const __FEATURE_REMOTE_BRIDGE__: boolean;
+  const __FEATURE_X402__: boolean;
+  const __FEATURE_VOICE__: boolean;
 }
 
 export {};

--- a/vite.config.content.mjs
+++ b/vite.config.content.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { featureDefine } from './vite.featureFlags.mjs';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -10,6 +11,9 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 export default defineConfig({
   define: {
     __BUILD_MODE__: JSON.stringify('extension'),
+    // Track 22 — same extension matrix as vite.config.mjs. Note this build
+    // uses inlineDynamicImports:true, so OFF flags strip via DCE only.
+    ...featureDefine('extension', process.env),
   },
   plugins: [
     svelte({

--- a/vite.config.desktop.mts
+++ b/vite.config.desktop.mts
@@ -3,6 +3,8 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 import sveltePreprocess from 'svelte-preprocess';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
+// @ts-ignore - plain .mjs data module, no types (dependency-free by design)
+import { featureDefine } from './vite.featureFlags.mjs';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -26,6 +28,8 @@ export default defineConfig({
   envDir: resolve(__dirname, 'src/desktop'), // Load .env from src/desktop
   define: {
     __BUILD_MODE__: JSON.stringify('desktop'),
+    // Track 22 — desktop matrix (heavier subsystems default ON here).
+    ...featureDefine('desktop', process.env),
   },
   build: {
     rollupOptions: {

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
+import { featureDefine } from './vite.featureFlags.mjs';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -114,6 +115,9 @@ export default defineConfig({
   envDir: resolve(__dirname, 'src/extension'), // Load .env from src/extension
   define: {
     __BUILD_MODE__: JSON.stringify('extension'),
+    // Track 22 — compile-time feature flags (per-platform matrix). The SW
+    // has no process.env; APPLEPI_FEATURE_* here is a build-time-only knob.
+    ...featureDefine('extension', process.env),
   },
   build: {
     // Disable modulePreload completely - the polyfill uses `document` which doesn't exist in service workers

--- a/vite.config.server.mts
+++ b/vite.config.server.mts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
+// @ts-ignore - plain .mjs data module, no types (dependency-free by design)
+import { featureDefine } from './vite.featureFlags.mjs';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -11,6 +13,9 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 export default defineConfig({
   define: {
     __BUILD_MODE__: JSON.stringify('server'),
+    // Track 22 — server matrix. Bundle size barely matters here; the value
+    // is keeping unvetted experimental paths out of the production image.
+    ...featureDefine('server', process.env),
   },
   build: {
     ssr: resolve(__dirname, 'src/server/index.ts'),

--- a/vite.featureFlags.mjs
+++ b/vite.featureFlags.mjs
@@ -1,0 +1,71 @@
+// vite.featureFlags.mjs
+//
+// Track 22 — single dependency-free feature-flag default matrix.
+//
+// This file is the ONLY source of compile-time feature defaults. It is plain
+// data + one helper, with ZERO `@/`/TypeScript/app imports, so it can be
+// imported by the plain `.mjs` Vite configs at Node config-eval time (which
+// cannot load a `.ts` or `@/`-aliased module). `src/core/features/feature.ts`
+// re-states the same flag set as typed constants for app code.
+//
+// Two layers — do not conflate (see design.md "Two layers"):
+//   - COMPILE-TIME (this file -> Vite `define` -> __FEATURE_*__): code is
+//     physically present/absent in the artifact. Flipping requires a REBUILD.
+//   - RUNTIME (FeatureFlagRecorder + Track 20): code is present but inert;
+//     flips without a rebuild. NOT this file.
+//
+// `APPLEPI_FEATURE_<NAME>` env vars override a default at BUILD time only
+// (they change what gets baked) — they are a CI/per-build knob, never a
+// production runtime override. The extension service worker has no
+// `process.env` at all, so an extension flag is a pure baked constant.
+
+/** Canonical flag registry. Keep in sync with feature.ts `FlagName`. */
+export const FLAG_NAMES = ['MCP', 'A2A', 'REMOTE_BRIDGE', 'X402', 'VOICE'];
+
+/**
+ * Per-platform compile-time defaults.
+ *
+ * Behavior-preserving rule: a subsystem that ships TODAY defaults ON on every
+ * platform it currently ships on, so this track introduces the *ability* to
+ * gate it without changing what users get. Only genuinely not-yet-shipping
+ * experimental subsystems default OFF.
+ *
+ *   - MCP / A2A  : shipping in the extension SW today -> ON (gateable; the
+ *                  OFF path is exercised by forced-OFF analyzer builds, not by
+ *                  default, so this PR is a no-op for users).
+ *   - REMOTE_BRIDGE (Track 21) : not built yet -> OFF everywhere; desktop ON
+ *                  once it lands (host worker is a desktop concern).
+ *   - X402 (Track 23) : not built yet -> OFF everywhere until vetted.
+ *   - VOICE      : not built yet -> OFF on extension (size); desktop ON later.
+ */
+export const FLAG_DEFAULTS = {
+  extension: { MCP: true,  A2A: true,  REMOTE_BRIDGE: false, X402: false, VOICE: false },
+  desktop:   { MCP: true,  A2A: true,  REMOTE_BRIDGE: true,  X402: false, VOICE: true  },
+  server:    { MCP: true,  A2A: false, REMOTE_BRIDGE: false, X402: false, VOICE: false },
+};
+
+/**
+ * Build the Vite `define` fragment for a platform.
+ *
+ * @param {keyof typeof FLAG_DEFAULTS} platform
+ * @param {Record<string, string | undefined>} [env]  typically process.env
+ * @returns {Record<string, string>}  e.g. { __FEATURE_MCP__: "true", ... }
+ *          (values are JSON.stringify'd booleans, exactly like __BUILD_MODE__)
+ */
+export function featureDefine(platform, env = {}) {
+  const defaults = FLAG_DEFAULTS[platform];
+  if (!defaults) {
+    throw new Error(
+      `featureDefine: unknown platform "${platform}" (expected one of ${Object.keys(FLAG_DEFAULTS).join(', ')})`
+    );
+  }
+  /** @type {Record<string, string>} */
+  const out = {};
+  for (const name of FLAG_NAMES) {
+    const override = env[`APPLEPI_FEATURE_${name}`];
+    const value =
+      override === undefined ? defaults[name] : override === '1' || override === 'true';
+    out[`__FEATURE_${name}__`] = JSON.stringify(value);
+  }
+  return out;
+}


### PR DESCRIPTION
Implements [Track 22](.ai_design/agent_improvements/22_feature_flags_lazy_loading/design.md) end-to-end. Design + tasks were committed to `agent-improvements` separately; this PR is the implementation only.

## What this does

A compile-time feature switch that **physically removes a subsystem's code from the shipped bundle when its flag is OFF** — so heavy/experimental subsystems can ship dark without bloating the size-critical extension. Kept strictly separate from the existing runtime `FeatureFlagRecorder` layer.

## Phases (all complete)

- **Phase 1 — substrate.** `vite.featureFlags.mjs` (single dependency-free per-platform default matrix + `featureDefine()`), `src/core/features/feature.ts` (one bare typed injected constant per flag — mirrors the 80 existing `__BUILD_MODE__` sites; **no** indexed `feature('X')`, which would defeat DCE), `__FEATURE_*` ambient decls, wired into all four Vite configs.
- **Phase 0 — SW strip spike (RESOLVED → GO).** The design flagged a real blocker: the design's original "gate a dynamic `import()`" mechanism vs. `service-worker.ts:49-51` claiming dynamic import is banned in MV3 SWs (while `:992` ships one anyway). **Resolved empirically** — a controlled A/B build (identical source, only flags differ) shows forcing MCP+A2A OFF removes **~335 KB** (`core/mcp` + `core/a2a` fully absent from emitted JS); ON re-includes them. Dynamic import works fine in this Vite/MV3 setup; no side-effect pinning, so no refactor needed. Full write-up: `phase0-sw-strip-decision.md`.
- **Phase 2 — gate MCP + A2A** in `service-worker.ts`: manager classes/adapters are `import type` only at top level, loaded via dynamic `import()` inside `if (MCP)` / `if (A2A)` init blocks. **Defaults are ON everywhere they ship today → this PR is behavior-preserving for users**; the OFF path is a proven build-time capability for the future product-tiering direction.
- **Phase 3 — discipline + attribution.** Flag registry + per-flag expiry notes; three-layer split documented; `reportFeatureFlags()` reports baked values into `FeatureFlagRecorder` (no-op in prod); a Vite-based regression test asserts a gated module is absent when OFF / present when ON (fails loudly if `feature.ts` regresses).

## Verification

- `tsc --noEmit`: clean (exit 0) — all build modes.
- 10 new feature tests green (incl. the faithful Vite+Rollup DCE guard).
- 101 affected existing tests green (`session-services`, `SessionServices`, `FreshSession`, `diagnostics/checks`).
- Extension OFF **and** ON builds succeed.

## Honest caveats

- Correctness verified at **build/bundle level** (chunk emission, string absence, ~335 KB delta) + unit/regression/type/affected-suite tests. A packaged extension in a **live Chrome MV3 runtime was not exercised** in this environment; the gated dynamic-import path is shape-identical to the already-shipping `service-worker.ts:992` import, so residual risk is low but non-zero — recommend a manual smoke of an MCP-enabled packaged build before flipping any default OFF.
- Full `npm test` (Rust + entire vitest suite) was **not** run — it is heavy and largely unrelated; the targeted runs cover the changed surface.
- `REMOTE_BRIDGE` / `X402` / `VOICE` flags exist but have no subsystems yet (Tracks 21/23 deferred) — they default OFF and are wired for when those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)