### PR TITLE
[codex] Implement Track 40 subagent runtime modes

### DIFF
--- a/src/core/AgentTask.ts
+++ b/src/core/AgentTask.ts
@@ -47,6 +47,7 @@ export class AgentTask {
     input: ResponseItem[],
     options?: {
       maxTurns?: number;
+      drainPendingMessages?: () => string[];
       /**
        * (Track 04) Optional output store + task id. When provided, the
        * underlying TaskRunner persists chunks for background-task panels
@@ -74,6 +75,7 @@ export class AgentTask {
       {
         autoCompact: true,
         maxTurns: options?.maxTurns,
+        drainPendingMessages: options?.drainPendingMessages,
         taskOutputStore: options?.taskOutputStore,
         taskId: options?.taskId,
       }

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -127,6 +127,13 @@ export class Session {
   // Title generation stage: 0 = not started, 1 = generated at 2 messages, 2 = generated at 5 messages (final)
   private titleGenerationStage: number = 0;
   private initializationPromise: Promise<void> | null = null;
+  /**
+   * Fatal initialization error for a non-persistent child/forked session.
+   * A forked sub-agent told it inherited the parent conversation must not
+   * silently run with empty history, so this is surfaced from initialize()
+   * rather than swallowed (see constructor non-persistent branch).
+   */
+  private initError: Error | null = null;
   private hookDispatcher: HookDispatcher | null = null;
 
   // Track 05b: per-session post-turn callbacks (e.g. session-summary
@@ -277,6 +284,12 @@ export class Session {
       // in-memory history before the first turn runs.
       this.initializationPromise = this.recordInitialHistory(historyMode).catch(err => {
         console.error('Failed to initialize non-persistent session history:', err);
+        // Forked/child context is a correctness precondition: surface the
+        // failure via initialize() so the sub-agent runner reports an error
+        // instead of running with empty history. Recorded as a flag rather
+        // than a rejected promise to avoid an unhandled-rejection before
+        // initialize() is awaited.
+        this.initError = err instanceof Error ? err : new Error(String(err));
       });
     }
   }
@@ -594,6 +607,9 @@ export class Session {
     // Wait for background initialization if it's in progress
     if (this.initializationPromise) {
       await this.initializationPromise;
+    }
+    if (this.initError) {
+      throw this.initError;
     }
     return Promise.resolve();
   }

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -272,6 +272,12 @@ export class Session {
       this.initializationPromise = this.initializeSession('resume', this.sessionId, this.config).catch(err => {
         console.error('Failed to resume session:', err);
       });
+    } else if (!this.isPersistent && historyMode.mode !== 'new') {
+      // Child/forked sessions are non-persistent but still need the provided
+      // in-memory history before the first turn runs.
+      this.initializationPromise = this.recordInitialHistory(historyMode).catch(err => {
+        console.error('Failed to initialize non-persistent session history:', err);
+      });
     }
   }
 

--- a/src/core/__tests__/Session.test.ts
+++ b/src/core/__tests__/Session.test.ts
@@ -207,6 +207,29 @@ describe('Session', () => {
       await session.initialize();
       await expect(session.initialize()).resolves.toBeUndefined();
     });
+
+    it('surfaces a non-persistent forked history init failure instead of swallowing it', async () => {
+      // Regression: a forked sub-agent is told it inherited the parent
+      // conversation. If reconstruct/persist fails it must NOT silently run
+      // with empty history — initialize() has to reject so the runner reports it.
+      const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const recordSpy = vi
+        .spyOn(Session.prototype as any, 'recordInitialHistory')
+        .mockRejectedValue(new Error('forked reconstruct failed'));
+
+      try {
+        const session = new Session(undefined, false, undefined, undefined, {
+          mode: 'forked',
+          sourceConversationId: 'parent-session',
+          rolloutItems: [],
+        });
+        await expect(session.initialize()).rejects.toThrow('forked reconstruct failed');
+        expect(consoleErr).toHaveBeenCalled();
+      } finally {
+        recordSpy.mockRestore();
+        consoleErr.mockRestore();
+      }
+    });
   });
 
   // =========================================================================

--- a/src/core/engine/RepublicAgentEngine.ts
+++ b/src/core/engine/RepublicAgentEngine.ts
@@ -75,6 +75,7 @@ export class RepublicAgentEngine {
         this.config.persistent ?? false,
         undefined,
         this.toolRegistry,
+        this.config.initialHistory,
       );
 
       // Apply config values (systemPrompt, userInstructions, model) to the session's TurnContext.
@@ -114,6 +115,10 @@ export class RepublicAgentEngine {
     // and the engine's getTaskOutput can both reach the same backing store.
     if (this.session && this.config.taskOutputStore) {
       this.session.setTaskOutputStore(this.config.taskOutputStore);
+    }
+
+    if (this.ownsSession && this.session?.initialize) {
+      await this.session.initialize();
     }
 
     // Setup approval system
@@ -393,6 +398,7 @@ export class RepublicAgentEngine {
     depth?: number;
     maxDepth?: number;
     drainPendingMessages?: () => string[];
+    initialHistory?: RepublicAgentEngineConfig['initialHistory'];
     /** (Track 04) Inherit parent's TaskOutputStore so sub-agent's TaskRunner writes chunks. */
     taskOutputStore?: RepublicAgentEngineConfig['taskOutputStore'];
   }): RepublicAgentEngine {
@@ -412,6 +418,7 @@ export class RepublicAgentEngine {
       depth: childConfig.depth ?? (this.getDepth() + 1),
       maxDepth: childConfig.maxDepth ?? this.getMaxDepth(),
       drainPendingMessages: childConfig.drainPendingMessages,
+      initialHistory: childConfig.initialHistory,
       taskOutputStore: childConfig.taskOutputStore ?? this.config.taskOutputStore,
     });
   }
