### PR TITLE
test(server): fix stale WebSearchTool mock in registerServerTools.test

### DIFF
--- a/src/server/tools/__tests__/registerServerTools.test.ts
+++ b/src/server/tools/__tests__/registerServerTools.test.ts
@@ -48,6 +48,15 @@ vi.mock('@/tools/PlanningTool', () => ({
 
 vi.mock('@/tools/WebSearchTool', () => ({
   WebSearchTool: vi.fn().mockImplementation(() => mockWebSearchTool),
+  // registerServerTools also destructures WEB_SEARCH_CONCURRENCY from this
+  // module (added in track-14); the mock must provide it or vitest throws
+  // "No WEB_SEARCH_CONCURRENCY export is defined on the mock". Mirrors the
+  // real ToolConcurrencyProfile shape in src/tools/WebSearchTool.ts.
+  WEB_SEARCH_CONCURRENCY: {
+    isConcurrencySafe: () => true,
+    isReadOnly: () => true,
+    isDestructive: () => false,
+  },
 }));
 
 vi.mock('@/core/approval/assessors/StaticRiskAssessor', () => ({


### PR DESCRIPTION
## Problem
`agent-improvements` has a pre-existing red test: `registerServerTools.test.ts` failed with `No "WEB_SEARCH_CONCURRENCY" export is defined on the "@/tools/WebSearchTool" mock`.

`registerServerTools.ts:80` destructures `{ WebSearchTool, WEB_SEARCH_CONCURRENCY }` (the latter added in track-14), but the test's `vi.mock('@/tools/WebSearchTool')` only stubbed `WebSearchTool`.

## Fix
Add `WEB_SEARCH_CONCURRENCY` to the mock factory, mirroring the real `ToolConcurrencyProfile` shape in `src/tools/WebSearchTool.ts`. Test-only change.

## Verification
- `registerServerTools.test.ts`: 11/11 pass.
- **Full `vitest run`: 9074 passed / 0 failed** (was 1 failed).

## Out of scope (flagged, not fixed here)
Running the full suite surfaced a *separate, unrelated* pre-existing breakage: `tests/integration/server-channels.test.ts` fails to collect because it imports `@/server/plugins/channel-bridge`, removed by commit `86cc7e4a` (`refactor(server): rename src/server/plugins → src/server/channel-connectors`). That is a stale integration test from a server refactor (symbols renamed, not just the path) and needs the new connector-API semantics — it belongs to the refactor owner, not this mock fix and not Track 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)