### PR TITLE
[codex] Implement cross-track consistency hardening

### DIFF
--- a/.ai_design/agent_improvements/track_status.yml
+++ b/.ai_design/agent_improvements/track_status.yml
@@ -1,0 +1,65 @@
+schema_version: 1
+updated: 2026-05-20
+aliases:
+  improve_consistentcy0520:
+    - improve_consistency_0520
+status_values:
+  design_status: [ready, done, open, abandoned, deferred]
+  code_status: [done, open, abandoned, deferred]
+tracks:
+  - { id: "01", path: "01_hook_event_system_DONE", design_status: done, code_status: done, pr: 198, merge_date: 2026-05-13 }
+  - { id: "02", path: "02_tool_metadata_concurrency_DONE", design_status: done, code_status: done, pr: 197, merge_date: 2026-05-13 }
+  - { id: "03", path: "03_command_skill_system_DONE", design_status: done, code_status: done, pr: 204, merge_date: 2026-05-14 }
+  - { id: "04", path: "04_typed_task_families_DONE", design_status: done, code_status: done, pr: 205, merge_date: 2026-05-13 }
+  - { id: "05", path: "05_session_memory_DONE", design_status: done, code_status: done, pr: 167, merge_date: 2026-05-12 }
+  - { id: "05b", path: "05b_auto_extraction_compaction_interlock_DONE", design_status: done, code_status: done, pr: 206, merge_date: 2026-05-14 }
+  - { id: "06", path: "06_multi_agent_coordination_ABANDONED", design_status: abandoned, code_status: abandoned }
+  - { id: "07", path: "07_centralized_state_DONE", design_status: done, code_status: done, pr: 214, merge_date: 2026-05-14 }
+  - { id: "08", path: "08_centralized_message_queue_DONE", design_status: done, code_status: done, pr: 219, merge_date: 2026-05-14 }
+  - { id: "09", path: "09_tool_result_persistence_DONE", design_status: done, code_status: done, pr: 213, merge_date: 2026-05-14 }
+  - { id: "10", path: "10_plugin_system_DONE", design_status: done, code_status: done }
+  - { id: "11", path: "11_parallel_tool_calls_DONE", design_status: done, code_status: done, pr: 221, merge_date: 2026-05-15 }
+  - { id: "12", path: "12_rate_limit_resilience_DONE", design_status: done, code_status: done, pr: 230, merge_date: 2026-05-16 }
+  - { id: "13", path: "13_input_pipeline_mentions_DONE", design_status: done, code_status: done, pr: 229, merge_date: 2026-05-16 }
+  - { id: "14", path: "14_plan_review_DONE", design_status: done, code_status: done, pr: 233, merge_date: 2026-05-16 }
+  - { id: "15", path: "15_conversation_rewind_DONE", design_status: done, code_status: done, pr: 234, merge_date: 2026-05-16 }
+  - { id: "16", path: "16_telemetry_analytics_DONE", design_status: done, code_status: done, pr: 239, merge_date: 2026-05-18 }
+  - { id: "17", path: "17_operational_diagnostics_DONE", design_status: done, code_status: done, pr: 232, merge_date: 2026-05-16 }
+  - { id: "18", path: "18_usd_cost_tracking_DONE", design_status: done, code_status: done, pr: 231, merge_date: 2026-05-16 }
+  - { id: "19", path: "19_migration_framework_DEFERRED", design_status: deferred, code_status: deferred }
+  - { id: "20", path: "20_managed_policy_settings_DONE", design_status: done, code_status: done, pr: 237, merge_date: 2026-05-16 }
+  - { id: "21", path: "21_remote_bridge_relay_DEFERRED", design_status: deferred, code_status: deferred }
+  - { id: "22", path: "22_feature_flags_lazy_loading_DONE", design_status: done, code_status: done, pr: 242, merge_date: 2026-05-18 }
+  - { id: "23", path: "23_agentic_payments_x402_DONE", design_status: done, code_status: done, pr: 238, merge_date: 2026-05-18 }
+  - { id: "24", path: "24_minor_ux_hardening_followups_DONE", design_status: done, code_status: done, pr: 240, merge_date: 2026-05-16 }
+  - { id: "25", path: "25_context_compaction_robustness_DONE", design_status: done, code_status: done }
+  - { id: "26", path: "26_track01_hook_system_completion_DONE", design_status: done, code_status: done }
+  - { id: "27", path: "27_track02_progress_ux_sibling_abort_DONE", design_status: done, code_status: done }
+  - { id: "28", path: "28_track03_skill_security_server_parity_DONE", design_status: done, code_status: done }
+  - { id: "29", path: "29_track04_background_task_delivery_DONE", design_status: done, code_status: done }
+  - { id: "30", path: "30_track05_memory_privacy_ui_DONE", design_status: done, code_status: done }
+  - { id: "31", path: "31_track05b_session_summary_e2e_DONE", design_status: done, code_status: done }
+  - { id: "32", path: "32_track09_tool_result_persistence_wiring_DONE", design_status: done, code_status: done }
+  - { id: "33", path: "33_int_tool_exec_route_consistency_DONE", design_status: done, code_status: done }
+  - { id: "34", path: "34_int_extractor_task_seam_DONE", design_status: done, code_status: done }
+  - { id: "35", path: "35_int_reactive_config_staleness_DONE", design_status: done, code_status: done }
+  - { id: "36", path: "36_int_concurrent_approval_serialization_DONE", design_status: done, code_status: done }
+  - { id: "37", path: "37_int_persisted_result_durability_DONE", design_status: done, code_status: done }
+  - { id: "38", path: "38_keyboard_shortcut_system_DONE", design_status: done, code_status: done, pr: 241, merge_date: 2026-05-18 }
+  - { id: "39", path: "39_dynamic_tool_management_DONE", design_status: done, code_status: done }
+  - { id: "40", path: "40_subagent_runtime_optimization_DONE", design_status: done, code_status: done, pr: 243, merge_date: 2026-05-18 }
+  - { id: "41", path: "41_shadow_agent_runtime_DONE", design_status: done, code_status: done, pr: 245, merge_date: 2026-05-18 }
+  - { id: "42", path: "42_system_prompt_content_improvements_DONE", design_status: done, code_status: done, pr: 244, merge_date: 2026-05-18 }
+  - { id: "43", path: "43_apple_pi_runtime_decoupling_DONE", design_status: done, code_status: done, pr: "246+255", merge_date: 2026-05-20 }
+  - { id: "44", path: "44_desktop_runtime_state_ownership_DONE", design_status: done, code_status: done, pr: 256, merge_date: 2026-05-20 }
+  - { id: "45", path: "45_track43_runtime_integration_followups", design_status: ready, code_status: open }
+  - { id: "improve_consistentcy0520", path: "improve_consistentcy0520", design_status: ready, code_status: open }
+legacy_design_sets:
+  - applepi_agent_modes
+  - applepi_file_tools
+  - message_routing_v2
+  - migrate_main_engine
+  - server_mode
+  - simplify_session
+  - sub_agent_improvements
+  - subagent