@@ -551,7 +558,10 @@ export class RepublicAgentEngine {
       // Create RegularTask and delegate to Session.spawnTask()
       // Pass maxTurns from engine config so sub-agents enforce their turn limits.
       const { RegularTask } = await import('../tasks/RegularTask');
-      const task = new RegularTask({ maxTurns: this.config.maxTurns });
+      const task = new RegularTask({
+        maxTurns: this.config.maxTurns,
+        drainPendingMessages: this.config.drainPendingMessages,
+      });
 
       await this.session.spawnTask(task, turnContext, submissionId, protocolItems);
 

--- a/src/core/engine/RepublicAgentEngineConfig.ts
+++ b/src/core/engine/RepublicAgentEngineConfig.ts
@@ -9,6 +9,7 @@ import type { Session } from '../Session';
 import type { ApprovalManager } from '../ApprovalManager';
 import type { AskForApproval, ReviewDecision } from '../protocol/types';
 import type { IBrowserController } from '../platform/IPlatformAdapter';
+import type { InitialHistory } from '../session/state/types';
 
 export interface RepublicAgentEngineConfig {
   /** AgentConfig instance (shared — for credentials and provider info) */
@@ -116,7 +117,7 @@ export interface RepublicAgentEngineConfig {
   /**
    * Initial conversation history (for session recovery).
    */
-  initialHistory?: ConversationEntry[];
+  initialHistory?: InitialHistory;
 }
 
 export interface EngineResult {

--- a/src/core/plugins/loaders/SubAgentSlotLoader.ts
+++ b/src/core/plugins/loaders/SubAgentSlotLoader.ts
@@ -19,6 +19,12 @@
 
 import type { SubAgentRunner } from '@/tools/AgentTool/SubAgentRunner';
 import type { SubAgentTypeConfig } from '@/tools/AgentTool/types';
+import {
+  AgentType,
+  SubAgentContextMode,
+  isAgentType,
+  isSubAgentContextMode,
+} from '@/tools/AgentTool/agentTypes';
 import type { LoadedPlugin, PluginError, PluginId } from '../types';
 import { substituteContent } from '../userConfigSubstitution';
 import type { FileReader, DirLister } from './SkillSlotLoader';
@@ -88,11 +94,16 @@ export class SubAgentSlotLoader {
         try {
           const { frontmatter, body } = parseFrontmatter(content);
           const bareName = frontmatter.name || basenameNoExt(entry);
+          const allowedContextModes = parseContextModes(frontmatter.allowedContextModes);
           const config: SubAgentTypeConfig = {
             id: `${pluginName}:${bareName}`,
             name: frontmatter.name || bareName,
             description: frontmatter.description || `Plugin-defined: ${bareName}`,
             systemPrompt: substituteContent(body, plugin, userConfig),
+            agentType: parsePluginAgentType(frontmatter.agentType),
+            defaultContextMode: parseContextMode(frontmatter.defaultContextMode)
+              ?? allowedContextModes[0],
+            allowedContextModes,
             maxTurns: parseIntSafe(frontmatter.maxTurns),
             // model intentionally not exposed via frontmatter parsing in v1
           };
@@ -150,6 +161,34 @@ function parseIntSafe(s: string | undefined): number | undefined {
   if (s == null) return undefined;
   const n = parseInt(s, 10);
   return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+function parsePluginAgentType(s: string | undefined): AgentType {
+  if (s == null || s === '') return AgentType.GeneralPurpose;
+  if (!isAgentType(s) || s === AgentType.Internal) {
+    throw new Error(`Invalid plugin agentType: ${s}`);
+  }
+  return s;
+}
+
+function parseContextMode(s: string | undefined): SubAgentContextMode | undefined {
+  if (s == null || s === '') return undefined;
+  if (!isSubAgentContextMode(s)) {
+    throw new Error(`Invalid sub-agent context mode: ${s}`);
+  }
+  return s;
+}
+
+function parseContextModes(s: string | undefined): SubAgentContextMode[] {
+  if (s == null || s === '') return [SubAgentContextMode.Isolated];
+  const modes = s.split(',').map((v) => v.trim()).filter(Boolean);
+  if (modes.length === 0) return [SubAgentContextMode.Isolated];
+  for (const mode of modes) {
+    if (!isSubAgentContextMode(mode)) {
+      throw new Error(`Invalid sub-agent context mode: ${mode}`);
+    }
+  }
+  return modes as SubAgentContextMode[];
 }
 
 // SECURITY (Track 10): jail untrusted manifest agent paths under root.

--- a/src/core/protocol/events.ts
+++ b/src/core/protocol/events.ts
@@ -119,6 +119,7 @@ export type EventMsg =
   | { type: 'SubAgentStart'; data: SubAgentStartEvent }
   | { type: 'SubAgentComplete'; data: SubAgentCompleteEvent }
   | { type: 'SubAgentError'; data: SubAgentErrorEvent }
+  | { type: 'SubAgentWarning'; data: SubAgentWarningEvent }
   // Session summary telemetry (internal observability; UI ignores by default)
   | { type: 'SessionSummaryTelemetry'; data: SessionSummaryTelemetryEventData }
   // Track 04: typed-task layer events (background sub-agents only in v1)
@@ -863,12 +864,18 @@ export interface HookBlockedEvent {
 export interface SubAgentStartEvent {
   runId: string;
   subAgentType: string;
+  agentType?: string;
+  contextMode?: string;
+  executionMode?: string;
   description: string;
 }
 
 export interface SubAgentCompleteEvent {
   runId: string;
   subAgentType: string;
+  agentType?: string;
+  contextMode?: string;
+  executionMode?: string;
   turnCount: number;
   tokenUsage?: {
     input: number;
@@ -879,8 +886,13 @@ export interface SubAgentCompleteEvent {
 }
 
 export interface SubAgentErrorEvent {
-  runId: string;
-  subAgentType: string;
+  runId?: string;
+  subAgentType?: string;
   error: string;
 }
 
+export interface SubAgentWarningEvent {
+  runId: string;
+  subAgentType: string;
+  warning: string;
+}

--- a/src/core/skills/SkillExecutor.ts
+++ b/src/core/skills/SkillExecutor.ts
@@ -17,6 +17,7 @@ import type { HookRegistry } from '@/core/hooks/HookRegistry';
 import { SessionHookStore } from '@/core/hooks/loaders/SessionHookStore';
 import { substituteVariables } from './SkillParser';
 import { registerSkillScopedHooks } from './registerSkillScopedHooks';
+import { SubAgentContextMode } from '@/tools/AgentTool/agentTypes';
 
 /**
  * Shape of the sub_agent invocation. Matches the JSON the sub_agent tool
@@ -36,6 +37,7 @@ export interface SubAgentInvocationParams {
   type: string;
   prompt: string;
   description: string;
+  contextMode?: import('@/tools/AgentTool/agentTypes').SubAgentContextMode;
 }
 
 export type SubAgentInvoker = (params: SubAgentInvocationParams) => Promise<SubAgentResult>;
@@ -129,6 +131,7 @@ export class SkillExecutor {
           type: skill.agent!,
           prompt: body,
           description: `Skill: ${skillName}`,
+          contextMode: SubAgentContextMode.Fork,
         });
         return {
           success: result.success,

--- a/src/core/skills/__tests__/SkillExecutor.test.ts
+++ b/src/core/skills/__tests__/SkillExecutor.test.ts
@@ -84,6 +84,7 @@ describe('SkillExecutor — forked', () => {
       type: 'general-purpose',
       prompt: 'Do thing',
       description: 'Skill: test-skill',
+      contextMode: 'fork',
     });
     expect(result.status).toBe('forked');
     if (result.status === 'forked') {

--- a/src/core/skills/__tests__/SkillExecutor.test.ts
+++ b/src/core/skills/__tests__/SkillExecutor.test.ts
@@ -127,6 +127,26 @@ describe('SkillExecutor — forked', () => {
       expect(result.error).toBe('sub-agent crashed');
     }
   });
+
+  it("surfaces a clear error when the skill's agent does not allow fork", async () => {
+    // SkillExecutor always requests contextMode: 'fork'. If the skill points
+    // at an agent type whose allowedContextModes excludes fork, the runner
+    // rejects it and that reason must reach the caller verbatim (not be
+    // swallowed into a generic failure).
+    const skill = baseSkill({ context: 'fork', agent: 'isolated-only' });
+    const subAgentInvoker: SubAgentInvoker = async () => ({
+      success: false,
+      runId: 'run-rejected',
+      error: "Sub-agent type 'isolated-only' does not allow context mode 'fork'",
+    });
+    const exec = new SkillExecutor(makeRegistry(skill), hookRegistry, subAgentInvoker);
+    const result = await exec.execute('test-skill', '');
+    expect(result.status).toBe('forked');
+    if (result.status === 'forked') {
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/does not allow context mode 'fork'/);
+    }
+  });
 });
 
 describe('SkillExecutor — skill-scoped hooks', () => {

--- a/src/core/skills/buildSubAgentInvoker.ts
+++ b/src/core/skills/buildSubAgentInvoker.ts
@@ -48,7 +48,11 @@ export function buildSubAgentInvoker(
     try {
       const exec = await registry.execute({
         toolName: 'sub_agent',
-        parameters: { ...subParams, background: false },
+        parameters: {
+          ...subParams,
+          context_mode: subParams.contextMode,
+          background: false,
+        },
         sessionId: ctx.sessionId,
         turnId: ctx.turnId,
         callId: ctx.callId,

--- a/src/core/tasks/RegularTask.ts
+++ b/src/core/tasks/RegularTask.ts
@@ -21,9 +21,11 @@ import type { ToolRegistry } from '../../tools/ToolRegistry';
 export class RegularTask implements SessionTask {
   private agentTask: AgentTask | null = null;
   private maxTurns?: number;
+  private drainPendingMessages?: () => string[];
 
-  constructor(options?: { maxTurns?: number }) {
+  constructor(options?: { maxTurns?: number; drainPendingMessages?: () => string[] }) {
     this.maxTurns = options?.maxTurns;
+    this.drainPendingMessages = options?.drainPendingMessages;
   }
 
   /**
@@ -75,6 +77,7 @@ export class RegularTask implements SessionTask {
       responseItems,
       {
         maxTurns: this.maxTurns,
+        drainPendingMessages: this.drainPendingMessages,
         taskOutputStore: taskOutputStore ?? undefined,
         taskId: taskOutputStore ? subId : undefined,
       }

--- a/src/core/tasks/types.ts
+++ b/src/core/tasks/types.ts
@@ -74,6 +74,12 @@ export interface TaskStateBase {
 
 export interface BackgroundAgentTaskState extends TaskStateBase {
   type: 'background_agent';
+  /** Track 40: enum-backed runtime behavior identity */
+  agentType?: import('@/tools/AgentTool/agentTypes').AgentType;
+  /** Track 40: isolated vs forked-subagent context mode */
+  contextMode?: import('@/tools/AgentTool/agentTypes').SubAgentContextMode;
+  /** Track 40: foreground/background execution mode */
+  executionMode?: import('@/tools/AgentTool/agentTypes').SubAgentExecutionMode;
   /** Joins back to SubAgentRegistry; equals `id` for v1 (identity collapse) */
   runId: string;
   /** Parent session that spawned this sub-agent */

--- a/src/tools/AgentTool/SubAgentRunner.ts
+++ b/src/tools/AgentTool/SubAgentRunner.ts
@@ -6,6 +6,9 @@ import { SubAgentEventRouter } from '@/core/events/SubAgentEventRouter';
 import { createSubAgentToolRegistry } from '../ToolRegistryCloner';
 import { SubAgentRegistry } from './SubAgentRegistry';
 import { BUILTIN_SUBAGENT_TYPES } from './builtinTypes';
+import { SubAgentContextMode } from './agentTypes';
+import { resolveSubAgentBehavior } from './behavior';
+import { buildForkedSubAgentInitialHistory } from './forkContext';
 import type {
   SubAgentTypeConfig,
   SubAgentToolParams,
@@ -18,7 +21,10 @@ import type {
 } from './types';
 import type { BackgroundAgentTaskState } from '@/core/tasks/types';
 import { PANEL_GRACE_MS } from '@/core/tasks/timing';
-import { assertValidSubAgentTypeConfig } from './validateTypeConfig';
+import {
+  assertValidSubAgentTypeConfig,
+  normalizeSubAgentTypeConfig,
+} from './validateTypeConfig';
 
 /**
  * Source tag for sub-agent type registrations. Used by the plugin port
@@ -69,13 +75,13 @@ export class SubAgentRunner implements IAgentRunner {
 
     // Register built-in types
     for (const type of BUILTIN_SUBAGENT_TYPES) {
-      this.types.set(type.id, type);
+      this.types.set(type.id, normalizeSubAgentTypeConfig(type, { allowInternal: true }));
     }
 
     // Register custom types (from constructor — typically config-sourced)
     if (options.customTypes) {
       for (const type of options.customTypes) {
-        this.types.set(type.id, type);
+        this.types.set(type.id, normalizeSubAgentTypeConfig(type));
       }
     }
     // No onTypesChanged fires during construction — the outer
@@ -165,30 +171,31 @@ export class SubAgentRunner implements IAgentRunner {
    */
   async addType(config: SubAgentTypeConfig, source: SubAgentTypeSource): Promise<void> {
     assertValidSubAgentTypeConfig(config);
+    const normalizedConfig = normalizeSubAgentTypeConfig(config);
     if (source.type === 'plugin') {
-      const owner = this.pluginTypeOwner.get(config.id);
-      if (owner === undefined && this.types.has(config.id)) {
+      const owner = this.pluginTypeOwner.get(normalizedConfig.id);
+      if (owner === undefined && this.types.has(normalizedConfig.id)) {
         throw new Error(
-          `Plugin '${source.pluginId}' cannot register sub-agent type '${config.id}': ` +
+          `Plugin '${source.pluginId}' cannot register sub-agent type '${normalizedConfig.id}': ` +
             `id is already held by a builtin or config-supplied type`,
         );
       }
       if (owner !== undefined && owner !== source.pluginId) {
         throw new Error(
-          `Plugin '${source.pluginId}' cannot register sub-agent type '${config.id}': ` +
+          `Plugin '${source.pluginId}' cannot register sub-agent type '${normalizedConfig.id}': ` +
             `id is already owned by plugin '${owner}'`,
         );
       }
-      this.types.set(config.id, config);
+      this.types.set(normalizedConfig.id, normalizedConfig);
       let set = this.pluginTypeIndex.get(source.pluginId);
       if (!set) {
         set = new Set();
         this.pluginTypeIndex.set(source.pluginId, set);
       }
-      set.add(config.id);
-      this.pluginTypeOwner.set(config.id, source.pluginId);
+      set.add(normalizedConfig.id);
+      this.pluginTypeOwner.set(normalizedConfig.id, source.pluginId);
     } else {
-      this.types.set(config.id, config);
+      this.types.set(normalizedConfig.id, normalizedConfig);
     }
     await this.scheduleRebuild();
   }
@@ -301,25 +308,26 @@ export class SubAgentRunner implements IAgentRunner {
             context,
             this.formatTaskNotification(context, params, result),
           );
-          // (Track 04) Update typed state to terminal on parent session.
-          this.markTypedTaskTerminated(context, result);
         }
+        // (Track 04) Update typed state to terminal on parent session even
+        // when quietBackground suppresses LLM-visible notification delivery.
+        this.markTypedTaskTerminated(context, result);
       } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error);
+        const failed: AgentRunResult = {
+          success: false,
+          response: '',
+          turnCount: 0,
+          stopReason: 'error',
+          error: errorMsg,
+        };
         if (!suppressNotification()) {
-          const failed: AgentRunResult = {
-            success: false,
-            response: '',
-            turnCount: 0,
-            stopReason: 'error',
-            error: errorMsg,
-          };
           this.safeEnqueueNotification(
             context,
             this.formatTaskNotification(context, params, failed),
           );
-          this.markTypedTaskTerminated(context, failed);
         }
+        this.markTypedTaskTerminated(context, failed);
       } finally {
         try {
           await this.cleanup(context);
@@ -440,6 +448,10 @@ export class SubAgentRunner implements IAgentRunner {
     const runId = crypto.randomUUID();
     const startTime = Date.now();
     const background = params.background ?? false;
+    const behavior = resolveSubAgentBehavior(resolvedTypeConfig, {
+      background,
+      contextMode: params.contextMode,
+    });
 
     // Create restricted tool registry
     const childRegistry = await createSubAgentToolRegistry(
@@ -459,7 +471,7 @@ export class SubAgentRunner implements IAgentRunner {
     const eventRouter = new SubAgentEventRouter({
       parentEmitter: (event) => this.parentEngine.pushEvent(event),
       engineId: runId,
-      suppressedTypes: resolvedTypeConfig.suppressedEvents,
+      suppressedTypes: behavior.suppressedEvents,
     });
 
     const parentConfig = this.parentEngine.getConfig();
@@ -469,15 +481,24 @@ export class SubAgentRunner implements IAgentRunner {
     // Only 'never' explicitly opts out of approval — prevents accidental bypass.
     // Background runs cannot prompt the user (parent has moved on), so force 'never'
     // regardless of the type's configured policy.
-    const effectiveApprovalPolicy = background
-      ? 'never'
-      : (resolvedTypeConfig.approvalPolicy ?? 'inherit');
+    const configuredApprovalPolicy = resolvedTypeConfig.approvalPolicy
+      ?? behavior.approvalPolicyDefault;
+    const effectiveApprovalPolicy = background ? 'never' : configuredApprovalPolicy;
     const approvalGate = effectiveApprovalPolicy === 'inherit'
       ? this.parentEngine.getToolRegistry().getApprovalGate()
       : undefined;
     const approvalPolicy = effectiveApprovalPolicy === 'inherit'
       ? parentSession?.getTurnContext?.().getApprovalPolicy?.() ?? 'on-request'
       : 'never';
+
+    const initialHistory = behavior.contextMode === SubAgentContextMode.Fork
+      ? buildForkedSubAgentInitialHistory(this.parentEngine, params.prompt, {
+        runId,
+        typeId: resolvedTypeConfig.id,
+        agentType: behavior.agentType,
+        contextMode: behavior.contextMode,
+      })
+      : undefined;
 
     // Create child engine via parent's factory method
     const engine = this.parentEngine.createChildEngine({
@@ -490,6 +511,7 @@ export class SubAgentRunner implements IAgentRunner {
       browserContext: parentConfig.browserContext,
       eventRouter,
       drainPendingMessages: () => this.registry.drainMessages(runId),
+      initialHistory,
       // (Track 04) Inherit parent's output store so the child's TaskRunner
       // can persist chunks. RegularTask in the child session reads
       // session.getTaskOutputStore() when wiring AgentTask -> TaskRunner.
@@ -543,6 +565,9 @@ export class SubAgentRunner implements IAgentRunner {
       typeConfig: resolvedTypeConfig,
       parentEngine: this.parentEngine,
       background,
+      behavior,
+      contextMode: behavior.contextMode,
+      executionMode: behavior.executionMode,
       startTime,
       unsubscribe,
     };
@@ -589,11 +614,14 @@ export class SubAgentRunner implements IAgentRunner {
       msg: {
         type: 'SubAgentStart',
         data: {
-          runId,
-          subAgentType: params.type,
-          description: params.description ?? params.prompt.slice(0, 50),
+            runId,
+            subAgentType: params.type,
+            agentType: behavior.agentType,
+            contextMode: behavior.contextMode,
+            executionMode: behavior.executionMode,
+            description: params.description ?? params.prompt.slice(0, 50),
+          },
         },
-      },
     });
 
     // (Track 04) Build typed BackgroundAgentTaskState and register on
@@ -609,6 +637,9 @@ export class SubAgentRunner implements IAgentRunner {
         type: 'background_agent',
         status: 'running',
         description,
+        agentType: behavior.agentType,
+        contextMode: behavior.contextMode,
+        executionMode: behavior.executionMode,
         startTime,
         outputOffset: 0,
         notified: false,
@@ -644,7 +675,12 @@ export class SubAgentRunner implements IAgentRunner {
     try {
       await context.engine.initialize();
 
-      const input: InputItem[] = [{ type: 'text', text: params.prompt }];
+      const input: InputItem[] = [{
+        type: 'text',
+        text: context.contextMode === SubAgentContextMode.Fork
+          ? 'Begin the delegated forked sub-agent task now.'
+          : params.prompt,
+      }];
       const result = await context.engine.run(input, {
         maxTurns: context.typeConfig.maxTurns,
         signal: context.abortController.signal,
@@ -670,6 +706,9 @@ export class SubAgentRunner implements IAgentRunner {
           data: {
             runId: context.runId,
             subAgentType: params.type,
+            agentType: context.behavior.agentType,
+            contextMode: context.contextMode,
+            executionMode: context.executionMode,
             turnCount: result.turnCount,
             tokenUsage,
             duration: Date.now() - context.startTime,
@@ -848,6 +887,9 @@ export class SubAgentRunner implements IAgentRunner {
     const notification: TaskNotification = {
       runId: context.runId,
       type: params.type,
+      agentType: context.behavior.agentType,
+      contextMode: context.contextMode,
+      executionMode: context.executionMode,
       description: params.description ?? params.type,
       status,
       result: result.response || undefined,
@@ -883,6 +925,15 @@ function serializeTaskNotification(n: TaskNotification): string {
   lines.push('<task-notification>');
   lines.push(`  <run-id>${escapeForLlmXml(n.runId)}</run-id>`);
   lines.push(`  <type>${escapeForLlmXml(n.type)}</type>`);
+  if (n.agentType) {
+    lines.push(`  <agent-type>${escapeForLlmXml(n.agentType)}</agent-type>`);
+  }
+  if (n.contextMode) {
+    lines.push(`  <context-mode>${escapeForLlmXml(n.contextMode)}</context-mode>`);
+  }
+  if (n.executionMode) {
+    lines.push(`  <execution-mode>${escapeForLlmXml(n.executionMode)}</execution-mode>`);
+  }
   lines.push(`  <status>${n.status}</status>`);
   lines.push(`  <summary>${escapeForLlmXml(n.description)}</summary>`);
   if (n.result) {

--- a/src/tools/AgentTool/SubAgentRunner.ts
+++ b/src/tools/AgentTool/SubAgentRunner.ts
@@ -614,14 +614,14 @@ export class SubAgentRunner implements IAgentRunner {
       msg: {
         type: 'SubAgentStart',
         data: {
-            runId,
-            subAgentType: params.type,
-            agentType: behavior.agentType,
-            contextMode: behavior.contextMode,
-            executionMode: behavior.executionMode,
-            description: params.description ?? params.prompt.slice(0, 50),
-          },
+          runId,
+          subAgentType: params.type,
+          agentType: behavior.agentType,
+          contextMode: behavior.contextMode,
+          executionMode: behavior.executionMode,
+          description: params.description ?? params.prompt.slice(0, 50),
         },
+      },
     });
 
     // (Track 04) Build typed BackgroundAgentTaskState and register on

--- a/src/tools/AgentTool/SubAgentTool.ts
+++ b/src/tools/AgentTool/SubAgentTool.ts
@@ -18,7 +18,7 @@ export function buildSubAgentToolDefinition(
     type: 'function',
     function: {
       name: 'sub_agent',
-      description: `Delegate a task to a specialized sub-agent. The sub-agent runs independently with its own context and returns a result. Use this when a task is self-contained and can be fully described in the prompt.
+      description: `Delegate a task to a specialized sub-agent. By default the sub-agent runs independently with its own isolated context and returns a result. Use context_mode="fork" when the child needs the current conversation history.
 
 Return shape depends on the background flag:
 - background=false (default): synchronous. Returns { success, response, runId, turnCount, stopReason, tokenUsage?, error? } — the full result of the sub-agent's run. Use response to read its output.
@@ -37,7 +37,7 @@ ${typeDescriptions}`,
           },
           prompt: {
             type: 'string',
-            description: 'Complete task description with all necessary context. The sub-agent has NO access to your conversation history — include everything it needs.',
+            description: 'Complete task description. In isolated mode, include all necessary context because the sub-agent has no conversation history. In fork mode, focus on the delegated task because the sub-agent receives the parent conversation snapshot.',
           },
           description: {
             type: 'string',
@@ -46,6 +46,11 @@ ${typeDescriptions}`,
           background: {
             type: 'boolean',
             description: 'Run in background (returns immediately with runId, sends <task-notification> on completion). Default: false.',
+          },
+          context_mode: {
+            type: 'string',
+            enum: ['isolated', 'fork'],
+            description: 'Context mode. "isolated" (default) starts with no parent conversation history. "fork" gives the sub-agent a snapshot of the parent conversation plus the delegated task.',
           },
         },
         required: ['type', 'prompt'],

--- a/src/tools/AgentTool/__tests__/SubAgentRunner.background.test.ts
+++ b/src/tools/AgentTool/__tests__/SubAgentRunner.background.test.ts
@@ -16,6 +16,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SubAgentRunner } from '../SubAgentRunner';
 import { SubAgentRegistry } from '../SubAgentRegistry';
 import type { SubAgentTypeConfig, BackgroundSubAgentResult, SubAgentResult } from '../types';
+import { AgentType, SubAgentContextMode } from '../agentTypes';
 
 // ---------------------------------------------------------------------------
 // Mocks for the heavy collaborators (ToolRegistryCloner, SubAgentEventRouter)
@@ -48,7 +49,7 @@ interface ParentEngineMock {
   getMaxDepth: () => number;
   getToolRegistry: () => { getApprovalGate: () => undefined };
   getConfig: () => Record<string, unknown>;
-  getSession: () => null;
+  getSession: () => any;
   pushEvent: ReturnType<typeof vi.fn>;
   onEvent: ReturnType<typeof vi.fn>;
   createChildEngine: ReturnType<typeof vi.fn>;
@@ -425,6 +426,72 @@ describe('SubAgentRunner cross-agent messaging — drain wiring', () => {
     expect(config?.drainPendingMessages?.()).toEqual([]);
 
     await settle();
+  });
+});
+
+describe('SubAgentRunner fork context mode', () => {
+  it('passes forked parent history into the child engine and uses a trigger input', async () => {
+    const parent = createParentEngine();
+    parent.getSession = () => ({
+      getSessionId: () => 'parent-session',
+      getConversationHistory: () => ({
+        items: [
+          {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: 'Parent context' }],
+          },
+        ],
+      }),
+      getTaskOutputStore: () => undefined,
+      registerTaskState: vi.fn(),
+    } as any);
+
+    const runner = new SubAgentRunner({
+      parentEngine: parent as never,
+      customTypes: [
+        makeType({
+          agentType: AgentType.Worker,
+          allowedContextModes: [SubAgentContextMode.Isolated, SubAgentContextMode.Fork],
+        }),
+      ],
+    });
+
+    const result = await runner.run({
+      type: 'worker',
+      prompt: 'Use the parent context',
+      contextMode: SubAgentContextMode.Fork,
+    });
+    if ('kind' in result) throw new Error('expected foreground result');
+
+    const config = parent.__childEngine.__capturedConfig as any;
+    expect(config.initialHistory?.mode).toBe('forked');
+    expect(config.initialHistory?.sourceConversationId).toBe('parent-session');
+    expect(JSON.stringify(config.initialHistory?.rolloutItems)).toContain('Parent context');
+    expect(JSON.stringify(config.initialHistory?.rolloutItems)).toContain('Use the parent context');
+    expect(parent.__childEngine.run).toHaveBeenCalledWith(
+      [{ type: 'text', text: 'Begin the delegated forked sub-agent task now.' }],
+      expect.anything(),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects fork mode when a type has not opted in', async () => {
+    const parent = createParentEngine();
+    const runner = new SubAgentRunner({
+      parentEngine: parent as never,
+      customTypes: [makeType()],
+    });
+
+    const result = await runner.run({
+      type: 'worker',
+      prompt: 'task',
+      contextMode: SubAgentContextMode.Fork,
+    });
+
+    if ('kind' in result) throw new Error('expected foreground result');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('does not allow context mode');
   });
 });
 

--- a/src/tools/AgentTool/__tests__/SubAgentTool.test.ts
+++ b/src/tools/AgentTool/__tests__/SubAgentTool.test.ts
@@ -147,16 +147,16 @@ describe('buildSubAgentToolDefinition', () => {
     expect(params.required).toEqual(['type', 'prompt']);
   });
 
-  it('includes all parameter properties (type, prompt, description, background)', () => {
+  it('includes all parameter properties', () => {
     const fn = assertFunctionTool(buildSubAgentToolDefinition(sampleTypes()));
     const params = fn.parameters as {
       type: 'object';
       properties: Record<string, any>;
     };
     expect(Object.keys(params.properties)).toEqual(
-      expect.arrayContaining(['type', 'prompt', 'description', 'background']),
+      expect.arrayContaining(['type', 'prompt', 'description', 'background', 'context_mode']),
     );
-    expect(Object.keys(params.properties)).toHaveLength(4);
+    expect(Object.keys(params.properties)).toHaveLength(5);
   });
 
   it('works with empty types array', () => {

--- a/src/tools/AgentTool/__tests__/behavior.test.ts
+++ b/src/tools/AgentTool/__tests__/behavior.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { AgentType, SubAgentContextMode, SubAgentExecutionMode } from '../agentTypes';
+import { resolveSubAgentBehavior } from '../behavior';
+import type { SubAgentTypeConfig } from '../types';
+import { normalizeSubAgentTypeConfig } from '../validateTypeConfig';
+
+function typeConfig(overrides: Partial<SubAgentTypeConfig> = {}): SubAgentTypeConfig {
+  return normalizeSubAgentTypeConfig({
+    id: 'test',
+    name: 'Test',
+    description: 'Test agent',
+    systemPrompt: 'Test prompt',
+    ...overrides,
+  });
+}
+
+describe('resolveSubAgentBehavior', () => {
+  it('defaults config agents to general-purpose isolated foreground behavior', () => {
+    const behavior = resolveSubAgentBehavior(typeConfig(), {});
+    expect(behavior.agentType).toBe(AgentType.GeneralPurpose);
+    expect(behavior.contextMode).toBe(SubAgentContextMode.Isolated);
+    expect(behavior.executionMode).toBe(SubAgentExecutionMode.Foreground);
+  });
+
+  it('resolves fork background mode when the type allows it', () => {
+    const behavior = resolveSubAgentBehavior(
+      typeConfig({
+        agentType: AgentType.Worker,
+        allowedContextModes: [SubAgentContextMode.Isolated, SubAgentContextMode.Fork],
+      }),
+      { background: true, contextMode: SubAgentContextMode.Fork },
+    );
+
+    expect(behavior.agentType).toBe(AgentType.Worker);
+    expect(behavior.contextMode).toBe(SubAgentContextMode.Fork);
+    expect(behavior.executionMode).toBe(SubAgentExecutionMode.Background);
+    expect(behavior.canUseParentHistory).toBe(true);
+  });
+
+  it('rejects disallowed context mode', () => {
+    expect(() =>
+      resolveSubAgentBehavior(typeConfig(), { contextMode: SubAgentContextMode.Fork }),
+    ).toThrow(/does not allow context mode/);
+  });
+});

--- a/src/tools/AgentTool/__tests__/behavior.test.ts
+++ b/src/tools/AgentTool/__tests__/behavior.test.ts
@@ -43,3 +43,40 @@ describe('resolveSubAgentBehavior', () => {
     ).toThrow(/does not allow context mode/);
   });
 });
+
+describe('normalizeSubAgentTypeConfig context-mode defaults', () => {
+  it('inherits the agentType profile modes when context fields are omitted', () => {
+    // Regression: previously hardcoded [Isolated], so a worker config that
+    // omitted allowedContextModes was silently locked out of fork even
+    // though the Worker profile allows it.
+    const normalized = typeConfig({ agentType: AgentType.Worker });
+    expect(normalized.allowedContextModes).toEqual([
+      SubAgentContextMode.Isolated,
+      SubAgentContextMode.Fork,
+    ]);
+    expect(normalized.defaultContextMode).toBe(SubAgentContextMode.Isolated);
+
+    // And the resolved behavior must agree (single source of truth).
+    const behavior = resolveSubAgentBehavior(normalized, {
+      contextMode: SubAgentContextMode.Fork,
+    });
+    expect(behavior.contextMode).toBe(SubAgentContextMode.Fork);
+  });
+
+  it('still defaults a typeless config to isolated-only', () => {
+    const normalized = typeConfig();
+    expect(normalized.allowedContextModes).toEqual([SubAgentContextMode.Isolated]);
+    expect(normalized.defaultContextMode).toBe(SubAgentContextMode.Isolated);
+  });
+
+  it('honors an explicit allowedContextModes over the profile and clamps the default into it', () => {
+    const normalized = typeConfig({
+      agentType: AgentType.Worker,
+      allowedContextModes: [SubAgentContextMode.Fork],
+    });
+    expect(normalized.allowedContextModes).toEqual([SubAgentContextMode.Fork]);
+    // Worker profile default is Isolated, which is not allowed here, so it
+    // clamps to the first allowed mode rather than producing an invalid default.
+    expect(normalized.defaultContextMode).toBe(SubAgentContextMode.Fork);
+  });
+});

--- a/src/tools/AgentTool/__tests__/forkContext.test.ts
+++ b/src/tools/AgentTool/__tests__/forkContext.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { AgentType, SubAgentContextMode } from '../agentTypes';
+import { buildForkedSubAgentInitialHistory } from '../forkContext';
+
+describe('buildForkedSubAgentInitialHistory', () => {
+  it('wraps parent history and delegated prompt into forked initial history', () => {
+    const parentSession = {
+      getSessionId: () => 'parent-session',
+      getConversationHistory: () => ({
+        items: [
+          {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: 'Original request' }],
+          },
+        ],
+      }),
+    };
+    const parentEngine = {
+      getSession: () => parentSession,
+    } as any;
+
+    const initialHistory = buildForkedSubAgentInitialHistory(
+      parentEngine,
+      'Investigate this',
+      {
+        runId: 'run-1',
+        typeId: 'worker',
+        agentType: AgentType.Worker,
+        contextMode: SubAgentContextMode.Fork,
+      },
+    );
+
+    expect(initialHistory.mode).toBe('forked');
+    if (initialHistory.mode !== 'forked') throw new Error('expected forked history');
+    expect(initialHistory.sourceConversationId).toBe('parent-session');
+    expect(initialHistory.rolloutItems).toHaveLength(2);
+    expect(initialHistory.rolloutItems[0]).toMatchObject({
+      type: 'response_item',
+      payload: { role: 'user' },
+    });
+    expect(JSON.stringify(initialHistory.rolloutItems[1])).toContain('Investigate this');
+  });
+
+  it('drops unpaired tool-call output from forked history', () => {
+    const parentSession = {
+      getSessionId: () => 'parent-session',
+      getConversationHistory: () => ({
+        items: [
+          {
+            type: 'function_call_output',
+            call_id: 'orphan',
+            output: 'orphan result',
+          },
+        ],
+      }),
+    };
+    const parentEngine = {
+      getSession: () => parentSession,
+    } as any;
+
+    const initialHistory = buildForkedSubAgentInitialHistory(parentEngine, 'Do task', {
+      runId: 'run-1',
+      typeId: 'worker',
+      agentType: AgentType.Worker,
+      contextMode: SubAgentContextMode.Fork,
+    });
+
+    if (initialHistory.mode !== 'forked') throw new Error('expected forked history');
+    expect(initialHistory.rolloutItems).toHaveLength(1);
+    expect(JSON.stringify(initialHistory.rolloutItems[0])).toContain('Do task');
+  });
+});

--- a/src/tools/AgentTool/agentTypes.ts
+++ b/src/tools/AgentTool/agentTypes.ts
@@ -1,0 +1,35 @@
+// File: src/tools/AgentTool/agentTypes.ts
+
+/**
+ * Runtime behavior identity for sub-agents.
+ *
+ * `SubAgentTypeConfig.id` remains a dynamic registration key for config and
+ * plugin agents. `AgentType` is the bounded enum runtime code can safely use
+ * for behavior profiles.
+ */
+export enum AgentType {
+  GeneralPurpose = 'general_purpose',
+  Researcher = 'researcher',
+  Planner = 'planner',
+  Worker = 'worker',
+  Verifier = 'verifier',
+  Internal = 'internal',
+}
+
+export enum SubAgentContextMode {
+  Isolated = 'isolated',
+  Fork = 'fork',
+}
+
+export enum SubAgentExecutionMode {
+  Foreground = 'foreground',
+  Background = 'background',
+}
+
+export function isAgentType(value: unknown): value is AgentType {
+  return typeof value === 'string' && (Object.values(AgentType) as string[]).includes(value);
+}
+
+export function isSubAgentContextMode(value: unknown): value is SubAgentContextMode {
+  return typeof value === 'string' && (Object.values(SubAgentContextMode) as string[]).includes(value);
+}

--- a/src/tools/AgentTool/behavior.ts
+++ b/src/tools/AgentTool/behavior.ts
@@ -1,0 +1,140 @@
+// File: src/tools/AgentTool/behavior.ts
+
+import {
+  AgentType,
+  SubAgentContextMode,
+  SubAgentExecutionMode,
+} from './agentTypes';
+import type { SubAgentToolParams, SubAgentTypeConfig } from './types';
+
+export interface SubAgentBehaviorProfile {
+  agentType: AgentType;
+  defaultContextMode: SubAgentContextMode;
+  allowedContextModes: SubAgentContextMode[];
+  approvalPolicyDefault: 'inherit' | 'never';
+  canRunInBackground: boolean;
+  canUseParentHistory: boolean;
+  canUseBrowserContext: boolean;
+  toolPolicy: 'configured' | 'read_only_bias' | 'mutation_capable' | 'internal_locked';
+  suppressStreamingEvents: boolean;
+}
+
+export interface ResolvedSubAgentBehavior extends SubAgentBehaviorProfile {
+  typeId: string;
+  contextMode: SubAgentContextMode;
+  executionMode: SubAgentExecutionMode;
+  suppressedEvents: string[];
+}
+
+const DEFAULT_SUPPRESSED_STREAMING_EVENTS = ['AgentMessageDelta', 'AgentReasoningDelta'];
+
+const PROFILE_BY_TYPE: Record<AgentType, SubAgentBehaviorProfile> = {
+  [AgentType.GeneralPurpose]: {
+    agentType: AgentType.GeneralPurpose,
+    defaultContextMode: SubAgentContextMode.Isolated,
+    allowedContextModes: [SubAgentContextMode.Isolated],
+    approvalPolicyDefault: 'inherit',
+    canRunInBackground: true,
+    canUseParentHistory: false,
+    canUseBrowserContext: true,
+    toolPolicy: 'configured',
+    suppressStreamingEvents: false,
+  },
+  [AgentType.Researcher]: {
+    agentType: AgentType.Researcher,
+    defaultContextMode: SubAgentContextMode.Isolated,
+    allowedContextModes: [SubAgentContextMode.Isolated, SubAgentContextMode.Fork],
+    approvalPolicyDefault: 'never',
+    canRunInBackground: true,
+    canUseParentHistory: true,
+    canUseBrowserContext: false,
+    toolPolicy: 'read_only_bias',
+    suppressStreamingEvents: true,
+  },
+  [AgentType.Planner]: {
+    agentType: AgentType.Planner,
+    defaultContextMode: SubAgentContextMode.Isolated,
+    allowedContextModes: [SubAgentContextMode.Isolated, SubAgentContextMode.Fork],
+    approvalPolicyDefault: 'never',
+    canRunInBackground: true,
+    canUseParentHistory: true,
+    canUseBrowserContext: false,
+    toolPolicy: 'read_only_bias',
+    suppressStreamingEvents: true,
+  },
+  [AgentType.Worker]: {
+    agentType: AgentType.Worker,
+    defaultContextMode: SubAgentContextMode.Isolated,
+    allowedContextModes: [SubAgentContextMode.Isolated, SubAgentContextMode.Fork],
+    approvalPolicyDefault: 'inherit',
+    canRunInBackground: true,
+    canUseParentHistory: true,
+    canUseBrowserContext: true,
+    toolPolicy: 'mutation_capable',
+    suppressStreamingEvents: true,
+  },
+  [AgentType.Verifier]: {
+    agentType: AgentType.Verifier,
+    defaultContextMode: SubAgentContextMode.Isolated,
+    allowedContextModes: [SubAgentContextMode.Isolated, SubAgentContextMode.Fork],
+    approvalPolicyDefault: 'never',
+    canRunInBackground: true,
+    canUseParentHistory: true,
+    canUseBrowserContext: false,
+    toolPolicy: 'read_only_bias',
+    suppressStreamingEvents: true,
+  },
+  [AgentType.Internal]: {
+    agentType: AgentType.Internal,
+    defaultContextMode: SubAgentContextMode.Fork,
+    allowedContextModes: [SubAgentContextMode.Fork],
+    approvalPolicyDefault: 'never',
+    canRunInBackground: true,
+    canUseParentHistory: true,
+    canUseBrowserContext: false,
+    toolPolicy: 'internal_locked',
+    suppressStreamingEvents: true,
+  },
+};
+
+export function getDefaultBehaviorProfile(agentType: AgentType): SubAgentBehaviorProfile {
+  return PROFILE_BY_TYPE[agentType];
+}
+
+export function resolveSubAgentBehavior(
+  config: SubAgentTypeConfig,
+  params: Pick<SubAgentToolParams, 'background' | 'contextMode'>,
+): ResolvedSubAgentBehavior {
+  const agentType = config.agentType ?? AgentType.GeneralPurpose;
+  const base = PROFILE_BY_TYPE[agentType] ?? PROFILE_BY_TYPE[AgentType.GeneralPurpose];
+  const allowedContextModes = config.allowedContextModes ?? base.allowedContextModes;
+  const defaultContextMode = config.defaultContextMode ?? base.defaultContextMode;
+  const contextMode = params.contextMode ?? defaultContextMode;
+
+  if (!allowedContextModes.includes(contextMode)) {
+    throw new Error(
+      `Sub-agent type '${config.id}' does not allow context mode '${contextMode}'`,
+    );
+  }
+
+  const executionMode = params.background
+    ? SubAgentExecutionMode.Background
+    : SubAgentExecutionMode.Foreground;
+
+  if (executionMode === SubAgentExecutionMode.Background && !base.canRunInBackground) {
+    throw new Error(`Sub-agent type '${config.id}' cannot run in background`);
+  }
+
+  const suppressedEvents = config.suppressedEvents
+    ?? (base.suppressStreamingEvents ? DEFAULT_SUPPRESSED_STREAMING_EVENTS : []);
+
+  return {
+    ...base,
+    typeId: config.id,
+    defaultContextMode,
+    allowedContextModes,
+    contextMode,
+    executionMode,
+    suppressedEvents,
+  };
+}

--- a/src/tools/AgentTool/builtinTypes.ts
+++ b/src/tools/AgentTool/builtinTypes.ts
@@ -1,10 +1,12 @@
 // File: src/tools/AgentTool/builtinTypes.ts
 
 import type { SubAgentTypeConfig } from './types';
+import { AgentType, SubAgentContextMode } from './agentTypes';
 
 export const BUILTIN_SUBAGENT_TYPES: SubAgentTypeConfig[] = [
   {
     id: 'researcher',
+    agentType: AgentType.Researcher,
     name: 'Researcher',
     description: 'Fast read-only agent for exploring the codebase, searching files, reading documentation, and gathering information. Use when you need to find or understand something before acting.',
     systemPrompt: `You are a research assistant. Your job is to find information, read files, search code, and report back concisely.
@@ -20,9 +22,12 @@ Rules:
     maxTurns: 15,
     approvalPolicy: 'never',
     suppressedEvents: ['AgentMessageDelta', 'AgentReasoningDelta'],
+    defaultContextMode: SubAgentContextMode.Isolated,
+    allowedContextModes: [SubAgentContextMode.Isolated, SubAgentContextMode.Fork],
   },
   {
     id: 'planner',
+    agentType: AgentType.Planner,
     name: 'Planner',
     description: 'Agent for analyzing requirements and creating implementation plans. Use when you need to break down a complex task into steps before executing.',
     systemPrompt: `You are a planning assistant. Analyze the task, identify the files and components involved, and create a clear step-by-step plan.
@@ -38,9 +43,12 @@ Rules:
     maxTurns: 20,
     approvalPolicy: 'never',
     suppressedEvents: ['AgentMessageDelta', 'AgentReasoningDelta'],
+    defaultContextMode: SubAgentContextMode.Isolated,
+    allowedContextModes: [SubAgentContextMode.Isolated, SubAgentContextMode.Fork],
   },
   {
     id: 'worker',
+    agentType: AgentType.Worker,
     name: 'Worker',
     description: 'General-purpose agent that can read, write, and execute. Use for independent sub-tasks that can be fully described in the prompt without needing back-and-forth.',
     systemPrompt: `You are a task executor. Complete the assigned task efficiently and report what you did.
@@ -55,5 +63,7 @@ Rules:
     maxTurns: 25,
     approvalPolicy: 'inherit',
     suppressedEvents: ['AgentMessageDelta'],
+    defaultContextMode: SubAgentContextMode.Isolated,
+    allowedContextModes: [SubAgentContextMode.Isolated, SubAgentContextMode.Fork],
   },
 ];

--- a/src/tools/AgentTool/forkContext.ts
+++ b/src/tools/AgentTool/forkContext.ts
@@ -1,0 +1,73 @@
+// File: src/tools/AgentTool/forkContext.ts
+
+import type { RepublicAgentEngine } from '@/core/engine/RepublicAgentEngine';
+import type { InitialHistory } from '@/core/session/state/types';
+import { pairingTrim } from '@/core/session/rewind';
+import type { ResponseItem } from '@/core/protocol/types';
+import type { RolloutItem } from '@/storage/rollout/types';
+import type { AgentType, SubAgentContextMode } from './agentTypes';
+
+export interface ForkContextMetadata {
+  runId: string;
+  typeId: string;
+  agentType: AgentType;
+  contextMode: SubAgentContextMode;
+}
+
+export function buildForkedSubAgentInitialHistory(
+  parentEngine: RepublicAgentEngine,
+  prompt: string,
+  metadata: ForkContextMetadata,
+): InitialHistory {
+  const parentSession = parentEngine.getSession();
+  if (!parentSession) {
+    throw new Error('Cannot build forked sub-agent context before parent session is initialized');
+  }
+
+  const sourceItems = parentSession.getConversationHistory().items as ResponseItem[];
+  const rolloutItems = responseItemsToRolloutItems(sourceItems);
+  const trimmed = pairingTrim(rolloutItems);
+
+  return {
+    mode: 'forked',
+    sourceConversationId: parentSession.getSessionId(),
+    rolloutItems: [
+      ...trimmed,
+      {
+        type: 'response_item',
+        payload: buildForkDirectiveMessage(prompt, metadata),
+      },
+    ],
+  };
+}
+
+export function responseItemsToRolloutItems(items: ResponseItem[]): RolloutItem[] {
+  return items.map((item) => ({
+    type: 'response_item',
+    payload: item,
+  }));
+}
+
+function buildForkDirectiveMessage(
+  prompt: string,
+  metadata: ForkContextMetadata,
+): ResponseItem {
+  return {
+    type: 'message',
+    role: 'user',
+    content: [
+      {
+        type: 'input_text',
+        text: [
+          '<forked-subagent-task>',
+          `You are a delegated forked subagent for type '${metadata.typeId}' (${metadata.agentType}).`,
+          'Use the inherited conversation only to complete the delegated task below.',
+          'Do not assume control of the main conversation. Return one final result to the parent.',
+          '',
+          prompt,
+          '</forked-subagent-task>',
+        ].join('\n'),
+      },
+    ],
+  } as ResponseItem;
+}

--- a/src/tools/AgentTool/index.ts
+++ b/src/tools/AgentTool/index.ts
@@ -20,6 +20,8 @@ export type { ActiveSubAgent } from './SubAgentRegistry';
 export { SubAgentRunner } from './SubAgentRunner';
 export { registerSubAgentTool } from './register';
 export type { RegisterSubAgentOptions } from './register';
+export { AgentType, SubAgentContextMode, SubAgentExecutionMode } from './agentTypes';
+export { resolveSubAgentBehavior } from './behavior';
 export {
   buildListSubAgentsToolDefinition,
   buildCancelSubAgentToolDefinition,

--- a/src/tools/AgentTool/managementTools.ts
+++ b/src/tools/AgentTool/managementTools.ts
@@ -79,6 +79,9 @@ export function createListSubAgentsHandler(registry: SubAgentRegistry) {
     const agents = registry.getAll().map(a => ({
       runId: a.runId,
       type: a.type,
+      agentType: a.context?.behavior.agentType,
+      contextMode: a.context?.contextMode,
+      executionMode: a.context?.executionMode,
       description: a.description,
       status: a.status,
       startTime: a.startTime,

--- a/src/tools/AgentTool/register.ts
+++ b/src/tools/AgentTool/register.ts
@@ -100,16 +100,29 @@ export async function registerSubAgentTool(
         return JSON.stringify({ success: false, error: 'Missing required parameter: prompt' });
       }
 
+      // Accept both the tool-schema snake_case `context_mode` and the
+      // internal camelCase `contextMode`. When a value is supplied but
+      // unrecognized, fail loudly instead of silently defaulting — this
+      // matches resolveSubAgentBehavior, which throws for a valid-but-
+      // disallowed mode rather than coercing it.
+      const rawContextMode = params.context_mode ?? params.contextMode;
+      let contextMode: SubAgentToolParams['contextMode'];
+      if (rawContextMode !== undefined) {
+        if (!isSubAgentContextMode(rawContextMode)) {
+          return JSON.stringify({
+            success: false,
+            error: `Invalid context_mode '${String(rawContextMode)}'. Expected 'isolated' or 'fork'.`,
+          });
+        }
+        contextMode = rawContextMode;
+      }
+
       const toolParams: SubAgentToolParams = {
         type: params.type,
         prompt: params.prompt,
         description: typeof params.description === 'string' ? params.description : undefined,
         background: params.background === true,
-        contextMode: isSubAgentContextMode(params.context_mode)
-          ? params.context_mode
-          : isSubAgentContextMode(params.contextMode)
-            ? params.contextMode
-            : undefined,
+        contextMode,
       };
 
       const result = await runner.run(toolParams);

--- a/src/tools/AgentTool/register.ts
+++ b/src/tools/AgentTool/register.ts
@@ -14,7 +14,11 @@ import {
   createSendMessageHandler,
 } from './managementTools';
 import type { SubAgentTypeConfig, SubAgentToolParams } from './types';
-import { validateSubAgentTypeConfig } from './validateTypeConfig';
+import {
+  normalizeSubAgentTypeConfig,
+  validateSubAgentTypeConfig,
+} from './validateTypeConfig';
+import { isSubAgentContextMode } from './agentTypes';
 
 export interface RegisterSubAgentOptions {
   /** Sub-agent types to register. Defaults to built-in types. */
@@ -54,7 +58,17 @@ export async function registerSubAgentTool(
     const configData = agentConfig.getConfig();
     const rawTypes = (configData as unknown as Record<string, unknown>).subAgentTypes;
     if (Array.isArray(rawTypes)) {
-      configTypes = rawTypes.filter(validateSubAgentTypeConfig);
+      configTypes = [];
+      for (const raw of rawTypes) {
+        if (!validateSubAgentTypeConfig(raw)) continue;
+        try {
+          configTypes.push(normalizeSubAgentTypeConfig(raw));
+        } catch (error) {
+          console.warn(
+            `[SubAgent type config] ${raw.id}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
     }
   } catch {
     // Config loading is optional
@@ -91,6 +105,11 @@ export async function registerSubAgentTool(
         prompt: params.prompt,
         description: typeof params.description === 'string' ? params.description : undefined,
         background: params.background === true,
+        contextMode: isSubAgentContextMode(params.context_mode)
+          ? params.context_mode
+          : isSubAgentContextMode(params.contextMode)
+            ? params.contextMode
+            : undefined,
       };
 
       const result = await runner.run(toolParams);

--- a/src/tools/AgentTool/types.ts
+++ b/src/tools/AgentTool/types.ts
@@ -1,5 +1,12 @@
 // File: src/tools/AgentTool/types.ts
 
+import type {
+  AgentType,
+  SubAgentContextMode,
+  SubAgentExecutionMode,
+} from './agentTypes';
+import type { ResolvedSubAgentBehavior } from './behavior';
+
 /**
  * Configuration for a sub-agent type.
  * Defines how a sub-agent behaves and what tools it has access to.
@@ -7,6 +14,9 @@
 export interface SubAgentTypeConfig {
   /** Unique identifier for this sub-agent type */
   id: string;
+
+  /** Enum-backed runtime behavior type. Registration id remains dynamic. */
+  agentType?: AgentType;
 
   /** Human-readable name */
   name: string;
@@ -47,6 +57,12 @@ export interface SubAgentTypeConfig {
 
   /** Event types to suppress when routing to parent */
   suppressedEvents?: string[];
+
+  /** Default context mode for this type. Defaults to isolated. */
+  defaultContextMode?: SubAgentContextMode;
+
+  /** Allowed context modes. Defaults depend on agentType. */
+  allowedContextModes?: SubAgentContextMode[];
 }
 
 /**
@@ -67,6 +83,9 @@ export interface SubAgentToolParams {
 
   /** Whether to run this sub-agent in the background */
   background?: boolean;
+
+  /** Whether the child starts isolated or with a fork of parent history */
+  contextMode?: SubAgentContextMode;
 
   /**
    * When `background: true`, suppress the synthetic `<task-notification>`
@@ -147,6 +166,15 @@ export interface AgentContext {
    * notification would be redundant noise to the parent LLM.
    */
   cancelled?: boolean;
+
+  /** Resolved behavior profile for this run */
+  behavior: ResolvedSubAgentBehavior;
+
+  /** Effective context mode for this run */
+  contextMode: SubAgentContextMode;
+
+  /** Effective foreground/background mode for this run */
+  executionMode: SubAgentExecutionMode;
 }
 
 /**
@@ -191,6 +219,9 @@ export interface SubAgentUsageSummary {
 export interface TaskNotification {
   runId: string;
   type: string;
+  agentType?: AgentType;
+  contextMode?: SubAgentContextMode;
+  executionMode?: SubAgentExecutionMode;
   description: string;
   status: 'completed' | 'failed' | 'cancelled';
   result?: string;

--- a/src/tools/AgentTool/validateTypeConfig.ts
+++ b/src/tools/AgentTool/validateTypeConfig.ts
@@ -7,6 +7,7 @@ import {
   isAgentType,
   isSubAgentContextMode,
 } from './agentTypes';
+import { getDefaultBehaviorProfile } from './behavior';
 
 /**
  * Validate that an unknown value conforms to `SubAgentTypeConfig`.
@@ -69,10 +70,18 @@ export function normalizeSubAgentTypeConfig(
     throw new Error(`Sub-agent type '${config.id}' cannot use internal agentType`);
   }
 
+  // Single source of truth: when context-mode fields are omitted they derive
+  // from the agentType behavior profile (same table resolveSubAgentBehavior
+  // uses). Previously this hardcoded [Isolated], so a config/plugin type
+  // declaring `agentType: 'worker'` (whose profile allows fork) was silently
+  // locked to isolated. Explicit config fields still win.
+  const profile = getDefaultBehaviorProfile(agentType);
   const allowedContextModes = config.allowedContextModes
-    ?? [SubAgentContextMode.Isolated];
+    ?? profile.allowedContextModes;
   const defaultContextMode = config.defaultContextMode
-    ?? allowedContextModes[0]
+    ?? (allowedContextModes.includes(profile.defaultContextMode)
+      ? profile.defaultContextMode
+      : allowedContextModes[0])
     ?? SubAgentContextMode.Isolated;
 
   if (!allowedContextModes.includes(defaultContextMode)) {

--- a/src/tools/AgentTool/validateTypeConfig.ts
+++ b/src/tools/AgentTool/validateTypeConfig.ts
@@ -1,6 +1,12 @@
 // File: src/tools/AgentTool/validateTypeConfig.ts
 
 import type { SubAgentTypeConfig } from './types';
+import {
+  AgentType,
+  SubAgentContextMode,
+  isAgentType,
+  isSubAgentContextMode,
+} from './agentTypes';
 
 /**
  * Validate that an unknown value conforms to `SubAgentTypeConfig`.
@@ -34,7 +40,53 @@ export function validateSubAgentTypeConfig(t: unknown): t is SubAgentTypeConfig 
     console.warn(`[SubAgent type config] ${obj.id}: invalid maxTurns`);
     return false;
   }
+  if (obj.agentType !== undefined && !isAgentType(obj.agentType)) {
+    console.warn(`[SubAgent type config] ${obj.id}: invalid agentType`);
+    return false;
+  }
+  if (obj.defaultContextMode !== undefined && !isSubAgentContextMode(obj.defaultContextMode)) {
+    console.warn(`[SubAgent type config] ${obj.id}: invalid defaultContextMode`);
+    return false;
+  }
+  if (obj.allowedContextModes !== undefined) {
+    if (
+      !Array.isArray(obj.allowedContextModes) ||
+      !obj.allowedContextModes.every(isSubAgentContextMode)
+    ) {
+      console.warn(`[SubAgent type config] ${obj.id}: invalid allowedContextModes`);
+      return false;
+    }
+  }
   return true;
+}
+
+export function normalizeSubAgentTypeConfig(
+  config: SubAgentTypeConfig,
+  options: { allowInternal?: boolean } = {},
+): SubAgentTypeConfig {
+  const agentType = config.agentType ?? AgentType.GeneralPurpose;
+  if (agentType === AgentType.Internal && options.allowInternal !== true) {
+    throw new Error(`Sub-agent type '${config.id}' cannot use internal agentType`);
+  }
+
+  const allowedContextModes = config.allowedContextModes
+    ?? [SubAgentContextMode.Isolated];
+  const defaultContextMode = config.defaultContextMode
+    ?? allowedContextModes[0]
+    ?? SubAgentContextMode.Isolated;
+
+  if (!allowedContextModes.includes(defaultContextMode)) {
+    throw new Error(
+      `Sub-agent type '${config.id}' defaultContextMode must be in allowedContextModes`,
+    );
+  }
+
+  return {
+    ...config,
+    agentType,
+    defaultContextMode,
+    allowedContextModes,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- adds enum-backed sub-agent behavior types and centralized behavior resolution
- wires child-engine initial history and pending-message draining so forked subagents and send_message work end to end
- adds explicit isolated/fork context modes, forked skill invocation, metadata events/notifications, and focused tests

## Validation
- npm run type-check
- npx vitest run src/tools/AgentTool/__tests__ src/core/skills/__tests__/buildSubAgentInvoker.test.ts src/core/skills/__tests__/SkillExecutor.test.ts src/core/engine/__tests__/RepublicAgentEngine.integration.test.ts
- npx vitest run src/core/plugins/loaders/__tests__ src/tools/AgentTool/__tests__ src/core/skills/__tests__/buildSubAgentInvoker.test.ts src/core/skills/__tests__/SkillExecutor.test.ts src/core/engine/__tests__/RepublicAgentEngine.integration.test.ts
- git diff --check

## Notes
- Full npx vitest run still has unrelated existing failures: tests/integration/server-channels.test.ts cannot resolve @/server/plugins/channel-bridge, and src/server/tools/__tests__/registerServerTools.test.ts has a WebSearchTool mock missing WEB_SEARCH_CONCURRENCY.
- Repo-wide npm run lint still fails on the existing lint baseline; the changed-file eslint subset has no errors.