--- a/scripts/check-agent-improvement-status.mjs
+++ b/scripts/check-agent-improvement-status.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import YAML from 'yaml';
+
+const root = process.cwd();
+const baseDir = path.join(root, '.ai_design', 'agent_improvements');
+const ledgerPath = path.join(baseDir, 'track_status.yml');
+const readmePath = path.join(baseDir, 'README.md');
+
+const ledger = YAML.parse(fs.readFileSync(ledgerPath, 'utf-8'));
+const readme = fs.readFileSync(readmePath, 'utf-8');
+const tracks = Array.isArray(ledger?.tracks) ? ledger.tracks : [];
+const errors = [];
+
+const suffixByStatus = {
+  done: '_DONE',
+  abandoned: '_ABANDONED',
+  deferred: '_DEFERRED',
+};
+
+for (const track of tracks) {
+  if (!track?.id || !track?.path || !track?.code_status || !track?.design_status) {
+    errors.push(`Malformed track row: ${JSON.stringify(track)}`);
+    continue;
+  }
+
+  const trackDir = path.join(baseDir, track.path);
+  if (!fs.existsSync(trackDir)) {
+    errors.push(`Missing directory for track ${track.id}: ${track.path}`);
+    continue;
+  }
+
+  const requiredSuffix = suffixByStatus[track.code_status];
+  if (requiredSuffix && !track.path.endsWith(requiredSuffix)) {
+    errors.push(`Track ${track.id} code_status=${track.code_status} but path lacks ${requiredSuffix}: ${track.path}`);
+  }
+
+  if (track.code_status === 'open' && /_(DONE|ABANDONED|DEFERRED)$/.test(track.path)) {
+    errors.push(`Track ${track.id} code_status=open but path looks terminal: ${track.path}`);
+  }
+
+  const readmeNeedle = `./${track.path}/design.md`;
+  if (!readme.includes(readmeNeedle)) {
+    errors.push(`README missing design link for track ${track.id}: ${readmeNeedle}`);
+  }
+}
+
+const legacy = Array.isArray(ledger?.legacy_design_sets) ? ledger.legacy_design_sets : [];
+for (const dir of legacy) {
+  const legacyPath = path.join(root, '.ai_design', dir);
+  if (!fs.existsSync(legacyPath)) {
+    errors.push(`Missing legacy design set listed in ledger: ${dir}`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error('Agent improvement status check failed:');
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+console.log(`Agent improvement status check passed (${tracks.length} tracks, ${legacy.length} legacy design sets).`);

--- a/src/core/PromptLoader.ts
+++ b/src/core/PromptLoader.ts
@@ -190,18 +190,22 @@ export async function loadPrompt(
  * Append registered prompt extensions to the base prompt.
  */
 function appendExtensions(base: string, ctx: PromptRuntimeContext): string {
-  const extensions = new Map<string, PromptExtensionFn>(globalPromptExtensions);
+  let extensions: Iterable<PromptExtensionFn> = globalPromptExtensions.values();
+  let extensionCount = globalPromptExtensions.size;
   if (ctx.sessionId) {
     const sessionExtensions = sessionPromptExtensions.get(ctx.sessionId);
     if (sessionExtensions) {
+      const merged = new Map<string, PromptExtensionFn>(globalPromptExtensions);
       for (const [name, fn] of sessionExtensions) {
-        extensions.set(name, fn);
+        merged.set(name, fn);
       }
+      extensions = merged.values();
+      extensionCount = merged.size;
     }
   }
-  if (extensions.size === 0) return base;
+  if (extensionCount === 0) return base;
 
-  const extras = Array.from(extensions.values())
+  const extras = Array.from(extensions)
     .map((fn) => fn(ctx))
     .filter(Boolean);
 

--- a/src/core/PromptLoader.ts
+++ b/src/core/PromptLoader.ts
@@ -16,14 +16,31 @@ import defaultPiExtensionPrompt from '../prompts/default_browserx_agent_prompt.m
 import defaultPiPrompt from '../prompts/default_applepi_agent_prompt.md?raw';
 import userInstructions from '../prompts/user_instruction.md?raw';
 import { PromptComposer, type AgentType, type AgentMode, type RuntimeContext, DEFAULT_MODE } from '../prompts/PromptComposer';
+import type { ToolRegistry } from '../tools/ToolRegistry';
+import type { TurnContext } from './TurnContext';
+
+export interface PromptRuntimeContext {
+  sessionId?: string;
+  mode?: AgentMode;
+  toolRegistry?: ToolRegistry;
+  turnContext?: TurnContext;
+}
+
+export type PromptExtensionScope =
+  | { type: 'global' }
+  | { type: 'session'; sessionId: string };
+
+type PromptExtensionFn = (ctx: PromptRuntimeContext) => string;
 
 // Module-level singleton — configured once, used on every loadPrompt() call
 let composer: PromptComposer | null = null;
 let configuredAgentType: AgentType = 'browserx';
 let staticContext: Partial<RuntimeContext> = {};
 
-/** Dynamic prompt extensions appended after the main system prompt, keyed by name */
-let promptExtensions: Map<string, () => string> = new Map();
+/** Global prompt extensions appended after the main system prompt, keyed by name. */
+let globalPromptExtensions: Map<string, PromptExtensionFn> = new Map();
+/** Session-scoped prompt extensions keyed by session id, then extension name. */
+let sessionPromptExtensions: Map<string, Map<string, PromptExtensionFn>> = new Map();
 
 /**
  * Optional provider of per-call dynamic RuntimeContext, merged over the
@@ -31,7 +48,7 @@ let promptExtensions: Map<string, () => string> = new Map();
  * within a session (e.g. Track 14 plan-review active flag) without
  * coupling PromptLoader to the ToolRegistry.
  */
-let dynamicContextProvider: (() => Partial<RuntimeContext>) | null = null;
+let dynamicContextProvider: ((ctx: PromptRuntimeContext) => Partial<RuntimeContext>) | null = null;
 
 /**
  * Register (or clear, with null) a dynamic RuntimeContext provider.
@@ -39,7 +56,7 @@ let dynamicContextProvider: (() => Partial<RuntimeContext>) | null = null;
  * static context (before currentDateTime).
  */
 export function setDynamicRuntimeContext(
-  fn: (() => Partial<RuntimeContext>) | null
+  fn: ((ctx: PromptRuntimeContext) => Partial<RuntimeContext>) | null
 ): void {
   dynamicContextProvider = fn;
 }
@@ -73,15 +90,49 @@ export function isComposerConfigured(): boolean {
  * return value is appended to the system prompt.
  * If an extension with the same name already exists, it is replaced.
  */
-export function registerPromptExtension(name: string, fn: () => string): void {
-  promptExtensions.set(name, fn);
+export function registerPromptExtension(
+  name: string,
+  fn: PromptExtensionFn,
+  scope: PromptExtensionScope = { type: 'global' },
+): () => void {
+  if (scope.type === 'session') {
+    let extensions = sessionPromptExtensions.get(scope.sessionId);
+    if (!extensions) {
+      extensions = new Map();
+      sessionPromptExtensions.set(scope.sessionId, extensions);
+    }
+    extensions.set(name, fn);
+    return () => unregisterPromptExtension(name, scope);
+  }
+
+  globalPromptExtensions.set(name, fn);
+  return () => unregisterPromptExtension(name, scope);
 }
 
 /**
  * Unregister a named prompt extension.
  */
-export function unregisterPromptExtension(name: string): void {
-  promptExtensions.delete(name);
+export function unregisterPromptExtension(
+  name: string,
+  scope: PromptExtensionScope = { type: 'global' },
+): void {
+  if (scope.type === 'session') {
+    const extensions = sessionPromptExtensions.get(scope.sessionId);
+    extensions?.delete(name);
+    if (extensions && extensions.size === 0) {
+      sessionPromptExtensions.delete(scope.sessionId);
+    }
+    return;
+  }
+
+  globalPromptExtensions.delete(name);
+}
+
+/**
+ * Clear all prompt extensions owned by a session.
+ */
+export function unregisterSessionPromptExtensions(sessionId: string): void {
+  sessionPromptExtensions.delete(sessionId);
 }
 
 /**
@@ -98,12 +149,19 @@ export function unregisterPromptExtension(name: string): void {
  * caller — it is NOT module-global state, so concurrent sessions in different
  * modes compose correctly.
  */
-export async function loadPrompt(mode: AgentMode = DEFAULT_MODE): Promise<string> {
+export async function loadPrompt(
+  mode: AgentMode = DEFAULT_MODE,
+  runtimeContext: PromptRuntimeContext = {},
+): Promise<string> {
+  const ctx: PromptRuntimeContext = {
+    ...runtimeContext,
+    mode,
+  };
   if (composer) {
     try {
       let dynamic: Partial<RuntimeContext> = {};
       try {
-        dynamic = dynamicContextProvider?.() ?? {};
+        dynamic = dynamicContextProvider?.(ctx) ?? {};
       } catch (e) {
         console.error('[PromptLoader] dynamic context provider failed:', e);
       }
@@ -113,7 +171,7 @@ export async function loadPrompt(mode: AgentMode = DEFAULT_MODE): Promise<string
         currentDateTime: new Date().toISOString(),
       };
       const prompt = composer.composeMainInstruction(configuredAgentType, mode, context);
-      return appendExtensions(prompt);
+      return appendExtensions(prompt, ctx);
     } catch (error) {
       console.error('[PromptLoader] composeMainInstruction failed, falling back to default prompt:', error);
     }
@@ -125,17 +183,26 @@ export async function loadPrompt(mode: AgentMode = DEFAULT_MODE): Promise<string
   } else {
     fallback = defaultPiExtensionPrompt;
   }
-  return appendExtensions(fallback);
+  return appendExtensions(fallback, ctx);
 }
 
 /**
  * Append registered prompt extensions to the base prompt.
  */
-function appendExtensions(base: string): string {
-  if (promptExtensions.size === 0) return base;
+function appendExtensions(base: string, ctx: PromptRuntimeContext): string {
+  const extensions = new Map<string, PromptExtensionFn>(globalPromptExtensions);
+  if (ctx.sessionId) {
+    const sessionExtensions = sessionPromptExtensions.get(ctx.sessionId);
+    if (sessionExtensions) {
+      for (const [name, fn] of sessionExtensions) {
+        extensions.set(name, fn);
+      }
+    }
+  }
+  if (extensions.size === 0) return base;
 
-  const extras = Array.from(promptExtensions.values())
-    .map((fn) => fn())
+  const extras = Array.from(extensions.values())
+    .map((fn) => fn(ctx))
     .filter(Boolean);
 
   if (extras.length === 0) return base;

--- a/src/core/RepublicAgent.ts
+++ b/src/core/RepublicAgent.ts
@@ -23,7 +23,16 @@ import { RepublicAgentEngine } from './engine/RepublicAgentEngine';
 import { AutoCompactHook } from './compact/autoCompactHook';
 import { type IUserNotifier, NoOpNotifier } from './IUserNotifier';
 import { v4 as uuidv4 } from 'uuid';
-import { loadPrompt, loadUserInstructions, configurePromptComposer, isComposerConfigured, registerPromptExtension, unregisterPromptExtension } from './PromptLoader';
+import {
+  loadPrompt,
+  loadUserInstructions,
+  configurePromptComposer,
+  isComposerConfigured,
+  registerPromptExtension,
+  unregisterPromptExtension,
+  unregisterSessionPromptExtensions,
+  type PromptRuntimeContext,
+} from './PromptLoader';
 import type { AgentMode } from '../prompts/PromptComposer';
 import { MODES } from '../prompts/PromptComposer';
 import { HookRegistry } from './hooks/HookRegistry';
@@ -85,6 +94,7 @@ export class RepublicAgent {
   private hookDispatcher: HookDispatcher;
   private configHookUnsubscribe: (() => void) | null = null;
   private autoCompactHook: AutoCompactHook | null = null;
+  private cleanupPromise: Promise<void> | null = null;
 
   constructor(
     config: AgentConfig,
@@ -217,7 +227,10 @@ export class RepublicAgent {
     // Load and set instructions
     const userInstructions = await loadUserInstructions();
     taskContext.setUserInstructions(userInstructions);
-    const baseInstructions = await loadPrompt(this.session.getAgentMode());
+    const baseInstructions = await loadPrompt(
+      this.session.getAgentMode(),
+      this.getPromptRuntimeContext(taskContext),
+    );
     taskContext.setBaseInstructions(baseInstructions);
 
     // Set the turn context on the session
@@ -443,7 +456,7 @@ export class RepublicAgent {
     if (turnCtx) {
       turnCtx.setAgentMode(mode);
       try {
-        const baseInstructions = await loadPrompt(mode);
+        const baseInstructions = await loadPrompt(mode, this.getPromptRuntimeContext(turnCtx));
         turnCtx.setBaseInstructions(baseInstructions);
       } catch (error) {
         console.error('[RepublicAgent] Failed to recompose prompt on mode switch:', error);
@@ -529,6 +542,15 @@ export class RepublicAgent {
     this.autoCompactHook.attach((fn) => this.session.registerPostTurnHook(fn));
   }
 
+  private getPromptRuntimeContext(turnContext?: TurnContext): PromptRuntimeContext {
+    return {
+      sessionId: this.session.getSessionId(),
+      mode: this.session.getAgentMode(),
+      toolRegistry: this.toolRegistry,
+      turnContext: turnContext ?? this.session.getTurnContext(),
+    };
+  }
+
   private async syncMemoryTools(): Promise<void> {
     const ms = this.session.getMemoryService();
 
@@ -544,7 +566,7 @@ export class RepublicAgent {
       registerPromptExtension(RepublicAgent.MEMORY_PROMPT_EXTENSION, () => {
         const svc = this.session.getMemoryService();
         return svc ? svc.getCachedGlobalContext() : '';
-      });
+      }, { type: 'session', sessionId: this.session.getSessionId() });
     } else {
       // Unregister tools
       for (const name of RepublicAgent.MEMORY_TOOL_NAMES) {
@@ -554,7 +576,10 @@ export class RepublicAgent {
       }
 
       // Unregister prompt extension
-      unregisterPromptExtension(RepublicAgent.MEMORY_PROMPT_EXTENSION);
+      unregisterPromptExtension(RepublicAgent.MEMORY_PROMPT_EXTENSION, {
+        type: 'session',
+        sessionId: this.session.getSessionId(),
+      });
     }
   }
 
@@ -592,7 +617,10 @@ export class RepublicAgent {
         ),
       );
 
-      const baseInstructions = await loadPrompt(this.session.getAgentMode());
+      const baseInstructions = await loadPrompt(
+        this.session.getAgentMode(),
+        this.getPromptRuntimeContext(taskContext),
+      );
       taskContext.setBaseInstructions(baseInstructions);
     } catch (error) {
       console.error('[RepublicAgent] Failed to refresh model client:', error);
@@ -633,7 +661,10 @@ export class RepublicAgent {
       ),
     );
 
-    const baseInstructions = await loadPrompt(this.session.getAgentMode());
+    const baseInstructions = await loadPrompt(
+      this.session.getAgentMode(),
+      this.getPromptRuntimeContext(turnCtx),
+    );
     turnCtx.setBaseInstructions(baseInstructions);
   }
 
@@ -1362,6 +1393,14 @@ export class RepublicAgent {
    * Cleanup resources
    */
   async cleanup(): Promise<void> {
+    if (this.cleanupPromise) {
+      return this.cleanupPromise;
+    }
+    this.cleanupPromise = this.cleanupOnce();
+    return this.cleanupPromise;
+  }
+
+  private async cleanupOnce(): Promise<void> {
     // Fire SessionEnd hooks with short timeout (1.5s) before tearing things down.
     // Failures here must not block shutdown.
     try {
@@ -1386,6 +1425,8 @@ export class RepublicAgent {
     if (this.engine) {
       await this.engine.dispose();
     }
+    await this.session.dispose({ reason: 'Shutdown' });
+    unregisterSessionPromptExtensions(this.session.getSessionId());
     await this.toolRegistry.cleanup();
     this.toolRegistry.clear();
     this.eventQueue = [];

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -69,7 +69,7 @@ export interface SessionDisposeOptions {
   recordCloseEvent?: boolean;
   /** Defaults to true. */
   flushRollout?: boolean;
-  /** Defaults to true for non-persistent sessions. */
+  /** Defaults to true, but cleanup only runs for non-persistent sessions. */
   cleanupToolResults?: boolean;
 }
 
@@ -2576,6 +2576,8 @@ export class Session {
    *
    * Records ResponseItems to both SessionState (in-memory history) and
    * RolloutRecorder (persistent storage).
+   * Concurrent callers are serialized through conversationCommitChain; callers
+   * only need to await their own returned promise.
    */
   async recordConversationItemsDual(items: ResponseItem[]): Promise<void> {
     const commit = this.conversationCommitChain.then(async () => {

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -53,12 +53,25 @@ import type {
 /**
  * Post-turn hook signature. Owned by Session because TurnManager is per-task
  * but hooks (notably the session-summary extractor) live the length of the
- * session. TurnManager fires hooks via `session.firePostTurnHooks(ctx)`.
+ * session. TaskRunner fires hooks after committing the turn delta.
  */
 export type PostTurnHook = (ctx: PostTurnContext) => Promise<void> | void;
 
 /** Lightweight alias so the field declaration doesn't pull the full class. */
 type SessionSummaryHookHandle = SessionSummaryHook;
+
+export interface SessionDisposeOptions {
+  /** Abort reason used for any active tasks still running during disposal. */
+  reason?: TurnAbortReason;
+  /** Defaults to true; set false only for legacy callers that already aborted. */
+  abortTasks?: boolean;
+  /** Preserve Session.close()'s rollout close marker when requested. */
+  recordCloseEvent?: boolean;
+  /** Defaults to true. */
+  flushRollout?: boolean;
+  /** Defaults to true for non-persistent sessions. */
+  cleanupToolResults?: boolean;
+}
 
 // Title generation imports
 import { TitleGenerator } from './title';
@@ -107,6 +120,7 @@ export class Session {
   private _mockCwd = '/'; // For backward compatibility in tests
   private eventEmitter: ((event: Event) => Promise<void>) | null = null;
   private isPersistent: boolean = true;
+  private isForkedContext = false;
   private toolRegistry: ToolRegistry | null = null; // Tool registry from RepublicAgent
 
   // Runtime state (not persisted, lives in Session only)
@@ -149,6 +163,9 @@ export class Session {
   private initError: Error | null = null;
   private hookDispatcher: HookDispatcher | null = null;
   private terminalTaskHookEmitted: Set<string> = new Set();
+  private disposeState: 'active' | 'disposing' | 'disposed' = 'active';
+  private disposePromise: Promise<void> | null = null;
+  private conversationCommitChain: Promise<void> = Promise.resolve();
 
   // Track 05b: per-session post-turn callbacks (e.g. session-summary
   // extractor). TurnManager is created per-task; the callback list lives on
@@ -185,6 +202,7 @@ export class Session {
         this.sessionId = crypto.randomUUID();
       }
     }
+    this.isForkedContext = initialHistory?.mode === 'forked';
 
     // Handle both new and old signatures for backward compatibility
     if (typeof configOrIsPersistent === 'boolean') {
@@ -564,6 +582,22 @@ export class Session {
    */
   getSessionId(): string {
     return this.sessionId;
+  }
+
+  /**
+   * True for durable top-level sessions. Non-persistent child/fork sessions
+   * can clean transient stores on dispose because no rollout will resume them.
+   */
+  isPersistentSession(): boolean {
+    return this.isPersistent;
+  }
+
+  /**
+   * Runtime metadata for sub-agent recursion guards. This deliberately does
+   * not depend on model-visible fork directive text.
+   */
+  isForkedSubAgentContext(): boolean {
+    return this.isForkedContext;
   }
 
   /**
@@ -970,47 +1004,7 @@ export class Session {
    * Close session and cleanup resources using RolloutRecorder
    */
   async close(): Promise<void> {
-    await this.closeMemoryService();
-
-    // Tool result persistence cleanup (track 09).
-    //
-    // Only purge persisted results on close for non-persistent sessions.
-    // Persistent sessions can be resumed — the rollout still contains
-    // <persisted-output> messages pointing at these storage keys / file
-    // paths, and the agent must be able to retrieve the full content on
-    // resume. Stale entries from persistent sessions are reclaimed via
-    // server-mode TTL sweep / cache quota eviction instead.
-    if (this.toolResultStore && !this.isPersistent) {
-      try {
-        await this.toolResultStore.cleanup(this.sessionId);
-      } catch (error) {
-        console.error('Failed to clean up tool result store:', error);
-      }
-    }
-
-    if (this.services?.rollout) {
-      try {
-        // Record session close event
-        const closeEvent: EventMsg = {
-          type: 'BackgroundEvent',
-          data: {
-            message: `Session closed: ${this.sessionId} (${this.getMessageCount()} messages)`
-          }
-        };
-
-        const rolloutItems: RolloutItem[] = [{
-          type: 'event_msg',
-          payload: closeEvent
-        }];
-
-        await this.services.rollout.recordItems(rolloutItems);
-
-        // Flush and close rollout recorder
-        await this.services.rollout.flush();
-      } catch (error) {
-        console.error('Failed to close rollout recorder:', error);
-      }
-    }
+    await this.dispose({ recordCloseEvent: true });
   }
 
   /**
@@ -1581,17 +1575,57 @@ export class Session {
    * Graceful shutdown
    */
   async shutdown(): Promise<void> {
+    await this.dispose({ reason: 'Shutdown' });
+  }
+
+  /**
+   * Idempotent terminal cleanup for a Session. This is the single place that
+   * stops active work, detaches session-owned hooks, closes memory services,
+   * cleans transient tool result storage, and flushes rollout state.
+   */
+  async dispose(options: SessionDisposeOptions = {}): Promise<void> {
+    if (this.disposeState === 'disposed') return;
+    if (this.disposeState === 'disposing' && this.disposePromise) {
+      return this.disposePromise;
+    }
+
+    this.disposeState = 'disposing';
+    this.disposePromise = this.disposeCore(options)
+      .finally(() => {
+        this.disposeState = 'disposed';
+      });
+    return this.disposePromise;
+  }
+
+  private async disposeCore(options: SessionDisposeOptions): Promise<void> {
+    const {
+      reason = 'Shutdown',
+      abortTasks = true,
+      recordCloseEvent = false,
+      flushRollout = true,
+      cleanupToolResults = true,
+    } = options;
+
+    if (abortTasks) {
+      try {
+        await this.abortAllTasks(reason);
+      } catch (err) {
+        console.warn(
+          '[Session] abortAllTasks failed during dispose:',
+          err instanceof Error ? err.message : String(err),
+        );
+        this.activeTasks.clear();
+        this.foregroundTaskId = null;
+      }
+    }
+
     try {
-      await this.abortAllTasks('Shutdown');
+      this.clearEvictionTimer();
     } catch (err) {
       console.warn(
-        '[Session] abortAllTasks failed during shutdown:',
+        '[Session] clearEvictionTimer failed during dispose:',
         err instanceof Error ? err.message : String(err),
       );
-      this.activeTasks.clear();
-      this.foregroundTaskId = null;
-    } finally {
-      this.clearEvictionTimer();
     }
 
     // Track 05b: detach the session-summary hook (unregisters post-turn
@@ -1609,9 +1643,55 @@ export class Session {
 
     await this.closeMemoryService();
 
+    // Tool result persistence cleanup (track 09).
+    //
+    // Only purge persisted results on dispose for non-persistent sessions.
+    // Persistent sessions can be resumed — the rollout still contains
+    // <persisted-output> messages pointing at these storage keys / file
+    // paths, and the agent must be able to retrieve the full content on
+    // resume. Stale entries from persistent sessions are reclaimed via
+    // server-mode TTL sweep / cache quota eviction instead.
+    if (cleanupToolResults && this.toolResultStore && !this.isPersistent) {
+      try {
+        await this.toolResultStore.cleanup(this.sessionId);
+      } catch (error) {
+        console.error('Failed to clean up tool result store:', error);
+      }
+    }
+
+    try {
+      await this.shadowAgentScheduler?.shutdown();
+    } catch (err) {
+      console.warn(
+        '[Session] shadowAgentScheduler.shutdown failed during dispose:',
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    this.shadowAgentScheduler = null;
+
+    await this.waitForConversationCommits();
+
     if (this.services?.rollout) {
       try {
-        await this.services.rollout.flush();
+        if (recordCloseEvent) {
+          const closeEvent: EventMsg = {
+            type: 'BackgroundEvent',
+            data: {
+              message: `Session closed: ${this.sessionId} (${this.getMessageCount()} messages)`
+            }
+          };
+
+          const rolloutItems: RolloutItem[] = [{
+            type: 'event_msg',
+            payload: closeEvent
+          }];
+
+          await this.services.rollout.recordItems(rolloutItems);
+        }
+
+        if (flushRollout) {
+          await this.services.rollout.flush();
+        }
       } catch (e) {
         console.error('Failed to flush rollout recorder:', e);
       }
@@ -2498,18 +2578,30 @@ export class Session {
    * RolloutRecorder (persistent storage).
    */
   async recordConversationItemsDual(items: ResponseItem[]): Promise<void> {
-    // If incoming items contain any DOM snapshot output, compress previous snapshots in history first
-    // This keeps the latest snapshot fresh for LLM reasoning
-    if (items.some(item => isDOMSnapshotOutput(item))) {
-      // Compress previous DOM snapshots BEFORE recording new items
-      this.sessionState.compressPreviousDomSnapshot();
+    const commit = this.conversationCommitChain.then(async () => {
+      // If incoming items contain any DOM snapshot output, compress previous snapshots in history first
+      // This keeps the latest snapshot fresh for LLM reasoning
+      if (items.some(item => isDOMSnapshotOutput(item))) {
+        // Compress previous DOM snapshots BEFORE recording new items
+        this.sessionState.compressPreviousDomSnapshot();
+      }
+
+      // Record to SessionState (in-memory history)
+      this.sessionState.recordItems(items);
+
+      // Persist to rollout storage
+      await this.persistRolloutResponseItems(items);
+    });
+    this.conversationCommitChain = commit.catch(() => undefined);
+    return commit;
+  }
+
+  private async waitForConversationCommits(): Promise<void> {
+    try {
+      await this.conversationCommitChain;
+    } catch {
+      // Individual commit failures are already handled by their callers.
     }
-
-    // Record to SessionState (in-memory history)
-    this.sessionState.recordItems(items);
-
-    // Persist to rollout storage
-    await this.persistRolloutResponseItems(items);
   }
 
   /**

--- a/src/core/TaskRunner.ts
+++ b/src/core/TaskRunner.ts
@@ -816,6 +816,30 @@ export class TaskRunner {
       await this.session.recordConversationItemsDual(itemsToRecord);
     }
 
+    // Post-turn hooks must observe the committed history. TurnManager builds
+    // the turn delta, while TaskRunner is the first point after the in-memory
+    // and durable conversation writes have completed.
+    const sess = this.session as unknown as {
+      firePostTurnHooks?: (ctx: unknown) => Promise<void>;
+      getSessionId?: () => string;
+      getConversationHistory?: () => { items: ResponseItem[] };
+    };
+    if (typeof sess.firePostTurnHooks === 'function') {
+      const historyItems =
+        typeof sess.getConversationHistory === 'function'
+          ? sess.getConversationHistory().items
+          : [];
+      const sessionId =
+        typeof sess.getSessionId === 'function' ? sess.getSessionId() : '';
+      await sess.firePostTurnHooks({
+        sessionId,
+        history: historyItems,
+        committedDelta: itemsToRecord,
+        totalTokenUsage,
+        lastTurnHadToolCalls: Boolean(turnResult.lastTurnHadToolCalls),
+      });
+    }
+
     // Extract last assistant message from recorded items
     const lastAgentMessage = this.getLastAssistantMessageFromTurn(itemsToRecord);
 

--- a/src/core/TurnManager.ts
+++ b/src/core/TurnManager.ts
@@ -10,7 +10,8 @@ import { TurnContext } from './TurnContext';
 import { withModelRetry } from './models/resilience/withRetry';
 import { calculateUSDCost } from './models/cost/cost';
 import { AgentConfig } from '../config/AgentConfig';
-import { loadPrompt } from './PromptLoader';
+import { loadPrompt, type PromptRuntimeContext } from './PromptLoader';
+import { DEFAULT_MODE, type AgentMode } from '../prompts/PromptComposer';
 import type {
   CompactionCompletedEvent,
   EventMsg,
@@ -85,6 +86,8 @@ export interface TurnRunResult {
   turnCostUSD?: number;
   /** Track 18: true when the model was absent from the cost table. */
   turnCostEstimated?: boolean;
+  /** True when this turn included any model-requested tool call. */
+  lastTurnHadToolCalls?: boolean;
 }
 
 /**
@@ -186,6 +189,19 @@ export class TurnManager {
     return this.cancelled;
   }
 
+  private getPromptRuntimeContext(): PromptRuntimeContext {
+    return {
+      sessionId: this.session.getSessionId?.() ?? this.turnContext.getSessionId?.() ?? this.session.sessionId,
+      mode: this.getAgentMode(),
+      toolRegistry: this.toolRegistry,
+      turnContext: this.turnContext,
+    };
+  }
+
+  private getAgentMode(): AgentMode {
+    return this.turnContext.getAgentMode?.() ?? this.session.getAgentMode?.() ?? DEFAULT_MODE;
+  }
+
   /**
    * Run a complete turn with retry logic
    */
@@ -199,7 +215,10 @@ export class TurnManager {
     // Falls back to the value cached on TurnContext if reload throws.
     let baseInstructions: string | undefined;
     try {
-      baseInstructions = await loadPrompt(this.turnContext.getAgentMode());
+      baseInstructions = await loadPrompt(
+        this.getAgentMode(),
+        this.getPromptRuntimeContext(),
+      );
     } catch (err) {
       console.warn('[TurnManager] loadPrompt() failed, reusing cached base instructions:', err);
       baseInstructions = this.turnContext.getBaseInstructions();
@@ -300,7 +319,9 @@ export class TurnManager {
           }
           currentInput = (await this.session.buildTurnInputWithHistory([])) as any[];
           try {
-            currentBaseInstructions = this.withToolExposureReminder(await loadPrompt());
+            currentBaseInstructions = this.withToolExposureReminder(
+              await loadPrompt(this.getAgentMode(), this.getPromptRuntimeContext()),
+            );
           } catch {
             currentBaseInstructions = this.withToolExposureReminder(this.turnContext.getBaseInstructions());
           }
@@ -493,47 +514,18 @@ export class TurnManager {
               await this.enforceImmediateLegacyTier2(processedItems);
             }
 
-            // Track 05b: fire post-turn hooks before returning. Hooks are
-            // owned by Session (since TurnManager is per-task but post-turn
-            // listeners — notably the session-summary extractor — live the
-            // length of the session). Errors are swallowed inside
-            // firePostTurnHooks so a misbehaving hook can't break the turn.
-            //
-            // Defensive `typeof` checks: many existing test fixtures mock
-            // Session without these methods. In production the real Session
-            // class always provides them; in tests we no-op gracefully.
-            const sess = this.session as unknown as {
-              firePostTurnHooks?: (ctx: unknown) => Promise<void>;
-              getSessionId?: () => string;
-              getConversationHistory?: () => { items: unknown[] };
-            };
-            if (typeof sess.firePostTurnHooks === 'function') {
-              const lastTurnHadToolCalls = processedItems.some(
-                (p) =>
-                  p.item?.type === 'function_call' ||
-                  p.item?.type === 'custom_tool_call',
-              );
-              const historyItems =
-                typeof sess.getConversationHistory === 'function'
-                  ? sess.getConversationHistory().items
-                  : [];
-              const sessionId =
-                typeof sess.getSessionId === 'function'
-                  ? sess.getSessionId()
-                  : '';
-              await sess.firePostTurnHooks({
-                sessionId,
-                history: historyItems,
-                totalTokenUsage,
-                lastTurnHadToolCalls,
-              });
-            }
+            const lastTurnHadToolCalls = processedItems.some(
+              (p) =>
+                p.item?.type === 'function_call' ||
+                p.item?.type === 'custom_tool_call',
+            );
 
             return {
               processedItems,
               totalTokenUsage,
               turnCostUSD,
               turnCostEstimated,
+              lastTurnHadToolCalls,
             };
           }
 
@@ -1142,7 +1134,12 @@ export class TurnManager {
     if (cached !== undefined) return cached;
 
     try {
-      const persisted = await store.persist(this.session.sessionId, callId, output);
+      const owner = this.session.isPersistentSession?.()
+        ? { kind: 'persistent_rollout' as const, sessionId: this.session.sessionId, callId }
+        : { kind: 'transient_session' as const, sessionId: this.session.sessionId, callId };
+      const persisted = await store.persist(this.session.sessionId, callId, output, {
+        owner,
+      });
       const message = buildPersistedOutputMessage(persisted);
       state.record(callId, message);
       return message;
@@ -1427,7 +1424,7 @@ export class TurnManager {
           // Per-session handles for the file-access tools (design §4.5). Live
           // in-process object refs; the session-less tools/index.ts path simply
           // omits these and the tools degrade gracefully.
-          workspaceRoot: this.session.getWorkspaceRoot(),
+          workspaceRoot: this.session.getWorkspaceRoot?.(),
           fileStateCache: this.session.getFileStateCache?.(),
           agentMode: this.session.getAgentMode?.(), // §4.2: file tools are code-mode only
         },

--- a/src/core/TurnManager.ts
+++ b/src/core/TurnManager.ts
@@ -191,7 +191,7 @@ export class TurnManager {
 
   private getPromptRuntimeContext(): PromptRuntimeContext {
     return {
-      sessionId: this.session.getSessionId?.() ?? this.turnContext.getSessionId?.() ?? this.session.sessionId,
+      sessionId: this.session.getSessionId(),
       mode: this.getAgentMode(),
       toolRegistry: this.toolRegistry,
       turnContext: this.turnContext,

--- a/src/core/__tests__/BrowserxAgent.model-switch.test.ts
+++ b/src/core/__tests__/BrowserxAgent.model-switch.test.ts
@@ -43,6 +43,9 @@ vi.mock('@/core/PromptLoader', () => ({
   loadUserInstructions: vi.fn(async () => 'user-instructions'),
   isComposerConfigured: vi.fn(() => false),
   configurePromptComposer: vi.fn(),
+  registerPromptExtension: vi.fn(),
+  unregisterPromptExtension: vi.fn(),
+  unregisterSessionPromptExtensions: vi.fn(),
 }));
 
 vi.mock('@/tools/registerPlatformTools', () => ({
@@ -215,6 +218,8 @@ describe('BrowserxAgent - handleModelConfigChange', () => {
       getTabId: vi.fn().mockReturnValue(-1),
       setTabId: vi.fn(),
       getId: vi.fn().mockReturnValue('session-id-1'),
+      getSessionId: vi.fn().mockReturnValue('conv-123'),
+      getAgentMode: vi.fn().mockReturnValue('general'),
       getConversationHistory: vi.fn().mockReturnValue({
         items: [
           { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
@@ -231,6 +236,13 @@ describe('BrowserxAgent - handleModelConfigChange', () => {
       getHistoryEntry: vi.fn(),
       clearHistory: vi.fn(),
       shutdown: vi.fn().mockResolvedValue(undefined),
+      dispose: vi.fn().mockResolvedValue(undefined),
+      refreshMemoryService: vi.fn().mockResolvedValue(undefined),
+      getMemoryService: vi.fn().mockReturnValue(null),
+      getSessionSummaryHook: vi.fn().mockReturnValue(null),
+      setSessionSummaryHook: vi.fn(),
+      registerPostTurnHook: vi.fn().mockReturnValue(() => undefined),
+      initialize: vi.fn().mockResolvedValue(undefined),
       initializeSession: vi.fn().mockResolvedValue(undefined),
       notifyApproval: vi.fn(),
       compact: vi.fn().mockResolvedValue({
@@ -254,6 +266,7 @@ describe('BrowserxAgent - handleModelConfigChange', () => {
 
     mockModelClientFactoryInstance = {
       initialize: vi.fn().mockResolvedValue(undefined),
+      clearCache: vi.fn(),
       createClientForCurrentModel: vi.fn().mockResolvedValue(
         makeMockModelClient('default-model')
       ),
@@ -330,13 +343,15 @@ describe('BrowserxAgent - handleModelConfigChange', () => {
       expect(mockTurnContextInstance.setSelectedModelKey).toHaveBeenCalledWith('anthropic:claude-4');
 
       // Should emit a BackgroundEvent confirming the immediate switch
-      const infoEvent = dispatcherSpy.mock.calls.find(
-        (call: any[]) =>
-          call[0]?.msg?.type === 'BackgroundEvent' &&
-          call[0]?.msg?.data?.level === 'info' &&
-          call[0]?.msg?.data?.message?.includes('Model switched to anthropic:claude-4')
-      );
-      expect(infoEvent).toBeDefined();
+      await vi.waitFor(() => {
+        const infoEvent = dispatcherSpy.mock.calls.find(
+          (call: any[]) =>
+            call[0]?.msg?.type === 'BackgroundEvent' &&
+            call[0]?.msg?.data?.level === 'info' &&
+            call[0]?.msg?.data?.message?.includes('Model switched to anthropic:claude-4')
+        );
+        expect(infoEvent).toBeDefined();
+      });
     });
 
     it('should not call createClientForCurrentModel when oldValue equals newValue', async () => {
@@ -787,18 +802,19 @@ describe('BrowserxAgent - handleModelConfigChange', () => {
   // =========================================================================
 
   describe('Edge cases', () => {
-    it('should ignore config-changed events with non-model section', async () => {
-      // Emit a non-model config change - the handler should not fire
+    it('should ignore config-changed events unrelated to model client construction', async () => {
+      // Emit a config change that should not affect the active model client.
       const handlers = config._handlers.get('config-changed');
       expect(handlers).toBeDefined();
       expect(handlers!.size).toBeGreaterThan(0);
 
-      // Emit a provider change
+      // Provider and tools changes intentionally refresh model-client construction;
+      // preferences changes should not.
       config._emit({
         type: 'config-changed',
-        section: 'provider',
+        section: 'preferences',
         oldValue: null,
-        newValue: { id: 'new-provider' },
+        newValue: { showRawAgentReasoning: true },
         timestamp: Date.now(),
       });
 

--- a/src/core/__tests__/PromptLoader.test.ts
+++ b/src/core/__tests__/PromptLoader.test.ts
@@ -110,6 +110,31 @@ describe('PromptLoader', () => {
     expect(prompt.indexOf('SKILLS_EXTENSION_MARKER')).toBeGreaterThan(prompt.indexOf('MEMORY_EXTENSION_MARKER'));
   });
 
+  it('isolates session-scoped prompt extensions by session id', async () => {
+    const {
+      loadPrompt,
+      configurePromptComposer,
+      registerPromptExtension,
+      unregisterSessionPromptExtensions,
+    } = await import('@/core/PromptLoader');
+
+    configurePromptComposer('browserx');
+    registerPromptExtension('session-only', () => 'SESSION_A_MARKER', {
+      type: 'session',
+      sessionId: 'session-a',
+    });
+
+    const promptA = await loadPrompt(undefined, { sessionId: 'session-a' });
+    const promptB = await loadPrompt(undefined, { sessionId: 'session-b' });
+
+    expect(promptA).toContain('SESSION_A_MARKER');
+    expect(promptB).not.toContain('SESSION_A_MARKER');
+
+    unregisterSessionPromptExtensions('session-a');
+    const promptAfterCleanup = await loadPrompt(undefined, { sessionId: 'session-a' });
+    expect(promptAfterCleanup).not.toContain('SESSION_A_MARKER');
+  });
+
   it('includes fresh currentDateTime on each loadPrompt call', async () => {
     const { loadPrompt, configurePromptComposer } = await import('@/core/PromptLoader');
 

--- a/src/core/__tests__/RepublicAgent.test.ts
+++ b/src/core/__tests__/RepublicAgent.test.ts
@@ -42,6 +42,7 @@ vi.mock('../PromptLoader', () => ({
   configurePromptComposer: vi.fn(),
   registerPromptExtension: vi.fn(),
   unregisterPromptExtension: vi.fn(),
+  unregisterSessionPromptExtensions: vi.fn(),
 }));
 
 vi.mock('../../tools/registerPlatformTools', () => ({
@@ -176,6 +177,7 @@ describe('RepublicAgent', () => {
       getTabId: vi.fn().mockReturnValue(-1),
       setTabId: vi.fn(),
       getId: vi.fn().mockReturnValue('session-id-1'),
+      getSessionId: vi.fn().mockReturnValue('conv-123'),
       getAgentMode: vi.fn().mockReturnValue('general'),
       setAgentMode: vi.fn(),
       getConversationHistory: vi.fn().mockReturnValue({ items: [] }),
@@ -192,6 +194,7 @@ describe('RepublicAgent', () => {
       getHistoryEntry: vi.fn(),
       clearHistory: vi.fn(),
       shutdown: vi.fn().mockResolvedValue(undefined),
+      dispose: vi.fn().mockResolvedValue(undefined),
       refreshMemoryService: vi.fn().mockResolvedValue(undefined),
       // Track 05b: session-summary hook accessors
       setSessionSummaryHook: vi.fn(),
@@ -608,7 +611,10 @@ describe('RepublicAgent', () => {
 
       expect(mockSessionInstance.setAgentMode).toHaveBeenCalledWith('code');
       expect(turnContext.setAgentMode).toHaveBeenCalledWith('code');
-      expect(loadPrompt).toHaveBeenCalledWith('code');
+      expect(loadPrompt).toHaveBeenCalledWith(
+        'code',
+        expect.objectContaining({ sessionId: 'conv-123' }),
+      );
       expect(turnContext.setBaseInstructions).toHaveBeenCalledWith('base-instructions');
       expect(dispatcherSpy.mock.calls.some(
         (call: any[]) =>

--- a/src/core/__tests__/RepublicAgent.test.ts
+++ b/src/core/__tests__/RepublicAgent.test.ts
@@ -114,7 +114,7 @@ import { AgentConfig } from '../../config/AgentConfig';
 import { Session } from '../Session';
 import type { Op } from '../protocol/types';
 import type { Event } from '../protocol/events';
-import { loadPrompt } from '../PromptLoader';
+import { loadPrompt, unregisterSessionPromptExtensions } from '../PromptLoader';
 
 // ---------------------------------------------------------------------------
 // Helper: create mock AgentConfig (plain object, not through vi.mock)
@@ -864,6 +864,18 @@ describe('RepublicAgent', () => {
       await agent.cleanup();
 
       expect(mockUserNotifierInstance.clearAll).toHaveBeenCalled();
+    });
+
+    it('removes session-scoped prompt extensions after disposing the session', async () => {
+      vi.mocked(unregisterSessionPromptExtensions).mockClear();
+
+      await agent.cleanup();
+
+      expect(unregisterSessionPromptExtensions).toHaveBeenCalledWith('conv-123');
+      expect(mockSessionInstance.dispose).toHaveBeenCalled();
+      expect(mockSessionInstance.dispose.mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(unregisterSessionPromptExtensions).mock.invocationCallOrder[0],
+      );
     });
 
     it('unsubscribes config hook watcher and removes config hooks on cleanup', async () => {

--- a/src/core/__tests__/TaskRunner.postTurnHook.test.ts
+++ b/src/core/__tests__/TaskRunner.postTurnHook.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TaskRunner } from '../TaskRunner';
+import type { ResponseItem } from '../protocol/types';
+
+describe('TaskRunner post-turn hooks', () => {
+  it('fires post-turn hooks after the turn delta is committed', async () => {
+    const history: ResponseItem[] = [];
+    const assistantMessage = {
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: 'done' }],
+    } as ResponseItem;
+
+    const session = {
+      recordConversationItemsDual: vi.fn(async (items: ResponseItem[]) => {
+        history.push(...items);
+      }),
+      firePostTurnHooks: vi.fn(async () => undefined),
+      getSessionId: () => 'session-1',
+      getConversationHistory: () => ({ items: history }),
+    };
+    const turnContext = {
+      getModelContextWindow: () => 100_000,
+      getAutoCompactTokenLimit: () => undefined,
+    };
+    const turnManager = { cancel: vi.fn() };
+
+    const runner = new TaskRunner(
+      session as never,
+      turnContext as never,
+      turnManager as never,
+      'submission-1',
+      [],
+    );
+
+    await (runner as unknown as {
+      processTurnResult: (result: unknown) => Promise<unknown>;
+    }).processTurnResult({
+      processedItems: [{ item: assistantMessage }],
+      totalTokenUsage: { total_tokens: 10, input_tokens: 5, output_tokens: 5 },
+      lastTurnHadToolCalls: false,
+    });
+
+    expect(session.recordConversationItemsDual).toHaveBeenCalledWith([assistantMessage]);
+    expect(session.firePostTurnHooks).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'session-1',
+      history: [assistantMessage],
+      committedDelta: [assistantMessage],
+      lastTurnHadToolCalls: false,
+    }));
+    expect(
+      session.recordConversationItemsDual.mock.invocationCallOrder[0],
+    ).toBeLessThan(session.firePostTurnHooks.mock.invocationCallOrder[0]!);
+  });
+});

--- a/src/core/__tests__/TurnManager.memory.integration.test.ts
+++ b/src/core/__tests__/TurnManager.memory.integration.test.ts
@@ -79,6 +79,7 @@ describe('TurnManager Memory Integration', () => {
         };
 
         mockSession = {
+            getSessionId: vi.fn().mockReturnValue('test-session-id'),
             getMemoryService: vi.fn().mockReturnValue(null),
             getToolRegistry: vi.fn().mockReturnValue(null),
             showRawAgentReasoning: vi.fn().mockReturnValue(false),

--- a/src/core/__tests__/TurnManager.memory.integration.test.ts
+++ b/src/core/__tests__/TurnManager.memory.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TurnManager } from '../TurnManager';
+import { setConfigStorage, type ConfigStorageProvider } from '../storage/ConfigStorageProvider';
 
 // Stub PromptLoader so the test does not depend on the bundled default prompt
 // and we can prove TurnManager pulls fresh base instructions per turn.
@@ -17,6 +18,44 @@ describe('TurnManager Memory Integration', () => {
     let turnManager: TurnManager;
 
     beforeEach(() => {
+        const storageData = new Map<string, unknown>();
+        const configStorage: ConfigStorageProvider = {
+            async get<T>(key: string): Promise<T | null> {
+                return storageData.has(key) ? (storageData.get(key) as T) : null;
+            },
+            async set<T>(key: string, value: T): Promise<void> {
+                storageData.set(key, value);
+            },
+            async remove(key: string): Promise<void> {
+                storageData.delete(key);
+            },
+            async getMany<T = unknown>(keys: string[]): Promise<Record<string, T>> {
+                const result: Record<string, T> = {};
+                for (const key of keys) {
+                    if (storageData.has(key)) result[key] = storageData.get(key) as T;
+                }
+                return result;
+            },
+            async setMany<T = unknown>(items: Record<string, T>): Promise<void> {
+                for (const [key, value] of Object.entries(items)) {
+                    storageData.set(key, value);
+                }
+            },
+            async removeMany(keys: string[]): Promise<void> {
+                for (const key of keys) storageData.delete(key);
+            },
+            async getAll(): Promise<Record<string, unknown>> {
+                return Object.fromEntries(storageData);
+            },
+            async clear(): Promise<void> {
+                storageData.clear();
+            },
+            async getBytesInUse(): Promise<number> {
+                return 0;
+            },
+        };
+        setConfigStorage(configStorage);
+
         (loadPrompt as any).mockReset();
         (loadPrompt as any).mockResolvedValue('Base instructions.');
 
@@ -36,6 +75,7 @@ describe('TurnManager Memory Integration', () => {
             getAgentMode: vi.fn().mockReturnValue('general'),
             getUnattended: vi.fn().mockReturnValue(false),
             getUnattendedResetCapMs: vi.fn().mockReturnValue(undefined),
+            setActiveToolAllowList: vi.fn(),
         };
 
         mockSession = {

--- a/src/core/__tests__/session-overhead.perf.test.ts
+++ b/src/core/__tests__/session-overhead.perf.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { AgentRegistry } from '@/core/registry/AgentRegistry';
+import { setConfigStorage, type ConfigStorageProvider } from '@/core/storage/ConfigStorageProvider';
 
 // Mock RepublicAgent with class
 vi.mock('@/core/RepublicAgent', () => {
@@ -31,6 +32,7 @@ vi.mock('@/core/RepublicAgent', () => {
           conversationId: `conv_${Date.now()}`,
           abortAllTasks: vi.fn().mockResolvedValue(undefined),
           close: vi.fn().mockResolvedValue(undefined),
+          dispose: vi.fn().mockResolvedValue(undefined),
           setTabId: vi.fn(),
         };
       }
@@ -41,7 +43,7 @@ vi.mock('@/core/RepublicAgent', () => {
         return {};
       }
       getToolRegistry() {
-        return { getTool: vi.fn(), setApprovalGate: vi.fn() };
+        return { getTool: vi.fn(), setApprovalGate: vi.fn(), setPaymentCapability: vi.fn() };
       }
       getHookDispatcher() {
         return { fire: vi.fn().mockResolvedValue({}) };
@@ -86,6 +88,43 @@ describe('Session Creation Performance (SC-006)', () => {
     vi.clearAllMocks();
     AgentRegistry.resetInstance();
     global.chrome = mockChrome as any;
+    const storageData = new Map<string, unknown>();
+    const configStorage: ConfigStorageProvider = {
+      async get<T>(key: string): Promise<T | null> {
+        return storageData.has(key) ? (storageData.get(key) as T) : null;
+      },
+      async set<T>(key: string, value: T): Promise<void> {
+        storageData.set(key, value);
+      },
+      async remove(key: string): Promise<void> {
+        storageData.delete(key);
+      },
+      async getMany<T = unknown>(keys: string[]): Promise<Record<string, T>> {
+        const result: Record<string, T> = {};
+        for (const key of keys) {
+          if (storageData.has(key)) result[key] = storageData.get(key) as T;
+        }
+        return result;
+      },
+      async setMany<T = unknown>(items: Record<string, T>): Promise<void> {
+        for (const [key, value] of Object.entries(items)) {
+          storageData.set(key, value);
+        }
+      },
+      async removeMany(keys: string[]): Promise<void> {
+        for (const key of keys) storageData.delete(key);
+      },
+      async getAll(): Promise<Record<string, unknown>> {
+        return Object.fromEntries(storageData);
+      },
+      async clear(): Promise<void> {
+        storageData.clear();
+      },
+      async getBytesInUse(): Promise<number> {
+        return 0;
+      },
+    };
+    setConfigStorage(configStorage);
 
     registry = AgentRegistry.getInstance({ maxConcurrent: 10 });
     registry.initialize(mockConfig as any);

--- a/src/core/a2a/__tests__/A2AToolAdapter.test.ts
+++ b/src/core/a2a/__tests__/A2AToolAdapter.test.ts
@@ -810,7 +810,7 @@ describe('A2AToolAdapter — registerA2ASkills', () => {
 
     await registerA2ASkills(manager, 'agent', skills, registry, true);
 
-    const riskAssessor = registry.register.mock.calls[0][2];
+    const riskAssessor = registry.register.mock.calls[0][2].riskAssessor;
     const assessment = riskAssessor.assess('tool', {});
     expect(assessment.action).toBe('auto_approve');
   });
@@ -822,7 +822,7 @@ describe('A2AToolAdapter — registerA2ASkills', () => {
 
     await registerA2ASkills(manager, 'agent', skills, registry, false);
 
-    const riskAssessor = registry.register.mock.calls[0][2];
+    const riskAssessor = registry.register.mock.calls[0][2].riskAssessor;
     const assessment = riskAssessor.assess('tool', {});
     expect(assessment.action).toBe('ask_user');
   });

--- a/src/core/plugins/policy.ts
+++ b/src/core/plugins/policy.ts
@@ -188,12 +188,15 @@ export const ALLOWED_OFFICIAL_MARKETPLACE_NAMES: readonly string[] = [];
 export const BLOCKED_OFFICIAL_NAME_PATTERN =
   /(official.*\b(browserx|airepublic)\b|\b(browserx|airepublic)\b.*official|^(browserx|airepublic)[-_](marketplace|plugins|official))/i;
 
-const NON_ASCII_PATTERN = /[^\x00-\x7F]/;
 const OFFICIAL_GITHUB_ORG = 'browserx';
+
+function containsNonAscii(value: string): boolean {
+  return Array.from(value).some((char) => char.charCodeAt(0) > 0x7f);
+}
 
 /** Names that look "official" (or use homographs) are reserved. */
 export function isBlockedOfficialName(name: string): boolean {
-  if (NON_ASCII_PATTERN.test(name)) return true; // homograph guard
+  if (containsNonAscii(name)) return true; // homograph guard
   if (BLOCKED_OFFICIAL_NAME_PATTERN.test(name)) {
     return !ALLOWED_OFFICIAL_MARKETPLACE_NAMES.includes(name);
   }

--- a/src/core/plugins/policy.ts
+++ b/src/core/plugins/policy.ts
@@ -191,7 +191,10 @@ export const BLOCKED_OFFICIAL_NAME_PATTERN =
 const OFFICIAL_GITHUB_ORG = 'browserx';
 
 function containsNonAscii(value: string): boolean {
-  return Array.from(value).some((char) => char.charCodeAt(0) > 0x7f);
+  for (let i = 0; i < value.length; i += 1) {
+    if (value.charCodeAt(i) > 0x7f) return true;
+  }
+  return false;
 }
 
 /** Names that look "official" (or use homographs) are reserved. */

--- a/src/core/protocol/events.ts
+++ b/src/core/protocol/events.ts
@@ -762,15 +762,25 @@ export interface ToolExecutionEndEvent {
 
 export interface ToolExecutionErrorEvent {
   tool_name: string;
+  call_id?: string;
   session_id?: string;
+  turn_id?: string;
+  code?: string;
   error: string;
+  details?: unknown;
   duration?: number;
 }
 
 export interface ToolExecutionTimeoutEvent {
   tool_name: string;
+  call_id?: string;
   session_id?: string;
+  turn_id?: string;
+  code?: string;
+  error?: string;
+  details?: unknown;
   timeout_ms: number;
+  duration?: number;
 }
 
 export interface ToolExecutionProgressEvent {

--- a/src/core/registry/AgentSession.ts
+++ b/src/core/registry/AgentSession.ts
@@ -472,9 +472,9 @@ export class AgentSession {
     if (this._agent) {
       try {
         const session = this._agent.getSession();
-        // Use 'UserInterrupt' as the abort reason for session termination
-        await session.abortAllTasks('UserInterrupt');
-        await session.close();
+        const abortReason =
+          reason === 'tabClosed' ? 'TabClosed' : reason === 'error' ? 'Error' : 'UserInterrupt';
+        await session.dispose({ reason: abortReason, recordCloseEvent: true });
         await this._agent.cleanup();
       } catch (error) {
         console.error(`[AgentSession] Error during agent cleanup:`, error);

--- a/src/core/registry/__tests__/AgentSession.test.ts
+++ b/src/core/registry/__tests__/AgentSession.test.ts
@@ -12,6 +12,7 @@ const mockSession = {
   sessionId: 'conv_test_123',
   abortAllTasks: vi.fn(),
   close: vi.fn(),
+  dispose: vi.fn(),
   setTabId: vi.fn(),
 };
 
@@ -261,8 +262,12 @@ describe('AgentSession', () => {
 
       await session.terminate('error');
 
-      expect(mockAgent.getSession().abortAllTasks).toHaveBeenCalled();
-      expect(mockAgent.getSession().close).toHaveBeenCalled();
+      expect(mockAgent.getSession().dispose).toHaveBeenCalledWith({
+        reason: 'Error',
+        recordCloseEvent: true,
+      });
+      expect(mockAgent.getSession().abortAllTasks).not.toHaveBeenCalled();
+      expect(mockAgent.getSession().close).not.toHaveBeenCalled();
       expect(mockAgent.cleanup).toHaveBeenCalled();
       expect(session.agent).toBeNull();
     });

--- a/src/core/sessionSummary/SessionSummaryHook.ts
+++ b/src/core/sessionSummary/SessionSummaryHook.ts
@@ -64,11 +64,14 @@ export interface SessionSummaryHookOptions {
 
 /**
  * Context passed to the post-turn callback. Kept minimal: everything the
- * hook needs is derivable from these four fields.
+ * hook needs is derivable from the committed history plus the current turn
+ * delta.
  */
 export interface PostTurnContext {
   sessionId: string;
   history: ResponseItem[];
+  /** Response items committed by the just-completed turn. */
+  committedDelta?: ResponseItem[];
   totalTokenUsage?: { total_tokens?: number; input_tokens?: number; output_tokens?: number };
   lastTurnHadToolCalls: boolean;
 }
@@ -134,7 +137,11 @@ export class SessionSummaryHook {
 
     // Register the sync prompt-extension callback. PromptLoader calls it on
     // every loadPrompt(); we return the truncated cached content.
-    registerPromptExtension(PROMPT_EXTENSION_NAME, () => this.renderForPrompt());
+    registerPromptExtension(
+      PROMPT_EXTENSION_NAME,
+      () => this.renderForPrompt(),
+      { type: 'session', sessionId: this.sessionId },
+    );
 
     this.telemetry.emit('init', {
       config: { ...this.config },
@@ -162,7 +169,10 @@ export class SessionSummaryHook {
     this.unregisterPostTurn = undefined;
 
     try {
-      unregisterPromptExtension(PROMPT_EXTENSION_NAME);
+      unregisterPromptExtension(PROMPT_EXTENSION_NAME, {
+        type: 'session',
+        sessionId: this.sessionId,
+      });
     } catch (err) {
       console.warn('[SessionSummary] unregisterPromptExtension failed', err);
     }

--- a/src/extension/background/service-worker.ts
+++ b/src/extension/background/service-worker.ts
@@ -188,8 +188,8 @@ async function configureExtensionPlatform(targetAgent: RepublicAgent): Promise<v
     recordPlanArtifact: (payload) =>
       targetAgent.getSession().persistRolloutItems([{ type: 'plan_artifact', payload }]),
   });
-  setDynamicRuntimeContext(() => ({
-    planReviewActive: toolRegistry.isPlanReviewActive(),
+  setDynamicRuntimeContext((ctx) => ({
+    planReviewActive: ctx.toolRegistry?.isPlanReviewActive?.() ?? toolRegistry.isPlanReviewActive(),
   }));
 
   // Tab closure handler

--- a/src/tools/AgentTool/SubAgentRunner.ts
+++ b/src/tools/AgentTool/SubAgentRunner.ts
@@ -528,7 +528,7 @@ export class SubAgentRunner implements IAgentRunner {
       !this.isNonInteractiveBackgroundSafe(behavior)
     ) {
       throw new Error(
-        `Background sub-agent type '${resolvedTypeConfig.id}' cannot inherit approval; configure approvalPolicy: "never" only for a read-only or internally locked profile`,
+        `Background sub-agent type '${resolvedTypeConfig.id}' cannot inherit approval; set approvalPolicy: "never" explicitly, or use a non-interactive profile that can safely downgrade inherited approval`,
       );
     }
     const effectiveApprovalPolicy =

--- a/src/tools/AgentTool/SubAgentRunner.ts
+++ b/src/tools/AgentTool/SubAgentRunner.ts
@@ -442,6 +442,12 @@ export class SubAgentRunner implements IAgentRunner {
     }
   }
 
+  private isNonInteractiveBackgroundSafe(
+    behavior: ReturnType<typeof resolveSubAgentBehavior>,
+  ): boolean {
+    return behavior.toolPolicy === 'read_only_bias' || behavior.toolPolicy === 'internal_locked';
+  }
+
   // ---------------------------------------------------------------------------
   // IAgentRunner: prepare
   // ---------------------------------------------------------------------------
@@ -469,6 +475,14 @@ export class SubAgentRunner implements IAgentRunner {
       background,
       contextMode: params.contextMode,
     });
+    const parentSession = this.parentEngine.getSession();
+
+    if (
+      behavior.contextMode === SubAgentContextMode.Fork &&
+      parentSession?.isForkedSubAgentContext?.()
+    ) {
+      throw new Error('Forked sub-agents cannot spawn another forked sub-agent');
+    }
 
     // Create restricted tool registry
     const childRegistry = await createSubAgentToolRegistry(
@@ -500,15 +514,27 @@ export class SubAgentRunner implements IAgentRunner {
     });
 
     const parentConfig = this.parentEngine.getConfig();
-    const parentSession = this.parentEngine.getSession();
 
     // Default to 'inherit' when approvalPolicy is not explicitly set.
     // Only 'never' explicitly opts out of approval — prevents accidental bypass.
-    // Background runs cannot prompt the user (parent has moved on), so force 'never'
-    // regardless of the type's configured policy.
+    // Background runs cannot prompt the user (parent has moved on), so they
+    // must either explicitly run with `never` or be a non-interactive profile
+    // that can safely downgrade inherited approval to `never`.
     const configuredApprovalPolicy = resolvedTypeConfig.approvalPolicy
       ?? behavior.approvalPolicyDefault;
-    const effectiveApprovalPolicy = background ? 'never' : configuredApprovalPolicy;
+    if (
+      background &&
+      configuredApprovalPolicy === 'inherit' &&
+      !this.isNonInteractiveBackgroundSafe(behavior)
+    ) {
+      throw new Error(
+        `Background sub-agent type '${resolvedTypeConfig.id}' cannot inherit approval; configure approvalPolicy: "never" only for a read-only or internally locked profile`,
+      );
+    }
+    const effectiveApprovalPolicy =
+      background && configuredApprovalPolicy === 'inherit'
+        ? 'never'
+        : configuredApprovalPolicy;
     const approvalGate = effectiveApprovalPolicy === 'inherit'
       ? this.parentEngine.getToolRegistry().getApprovalGate()
       : undefined;

--- a/src/tools/AgentTool/__tests__/SubAgentRunner.background.test.ts
+++ b/src/tools/AgentTool/__tests__/SubAgentRunner.background.test.ts
@@ -7,7 +7,7 @@
  * - failed background runs inject <status>failed</status>
  * - cancelled / interrupted runs inject <status>cancelled</status>
  * - foreground path is unchanged (SubAgentResult, no notification)
- * - background forces approvalPolicy = 'never' even when type says 'inherit'
+ * - background rejects unsafe inherited approval instead of silently downgrading
  * - cleanup runs exactly once for background (after the detached promise settles)
  * - send_message → drain hook is wired (the drain callback comes from the registry)
  */
@@ -400,11 +400,32 @@ describe('SubAgentRunner.run() — foreground (regression)', () => {
 });
 
 describe('SubAgentRunner.prepare() — approval policy for background', () => {
-  it('forces approvalPolicy = never even when type config says inherit', async () => {
+  it('rejects background runs that would silently downgrade inherited approval', async () => {
     const parent = createParentEngine();
     const runner = new SubAgentRunner({
       parentEngine: parent as never,
       customTypes: [makeType({ approvalPolicy: 'inherit' })],
+    });
+
+    const result = await runner.run({
+      type: 'worker',
+      prompt: 'task',
+      background: true,
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      stopReason: 'error',
+      error: expect.stringContaining('cannot inherit approval'),
+    });
+    expect(parent.__childEngine.__capturedConfig).toBeUndefined();
+  });
+
+  it('allows read-only background profiles to inherit by downgrading to never', async () => {
+    const parent = createParentEngine();
+    const runner = new SubAgentRunner({
+      parentEngine: parent as never,
+      customTypes: [makeType({ agentType: AgentType.Researcher, approvalPolicy: 'inherit' })],
     });
 
     await runner.run({
@@ -416,7 +437,7 @@ describe('SubAgentRunner.prepare() — approval policy for background', () => {
 
     const config = parent.__childEngine.__capturedConfig as Record<string, unknown>;
     expect(config.approvalPolicy).toBe('never');
-    // approvalGate must not be passed through when forcing 'never'
+    // approvalGate must not be passed through when downgrading safe background work to 'never'
     expect(config.approvalGate).toBeUndefined();
   });
 
@@ -535,7 +556,7 @@ describe('SubAgentRunner fork context mode', () => {
     expect(result.error).toContain('does not allow context mode');
   });
 
-  it('rejects recursive fork mode when parent history already contains fork boilerplate', async () => {
+  it('rejects recursive fork mode using runtime session metadata', async () => {
     const parent = createParentEngine();
     parent.getSession = () => ({
       getSessionId: () => 'parent-session',
@@ -544,10 +565,11 @@ describe('SubAgentRunner fork context mode', () => {
           {
             type: 'message',
             role: 'user',
-            content: [{ type: 'input_text', text: '<forked-subagent-task>\nPrior fork' }],
+            content: [{ type: 'input_text', text: 'Prior delegated work' }],
           },
         ],
       }),
+      isForkedSubAgentContext: () => true,
       getTaskOutputStore: () => undefined,
       registerTaskState: vi.fn(),
     } as any);
@@ -569,7 +591,7 @@ describe('SubAgentRunner fork context mode', () => {
 
     if ('kind' in result) throw new Error('expected foreground result');
     expect(result.success).toBe(false);
-    expect(result.error).toContain('already contains forked sub-agent context');
+    expect(result.error).toContain('cannot spawn another forked sub-agent');
     expect(parent.createChildEngine).not.toHaveBeenCalled();
   });
 });

--- a/src/tools/AgentTool/__tests__/forkContext.test.ts
+++ b/src/tools/AgentTool/__tests__/forkContext.test.ts
@@ -74,7 +74,7 @@ describe('buildForkedSubAgentInitialHistory', () => {
     expect(JSON.stringify(initialHistory.rolloutItems[0])).toContain('Do task');
   });
 
-  it('rejects recursive fork history containing the fork directive tag', () => {
+  it('does not reject based on model-visible fork directive text', () => {
     const parentSession = {
       getSessionId: () => 'parent-session',
       getConversationHistory: () => ({
@@ -91,14 +91,14 @@ describe('buildForkedSubAgentInitialHistory', () => {
       getSession: () => parentSession,
     } as any;
 
-    expect(() =>
-      buildForkedSubAgentInitialHistory(parentEngine, 'Do task', {
-        runId: 'run-1',
-        typeId: 'worker',
-        agentType: AgentType.Worker,
-        contextMode: SubAgentContextMode.Fork,
-      }),
-    ).toThrow('already contains forked sub-agent context');
+    const initialHistory = buildForkedSubAgentInitialHistory(parentEngine, 'Do task', {
+      runId: 'run-1',
+      typeId: 'worker',
+      agentType: AgentType.Worker,
+      contextMode: SubAgentContextMode.Fork,
+    });
+
+    expect(initialHistory.mode).toBe('forked');
   });
 
   it('detects fork directive tags in response items', () => {

--- a/src/tools/AgentTool/forkContext.ts
+++ b/src/tools/AgentTool/forkContext.ts
@@ -28,12 +28,6 @@ export function buildForkedSubAgentInitialHistory(
   }
 
   const sourceItems = parentSession.getConversationHistory().items as ResponseItem[];
-  if (containsForkDirective(sourceItems)) {
-    throw new Error(
-      'Cannot create a forked sub-agent from history that already contains forked sub-agent context',
-    );
-  }
-
   const rolloutItems = responseItemsToRolloutItems(sourceItems);
   const trimmed = pairingTrim(rolloutItems);
 

--- a/src/tools/ToolRegistry.ts
+++ b/src/tools/ToolRegistry.ts
@@ -192,6 +192,34 @@ export class ToolRegistry {
     return this.planReviewActive;
   }
 
+  private createEntry(
+    tool: ToolDefinition,
+    handler: ToolHandler,
+    optionsOrAssessor?: IRiskAssessor | ToolRegistrationOptions,
+  ): ToolRegistryEntry {
+    const opts: ToolRegistrationOptions = optionsOrAssessor && 'assess' in optionsOrAssessor
+      ? { riskAssessor: optionsOrAssessor as IRiskAssessor }
+      : (optionsOrAssessor as ToolRegistrationOptions ?? {});
+
+    const runtime: ToolRuntimeMetadata = {
+      concurrency: {
+        ...DEFAULT_TOOL_CONCURRENCY_PROFILE,
+        ...(opts.runtime?.concurrency ?? {}),
+      },
+      ui: opts.runtime?.ui,
+      result: opts.runtime?.result,
+    };
+
+    return {
+      definition: tool,
+      handler,
+      registrationTime: Date.now(),
+      riskAssessor: opts.riskAssessor,
+      runtime,
+      exposure: opts.exposure,
+    };
+  }
+
   /**
    * Register a tool with the registry.
    *
@@ -214,31 +242,7 @@ export class ToolRegistry {
       throw new Error(`Tool '${toolName}' is already registered`);
     }
 
-    // Normalize the third argument: bare IRiskAssessor vs ToolRegistrationOptions
-    const opts: ToolRegistrationOptions = optionsOrAssessor && 'assess' in optionsOrAssessor
-      ? { riskAssessor: optionsOrAssessor as IRiskAssessor }
-      : (optionsOrAssessor as ToolRegistrationOptions ?? {});
-
-    // Build runtime metadata with fail-closed defaults
-    const runtime: ToolRuntimeMetadata = {
-      concurrency: {
-        ...DEFAULT_TOOL_CONCURRENCY_PROFILE,
-        ...(opts.runtime?.concurrency ?? {}),
-      },
-      ui: opts.runtime?.ui,
-      result: opts.runtime?.result,
-    };
-
-    // Register the tool
-    const entry: ToolRegistryEntry = {
-      definition: tool,
-      handler,
-      registrationTime: Date.now(),
-      riskAssessor: opts.riskAssessor,
-      runtime,
-      exposure: opts.exposure,
-    };
-
+    const entry = this.createEntry(tool, handler, optionsOrAssessor);
     this.tools.set(toolName, entry);
 
     // Emit registration event
@@ -287,34 +291,32 @@ export class ToolRegistry {
    * runtime. The plain `register()` throws on duplicate, so callers that
    * want "either install or update" semantics use this instead.
    *
-   * NOT atomic: the old entry is removed (emitting `ToolUnregistered`)
-   * before `register()` is awaited, so there is a brief window where the
-   * tool is absent from the registry — a concurrent `discover()` or
-   * dispatch in that window will not see it. The new entry is guaranteed
-   * present only once this method resolves. In-flight tool calls already
-   * dispatched to the old handler continue with that closure. Callers
-   * needing gap-free swaps must serialize against tool discovery.
+   * Atomic from the registry's perspective: the map entry is replaced in one
+   * set(), so concurrent discover()/dispatch calls never observe a missing
+   * tool between delete and re-register. In-flight calls already dispatched
+   * to the previous handler continue with that closure.
    */
   async replace(
     tool: ToolDefinition,
     handler: ToolHandler,
     optionsOrAssessor?: IRiskAssessor | ToolRegistrationOptions,
   ): Promise<void> {
+    this.validateToolDefinition(tool);
     const toolName = this.getToolName(tool);
-    if (this.tools.has(toolName)) {
-      this.tools.delete(toolName);
-      this.emitEvent({
-        id: `evt_unregister_${toolName}`,
-        msg: {
-          type: 'ToolUnregistered',
-          data: {
-            tool_name: toolName,
-            unregistration_time: Date.now(),
-          },
+    const entry = this.createEntry(tool, handler, optionsOrAssessor);
+    this.tools.set(toolName, entry);
+    this.emitEvent({
+      id: `evt_register_${toolName}`,
+      msg: {
+        type: 'ToolRegistered',
+        data: {
+          tool_name: toolName,
+          category: undefined,
+          version: undefined,
+          registration_time: entry.registrationTime,
         },
-      });
-    }
-    await this.register(tool, handler, optionsOrAssessor);
+      },
+    });
   }
 
   /**
@@ -418,6 +420,29 @@ export class ToolRegistry {
    */
   async execute(request: ToolExecutionRequest): Promise<ToolExecutionResponse> {
     const startTime = Date.now();
+    const emitTerminalError = (
+      code: string,
+      message: string,
+      details?: unknown,
+      eventIdPrefix = 'evt_exec_error',
+    ) => {
+      this.emitEvent({
+        id: `${eventIdPrefix}_${request.toolName}_${request.callId ?? ''}`,
+        msg: {
+          type: 'ToolExecutionError',
+          data: {
+            tool_name: request.toolName,
+            call_id: request.callId,
+            session_id: request.sessionId,
+            turn_id: request.turnId,
+            code,
+            error: message,
+            details,
+            duration: Date.now() - startTime,
+          },
+        },
+      });
+    };
 
     try {
       const entry = this.tools.get(request.toolName);
@@ -446,11 +471,9 @@ export class ToolRegistry {
         };
       }
 
-      // Emit execution start event before any gate so consumers see the
-      // attempt even if it's later denied. Note: gate denials (PRE_EXECUTE_DENIED,
-      // APPROVAL_DENIED) return early and do NOT emit a matching ToolExecutionEnd —
-      // downstream consumers must treat the absence of an End event for a known
-      // call_id as "denied / aborted before execution".
+      // Emit execution start after registry lookup and parameter validation.
+      // Every subsequent early-denial path emits ToolExecutionError with the
+      // same identifiers, so consumers can close the lifecycle envelope.
       this.emitEvent({
         id: `evt_exec_start_${request.toolName}_${request.callId ?? ''}`,
         msg: {
@@ -475,6 +498,11 @@ export class ToolRegistry {
           request.parameters as Record<string, unknown>,
         );
         if (preDecision.behavior === 'deny') {
+          emitTerminalError(
+            'PRE_EXECUTE_DENIED',
+            `Tool '${request.toolName}' denied by pre-execute gate`,
+            { reason: preDecision.decisionReason },
+          );
           return {
             success: false,
             error: {
@@ -494,6 +522,11 @@ export class ToolRegistry {
       // is registry-native and fail-closed on every platform. The single,
       // sufficient enforcement point — see .ai_design 14_plan_review.
       if (this.planReviewActive && !this.isReadOnly(request.toolName, request.parameters as Record<string, unknown>)) {
+        emitTerminalError(
+          'APPROVAL_DENIED',
+          `Tool '${request.toolName}' is frozen during plan review — read-only actions only until the plan is approved`,
+          { reason: 'plan-review-freeze' },
+        );
         return {
           success: false,
           error: {
@@ -539,6 +572,11 @@ export class ToolRegistry {
         const reason = typeof result === 'object' && result !== null ? result.reason : undefined;
 
         if (decision === 'deny') {
+          emitTerminalError(
+            'APPROVAL_DENIED',
+            `Tool '${request.toolName}' was denied by the approval system`,
+            reason ? { reason } : undefined,
+          );
           return {
             success: false,
             error: {
@@ -627,8 +665,12 @@ export class ToolRegistry {
             type: isTimeout ? 'ToolExecutionTimeout' : 'ToolExecutionError',
             data: {
               tool_name: request.toolName,
+              call_id: request.callId,
               session_id: request.sessionId,
+              turn_id: request.turnId,
+              code: isTimeout ? 'TIMEOUT' : 'EXECUTION_ERROR',
               error: error.message,
+              details: error,
               duration: Date.now() - startTime,
               ...(isTimeout && { timeout_ms: timeout }),
             },
@@ -681,8 +723,12 @@ export class ToolRegistry {
           type: 'ToolExecutionError',
           data: {
             tool_name: request.toolName,
+            call_id: request.callId,
             session_id: request.sessionId,
+            turn_id: request.turnId,
+            code: 'EXECUTION_ERROR',
             error: error.message,
+            details: error,
             duration: Date.now() - startTime,
           },
         },

--- a/src/tools/ToolRegistry.ts
+++ b/src/tools/ToolRegistry.ts
@@ -306,7 +306,7 @@ export class ToolRegistry {
     const entry = this.createEntry(tool, handler, optionsOrAssessor);
     this.tools.set(toolName, entry);
     this.emitEvent({
-      id: `evt_register_${toolName}`,
+      id: `evt_replace_${toolName}_${entry.registrationTime}_${crypto.randomUUID()}`,
       msg: {
         type: 'ToolRegistered',
         data: {

--- a/src/tools/__tests__/ToolRegistry.coverage.test.ts
+++ b/src/tools/__tests__/ToolRegistry.coverage.test.ts
@@ -104,6 +104,7 @@ describe('ToolRegistry – extended coverage', () => {
       const firstHandler = vi.fn().mockResolvedValue('first');
       const secondHandler = vi.fn().mockResolvedValue('second');
       await registry.register(tool, firstHandler);
+      const registerEvent = (collector.collect as ReturnType<typeof vi.fn>).mock.calls[0][0];
       (collector.collect as ReturnType<typeof vi.fn>).mockClear();
 
       await registry.replace(tool, secondHandler);
@@ -116,6 +117,11 @@ describe('ToolRegistry – extended coverage', () => {
       );
       expect(events).toContain('ToolRegistered');
       expect(events).not.toContain('ToolUnregistered');
+      const replaceEvent = (collector.collect as ReturnType<typeof vi.fn>).mock.calls.find(
+        c => c[0].msg.type === 'ToolRegistered',
+      )?.[0];
+      expect(replaceEvent?.id).toMatch(/^evt_replace_swap_\d+_[0-9a-f-]+$/);
+      expect(replaceEvent?.id).not.toBe(registerEvent.id);
     });
   });
 

--- a/src/tools/__tests__/ToolRegistry.coverage.test.ts
+++ b/src/tools/__tests__/ToolRegistry.coverage.test.ts
@@ -98,6 +98,27 @@ describe('ToolRegistry – extended coverage', () => {
     });
   });
 
+  describe('replace', () => {
+    it('updates an existing tool without emitting an unregister gap', async () => {
+      const tool = createFunctionTool('swap');
+      const firstHandler = vi.fn().mockResolvedValue('first');
+      const secondHandler = vi.fn().mockResolvedValue('second');
+      await registry.register(tool, firstHandler);
+      (collector.collect as ReturnType<typeof vi.fn>).mockClear();
+
+      await registry.replace(tool, secondHandler);
+      const result = await registry.execute(makeRequest('swap'));
+
+      expect(result).toMatchObject({ success: true, data: 'second' });
+      expect(firstHandler).not.toHaveBeenCalled();
+      const events = (collector.collect as ReturnType<typeof vi.fn>).mock.calls.map(
+        c => c[0].msg.type,
+      );
+      expect(events).toContain('ToolRegistered');
+      expect(events).not.toContain('ToolUnregistered');
+    });
+  });
+
   // -----------------------------------------------------------------------
   // validate
   // -----------------------------------------------------------------------
@@ -459,6 +480,18 @@ describe('ToolRegistry – extended coverage', () => {
         c => c[0].msg.type,
       );
       expect(events).toContain('ToolExecutionStart');
+      expect(events).toContain('ToolExecutionError');
+
+      const terminal = (collector.collect as ReturnType<typeof vi.fn>).mock.calls
+        .map(c => c[0].msg)
+        .find((msg) => msg.type === 'ToolExecutionError');
+      expect(terminal?.data).toMatchObject({
+        tool_name: 'gated',
+        session_id: 'sess_1',
+        turn_id: 'turn_1',
+        code: 'APPROVAL_DENIED',
+        error: "Tool 'gated' was denied by the approval system",
+      });
     });
 
     it('should proceed when approval gate returns auto_approve', async () => {

--- a/src/tools/__tests__/toolResultStore.test.ts
+++ b/src/tools/__tests__/toolResultStore.test.ts
@@ -221,6 +221,24 @@ describe('CacheToolResultStore', () => {
     expect(item.customMetadata?.toolUseId).toBe('tool_use_aaa');
   });
 
+  it('cleanup preserves cache entries owned by persistent rollouts', async () => {
+    const persistent = await store.persist('sess1', 'tool_persist', 'P'.repeat(60_000), {
+      owner: { kind: 'persistent_rollout', sessionId: 'sess1', callId: 'tool_persist' },
+    });
+    const transient = await store.persist('sess1', 'tool_transient', 'T'.repeat(60_000), {
+      owner: { kind: 'transient_session', sessionId: 'sess1', callId: 'tool_transient' },
+    });
+
+    await store.cleanup('sess1');
+
+    await expect(manager.read(persistent.reference)).resolves.toMatchObject({
+      customMetadata: expect.objectContaining({
+        owner: expect.objectContaining({ kind: 'persistent_rollout' }),
+      }),
+    });
+    await expect(manager.read(transient.reference)).rejects.toThrow();
+  });
+
   it('retrieve round-trips the original content', async () => {
     const content = 'line1\n' + 'a'.repeat(80_000);
     const { reference } = await store.persist('sess1', 'tool_use_bbb', content);
@@ -241,8 +259,12 @@ describe('CacheToolResultStore', () => {
   });
 
   it('cleanup deletes tool_result entries and leaves user entries intact', async () => {
-    await store.persist('sess1', 'tool_a', 'A'.repeat(60_000));
-    await store.persist('sess1', 'tool_b', 'B'.repeat(60_000));
+    await store.persist('sess1', 'tool_a', 'A'.repeat(60_000), {
+      owner: { kind: 'transient_session', sessionId: 'sess1', callId: 'tool_a' },
+    });
+    await store.persist('sess1', 'tool_b', 'B'.repeat(60_000), {
+      owner: { kind: 'transient_session', sessionId: 'sess1', callId: 'tool_b' },
+    });
     // A user entry (no kind=tool_result tag)
     const userMeta = await manager.write('sess1', { foo: 'bar' }, 'user-data');
 
@@ -258,6 +280,16 @@ describe('CacheToolResultStore', () => {
       const full = await manager.read(m.storageKey);
       expect(full.customMetadata?.kind).not.toBe(CACHE_TOOL_RESULT_KIND);
     }
+  });
+
+  it('cleanup preserves legacy cache entries without owner metadata', async () => {
+    const legacy = await store.persist('sess1', 'legacy_tool', 'L'.repeat(60_000));
+
+    await store.cleanup('sess1');
+
+    await expect(manager.read(legacy.reference)).resolves.toMatchObject({
+      customMetadata: expect.objectContaining({ kind: CACHE_TOOL_RESULT_KIND }),
+    });
   });
 });
 
@@ -308,9 +340,33 @@ describe('FileToolResultStore', () => {
   });
 
   it('cleanup removes the session tool-results directory', async () => {
-    await store.persist('sess1', 'tool_use_aaa', 'hello');
+    await store.persist('sess1', 'tool_use_aaa', 'hello', {
+      owner: { kind: 'transient_session', sessionId: 'sess1', callId: 'tool_use_aaa' },
+    });
     await store.cleanup('sess1');
     const dir = join(rootDir, 'sess1', 'tool-results');
     await expect(readFile(join(dir, 'tool_use_aaa.txt'), 'utf-8')).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('cleanup preserves legacy files without owner metadata', async () => {
+    const legacy = await store.persist('sess1', 'legacy_tool', 'legacy');
+
+    await store.cleanup('sess1');
+
+    await expect(readFile(legacy.reference, 'utf-8')).resolves.toBe('legacy');
+  });
+
+  it('cleanup preserves file entries owned by persistent rollouts', async () => {
+    const persistent = await store.persist('sess1', 'tool_persist', 'persisted', {
+      owner: { kind: 'persistent_rollout', sessionId: 'sess1', callId: 'tool_persist' },
+    });
+    const transient = await store.persist('sess1', 'tool_transient', 'transient', {
+      owner: { kind: 'transient_session', sessionId: 'sess1', callId: 'tool_transient' },
+    });
+
+    await store.cleanup('sess1');
+
+    await expect(readFile(persistent.reference, 'utf-8')).resolves.toBe('persisted');
+    await expect(readFile(transient.reference, 'utf-8')).rejects.toMatchObject({ code: 'ENOENT' });
   });
 });

--- a/src/tools/resultStore.ts
+++ b/src/tools/resultStore.ts
@@ -359,6 +359,8 @@ export class FileToolResultStore implements ToolResultStore {
             ]);
           }),
       );
+      // Remove the now-empty transient result directory when cleanup deleted
+      // every owned result. ENOTEMPTY is expected when persistent owners remain.
       await rm(dir, { recursive: false, force: true }).catch(() => undefined);
     } catch (e) {
       console.warn('[FileToolResultStore] cleanup failed:', e);

--- a/src/tools/resultStore.ts
+++ b/src/tools/resultStore.ts
@@ -37,6 +37,16 @@ export interface PersistedResult {
   preview: string;
   /** True iff the preview was truncated (there's more in the persisted blob). */
   hasMore: boolean;
+  /** Ownership metadata used by cleanup/eviction to avoid breaking rollouts. */
+  owner?: PersistedResultOwner;
+}
+
+export type PersistedResultOwner =
+  | { kind: 'persistent_rollout'; sessionId: string; callId: string }
+  | { kind: 'transient_session'; sessionId: string; callId: string };
+
+export interface PersistToolResultOptions {
+  owner?: PersistedResultOwner;
 }
 
 /**
@@ -47,7 +57,12 @@ export interface PersistedResult {
  * and must not throw on duplicate writes.
  */
 export interface ToolResultStore {
-  persist(sessionId: string, toolUseId: string, content: string): Promise<PersistedResult>;
+  persist(
+    sessionId: string,
+    toolUseId: string,
+    content: string,
+    options?: PersistToolResultOptions,
+  ): Promise<PersistedResult>;
   retrieve(reference: string): Promise<string | null>;
   cleanup(sessionId: string): Promise<void>;
 }
@@ -171,6 +186,7 @@ export class CacheToolResultStore implements ToolResultStore {
     sessionId: string,
     toolUseId: string,
     content: string,
+    options: PersistToolResultOptions = {},
   ): Promise<PersistedResult> {
     if (content.length > CACHE_MAX_ITEM_SIZE) {
       throw new ToolResultTooLargeForStoreError(content.length, CACHE_MAX_ITEM_SIZE);
@@ -181,7 +197,7 @@ export class CacheToolResultStore implements ToolResultStore {
       `tool_result:${toolUseId}`,
       undefined,
       undefined,
-      { kind: CACHE_TOOL_RESULT_KIND, toolUseId },
+      { kind: CACHE_TOOL_RESULT_KIND, toolUseId, owner: options.owner },
     );
     const { preview, hasMore } = generatePreview(content, PREVIEW_SIZE_BYTES);
     return {
@@ -190,6 +206,7 @@ export class CacheToolResultStore implements ToolResultStore {
       originalSize: content.length,
       preview,
       hasMore,
+      owner: options.owner,
     };
   }
 
@@ -224,7 +241,10 @@ export class CacheToolResultStore implements ToolResultStore {
       entries.map(async (m) => {
         try {
           const full = await this.cache.read(m.storageKey);
-          if (full.customMetadata?.kind === CACHE_TOOL_RESULT_KIND) {
+          if (
+            full.customMetadata?.kind === CACHE_TOOL_RESULT_KIND &&
+            (full.customMetadata as { owner?: PersistedResultOwner }).owner?.kind === 'transient_session'
+          ) {
             targets.push(m.storageKey);
           }
         } catch {
@@ -252,14 +272,21 @@ export class FileToolResultStore implements ToolResultStore {
     return join(this.rootDir, sessionId, 'tool-results', `${toolUseId}.txt`);
   }
 
+  private async metaPathFor(sessionId: string, toolUseId: string): Promise<string> {
+    const { join } = await import('node:path');
+    return join(this.rootDir, sessionId, 'tool-results', `${toolUseId}.meta.json`);
+  }
+
   async persist(
     sessionId: string,
     toolUseId: string,
     content: string,
+    options: PersistToolResultOptions = {},
   ): Promise<PersistedResult> {
     const { writeFile, mkdir } = await import('node:fs/promises');
     const { dirname } = await import('node:path');
     const filepath = await this.pathFor(sessionId, toolUseId);
+    const metaPath = await this.metaPathFor(sessionId, toolUseId);
     await mkdir(dirname(filepath), { recursive: true });
     try {
       await writeFile(filepath, content, { encoding: 'utf-8', flag: 'wx' });
@@ -270,6 +297,15 @@ export class FileToolResultStore implements ToolResultStore {
       // the caller will fall back to legacy truncation.
       if (e?.code !== 'EEXIST') throw e;
     }
+    await writeFile(
+      metaPath,
+      JSON.stringify(
+        { kind: CACHE_TOOL_RESULT_KIND, toolUseId, owner: options.owner },
+        null,
+        2,
+      ),
+      { encoding: 'utf-8' },
+    );
     const { preview, hasMore } = generatePreview(content, PREVIEW_SIZE_BYTES);
     return {
       reference: filepath,
@@ -277,6 +313,7 @@ export class FileToolResultStore implements ToolResultStore {
       originalSize: content.length,
       preview,
       hasMore,
+      owner: options.owner,
     };
   }
 
@@ -291,11 +328,38 @@ export class FileToolResultStore implements ToolResultStore {
   }
 
   async cleanup(sessionId: string): Promise<void> {
-    const { rm } = await import('node:fs/promises');
+    const { readdir, readFile, rm, unlink } = await import('node:fs/promises');
     const { join } = await import('node:path');
     const dir = join(this.rootDir, sessionId, 'tool-results');
     try {
-      await rm(dir, { recursive: true, force: true });
+      const entries = await readdir(dir).catch((e: any) => {
+        if (e?.code === 'ENOENT') return [];
+        throw e;
+      });
+      await Promise.all(
+        entries
+          .filter((entry) => entry.endsWith('.txt'))
+          .map(async (entry) => {
+            const toolUseId = entry.slice(0, -'.txt'.length);
+            const filePath = join(dir, entry);
+            const metaPath = join(dir, `${toolUseId}.meta.json`);
+            let owner: PersistedResultOwner | undefined;
+            try {
+              const meta = JSON.parse(await readFile(metaPath, 'utf-8')) as {
+                owner?: PersistedResultOwner;
+              };
+              owner = meta.owner;
+            } catch {
+              owner = undefined;
+            }
+            if (owner?.kind !== 'transient_session') return;
+            await Promise.all([
+              unlink(filePath).catch(() => undefined),
+              unlink(metaPath).catch(() => undefined),
+            ]);
+          }),
+      );
+      await rm(dir, { recursive: false, force: true }).catch(() => undefined);
     } catch (e) {
       console.warn('[FileToolResultStore] cleanup failed:', e);
     }


### PR DESCRIPTION
## Summary

Implements the `improve_consistentcy0520` hardening track as one integration PR on top of `agent-improvements`.

Key changes:
- Scope prompt extensions by session and unregister session-owned extensions during cleanup.
- Make session disposal idempotent, centralize shutdown/close cleanup, and serialize conversation commits before rollout flush.
- Move post-turn hook firing after committed history is recorded and pass committed deltas to hooks.
- Tighten background sub-agent approval inheritance and fork-recursion checks using runtime state instead of prompt text.
- Emit terminal tool lifecycle events on gate/pre-execute failures and make tool replacement atomic.
- Add owner metadata for persisted tool results so transient cleanup does not delete rollout-owned blobs.
- Add an agent-improvement status ledger plus a checker to keep README/folder/status metadata aligned.

## Validation

- `npm run type-check`
- `npm run lint -- --quiet`
- `node scripts/check-agent-improvement-status.mjs`
- `npx vitest run src/core/__tests__/TurnManager.coverage.test.ts src/core/__tests__/TurnManager.memory.integration.test.ts --reporter dot`
- `npm run test -- --run`  
  - Rust: 13 passed
  - Vitest: 436 files passed, 1 skipped; 9,361 tests passed, 8 skipped
