### PR TITLE
Refactor hosted auth into configurable seams

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,12 @@
 # VITE_AUTH_STATUS_COOKIE_NAME=auth_status
 # VITE_AUTH_USER_NAME_COOKIE_NAME=user_name
 # VITE_AUTH_USER_EMAIL_COOKIE_NAME=user_email
+# VITE_AUTH_LOGIN_PATH=/signin
+# VITE_AUTH_DESKTOP_SESSION_PATH=/desktop/session
+# VITE_AUTH_DESKTOP_REFRESH_PATH=/desktop/refresh
+# VITE_AUTH_PROFILE_PATH=/profile
+# VITE_AUTH_USER_CENTER_PATH=/account
+# VITE_AUTH_PRICING_PATH=/plans
 
 # Vault encryption secret - used to wrap the encryption key at rest
 # MUST be 32+ characters. Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,13 @@
-# Backend API Configuration (optional - for AI Republic backend routing)
-# VITE_HOME_PAGE_BASE_URL=https://airepublic.com
+# Hosted auth and backend API configuration (optional)
+# VITE_AUTH_BASE_URL=https://auth.example.com
 # VITE_BACKEND_API_BASE_URL=
-# VITE_COOKIE_DOMAIN=.airepublic.com
+# VITE_AUTH_COOKIE_DOMAIN=.example.com
+# VITE_AUTH_ACCESS_COOKIE_NAME=access_token
+# VITE_AUTH_REFRESH_COOKIE_NAME=refresh_token
+# VITE_AUTH_CSRF_COOKIE_NAME=csrf_token
+# VITE_AUTH_STATUS_COOKIE_NAME=auth_status
+# VITE_AUTH_USER_NAME_COOKIE_NAME=user_name
+# VITE_AUTH_USER_EMAIL_COOKIE_NAME=user_email
 
 # Vault encryption secret - used to wrap the encryption key at rest
 # MUST be 32+ characters. Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Create extension .env
         run: |
           cat > src/extension/.env << EOF
-          VITE_COOKIE_DOMAIN=.airepublic.com
-          VITE_HOME_PAGE_BASE_URL=https://airepublic.com
-          VITE_BACKEND_API_BASE_URL=https://helper.airepublic.com
+          VITE_AUTH_COOKIE_DOMAIN=${{ vars.VITE_AUTH_COOKIE_DOMAIN }}
+          VITE_AUTH_BASE_URL=${{ vars.VITE_AUTH_BASE_URL }}
+          VITE_BACKEND_API_BASE_URL=${{ vars.VITE_BACKEND_API_BASE_URL }}
           VITE_VAULT_SECRET=${{ secrets.VITE_VAULT_SECRET }}
           EOF
 
@@ -155,9 +155,9 @@ jobs:
         shell: bash
         run: |
           cat > src/desktop/.env << 'EOF'
-          VITE_COOKIE_DOMAIN=.airepublic.com
-          VITE_HOME_PAGE_BASE_URL=https://airepublic.com
-          VITE_BACKEND_API_BASE_URL=https://helper.airepublic.com
+          VITE_AUTH_COOKIE_DOMAIN=${{ vars.VITE_AUTH_COOKIE_DOMAIN }}
+          VITE_AUTH_BASE_URL=${{ vars.VITE_AUTH_BASE_URL }}
+          VITE_BACKEND_API_BASE_URL=${{ vars.VITE_BACKEND_API_BASE_URL }}
           EOF
 
       - name: Setup Rust toolchain

--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ cp .env.example src/desktop/.env
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `VITE_HOME_PAGE_BASE_URL` | AI Republic home page URL | `https://airepublic.com` |
-| `VITE_BACKEND_API_BASE_URL` | Backend API endpoint | `https://api.airepublic.com` |
-| `VITE_COOKIE_DOMAIN` | Cookie domain for auth | `.airepublic.com` |
+| `VITE_AUTH_BASE_URL` | Optional hosted login/account base URL | `https://auth.example.com` |
+| `VITE_BACKEND_API_BASE_URL` | Optional backend API endpoint | `https://api.example.com` |
+| `VITE_AUTH_COOKIE_DOMAIN` | Optional cookie domain for hosted auth | `.example.com` |
+| `VITE_AUTH_ACCESS_COOKIE_NAME` | Hosted auth access-token cookie name | `access_token` |
+| `VITE_AUTH_REFRESH_COOKIE_NAME` | Hosted auth refresh-token cookie name | `refresh_token` |
 
 ---
 
@@ -135,22 +137,21 @@ Output: `tauri/target/release/bundle/{deb,appimage,nsis,dmg}/`
 
 #### Local Desktop Package Testing
 
-For a normal desktop package that talks to production login:
+For a normal desktop package:
 
 ```bash
 ./build.sh --install
 ```
 
-For local homepage/login testing through `https://localhome.airepublic.com`:
+For local hosted-login testing:
 
 ```bash
-VITE_HOME_PAGE_BASE_URL=https://localhome.airepublic.com ./build.sh --install
+VITE_AUTH_BASE_URL=https://auth.example.local ./build.sh --install
 ```
 
-You can also set `VITE_HOME_PAGE_BASE_URL=https://localhome.airepublic.com` in
-`src/desktop/.env`. The desktop web UI and runtime sidecar read the homepage URL
-during the build, so a package built with `VITE_HOME_PAGE_BASE_URL=https://airepublic.com`
-will keep opening production until it is rebuilt with the local value.
+You can also set `VITE_AUTH_BASE_URL=https://auth.example.local` in
+`src/desktop/.env`. The desktop web UI and runtime sidecar read the hosted auth
+URL during the build, so changing it requires rebuilding the desktop package.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ cp .env.example src/desktop/.env
 | `VITE_AUTH_COOKIE_DOMAIN` | Optional cookie domain for hosted auth | `.example.com` |
 | `VITE_AUTH_ACCESS_COOKIE_NAME` | Hosted auth access-token cookie name | `access_token` |
 | `VITE_AUTH_REFRESH_COOKIE_NAME` | Hosted auth refresh-token cookie name | `refresh_token` |
+| `VITE_AUTH_LOGIN_PATH` | Optional hosted login path | `/signin` |
+| `VITE_AUTH_PROFILE_PATH` | Optional hosted profile API path | `/profile` |
+| `VITE_AUTH_DESKTOP_SESSION_PATH` | Optional desktop session API path | `/desktop/session` |
+| `VITE_AUTH_DESKTOP_REFRESH_PATH` | Optional desktop token refresh API path | `/desktop/refresh` |
+| `VITE_AUTH_USER_CENTER_PATH` | Optional hosted account path | `/account` |
+| `VITE_AUTH_PRICING_PATH` | Optional hosted plan upgrade path | `/plans` |
 
 ---
 

--- a/build.sh
+++ b/build.sh
@@ -149,10 +149,15 @@ desktop_env_value() {
   printf '%s\n' "$value"
 }
 
-EFFECTIVE_HOME_PAGE_URL="${VITE_HOME_PAGE_BASE_URL:-$(desktop_env_value VITE_HOME_PAGE_BASE_URL)}"
-echo "ApplePi build home page URL: ${EFFECTIVE_HOME_PAGE_URL:-https://airepublic.com}"
-if [[ -n "${APPLEPI_HOME_PAGE_BASE_URL:-}" && -z "${VITE_HOME_PAGE_BASE_URL:-}" ]]; then
-  echo "Note: APPLEPI_HOME_PAGE_BASE_URL affects runtime Node code only; set VITE_HOME_PAGE_BASE_URL for the desktop WebView build."
+EFFECTIVE_AUTH_BASE_URL="${VITE_AUTH_BASE_URL:-$(desktop_env_value VITE_AUTH_BASE_URL)}"
+if [[ -z "$EFFECTIVE_AUTH_BASE_URL" ]]; then
+  EFFECTIVE_AUTH_BASE_URL="${VITE_HOME_PAGE_BASE_URL:-$(desktop_env_value VITE_HOME_PAGE_BASE_URL)}"
+fi
+echo "ApplePi build auth base URL: ${EFFECTIVE_AUTH_BASE_URL:-not configured}"
+if [[ -n "${APPLEPI_AUTH_BASE_URL:-}" && -z "${VITE_AUTH_BASE_URL:-}" ]]; then
+  echo "Note: APPLEPI_AUTH_BASE_URL affects runtime Node code only; set VITE_AUTH_BASE_URL for the desktop WebView build."
+elif [[ -n "${APPLEPI_HOME_PAGE_BASE_URL:-}" && -z "${VITE_HOME_PAGE_BASE_URL:-}" && -z "${VITE_AUTH_BASE_URL:-}" ]]; then
+  echo "Note: APPLEPI_HOME_PAGE_BASE_URL affects runtime Node code only; set VITE_AUTH_BASE_URL for the desktop WebView build."
 fi
 
 cd "$ROOT_DIR/tauri"

--- a/src/config/__tests__/authConfig.test.ts
+++ b/src/config/__tests__/authConfig.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveAuthConfig } from '../authConfig';
+
+const ENV_KEYS = [
+  'APPLEPI_AUTH_BASE_URL',
+  'APPLEPI_HOME_PAGE_BASE_URL',
+  'VITE_AUTH_BASE_URL',
+  'VITE_HOME_PAGE_BASE_URL',
+  'VITE_AUTH_COOKIE_DOMAIN',
+  'VITE_COOKIE_DOMAIN',
+  'VITE_AUTH_ACCESS_COOKIE_NAME',
+  'VITE_AUTH_REFRESH_COOKIE_NAME',
+  'VITE_AUTH_CSRF_COOKIE_NAME',
+  'VITE_AUTH_STATUS_COOKIE_NAME',
+  'VITE_AUTH_USER_NAME_COOKIE_NAME',
+  'VITE_AUTH_USER_EMAIL_COOKIE_NAME',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+
+describe('resolveAuthConfig', () => {
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      originalEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const original = originalEnv.get(key);
+      if (original === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original;
+      }
+    }
+    originalEnv.clear();
+  });
+
+  it('does not configure a hosted provider by default', () => {
+    expect(resolveAuthConfig()).toMatchObject({
+      authBaseUrl: null,
+      cookieDomain: null,
+      cookieNames: {
+        access: 'access_token',
+        refresh: 'refresh_token',
+        csrf: 'csrf_token',
+        status: 'auth_status',
+        userName: 'user_name',
+        userEmail: 'user_email',
+      },
+      source: {
+        authBaseUrl: 'default',
+        cookieDomain: 'default',
+        cookieNames: 'default',
+      },
+    });
+  });
+
+  it('reads neutral hosted auth env values', () => {
+    process.env.VITE_AUTH_BASE_URL = 'https://auth.example.com';
+    process.env.VITE_AUTH_COOKIE_DOMAIN = '.example.com';
+    process.env.VITE_AUTH_ACCESS_COOKIE_NAME = 'custom_access';
+    process.env.VITE_AUTH_REFRESH_COOKIE_NAME = 'custom_refresh';
+    process.env.VITE_AUTH_CSRF_COOKIE_NAME = 'custom_csrf';
+    process.env.VITE_AUTH_STATUS_COOKIE_NAME = 'custom_status';
+    process.env.VITE_AUTH_USER_NAME_COOKIE_NAME = 'custom_name';
+    process.env.VITE_AUTH_USER_EMAIL_COOKIE_NAME = 'custom_email';
+
+    expect(resolveAuthConfig()).toMatchObject({
+      authBaseUrl: 'https://auth.example.com',
+      cookieDomain: '.example.com',
+      cookieNames: {
+        access: 'custom_access',
+        refresh: 'custom_refresh',
+        csrf: 'custom_csrf',
+        status: 'custom_status',
+        userName: 'custom_name',
+        userEmail: 'custom_email',
+      },
+      source: {
+        authBaseUrl: 'env',
+        cookieDomain: 'env',
+        cookieNames: 'env',
+      },
+    });
+  });
+
+  it('keeps legacy env aliases for existing private builds', () => {
+    process.env.VITE_HOME_PAGE_BASE_URL = 'https://legacy-home.example.com';
+    process.env.VITE_COOKIE_DOMAIN = '.legacy.example.com';
+
+    expect(resolveAuthConfig()).toMatchObject({
+      authBaseUrl: 'https://legacy-home.example.com',
+      cookieDomain: '.legacy.example.com',
+      source: {
+        authBaseUrl: 'env',
+        cookieDomain: 'env',
+      },
+    });
+  });
+});

--- a/src/config/__tests__/authConfig.test.ts
+++ b/src/config/__tests__/authConfig.test.ts
@@ -14,6 +14,13 @@ const ENV_KEYS = [
   'VITE_AUTH_STATUS_COOKIE_NAME',
   'VITE_AUTH_USER_NAME_COOKIE_NAME',
   'VITE_AUTH_USER_EMAIL_COOKIE_NAME',
+  'VITE_AUTH_LOGIN_PATH',
+  'VITE_AUTH_DESKTOP_SESSION_PATH',
+  'VITE_AUTH_DESKTOP_REFRESH_PATH',
+  'VITE_AUTH_PROFILE_PATH',
+  'VITE_AUTH_USER_CENTER_PATH',
+  'VITE_AUTH_PRICING_PATH',
+  'APPLEPI_AUTH_DESKTOP_SESSION_PATH',
 ] as const;
 
 const originalEnv = new Map<string, string | undefined>();
@@ -50,10 +57,19 @@ describe('resolveAuthConfig', () => {
         userName: 'user_name',
         userEmail: 'user_email',
       },
+      routes: {
+        login: null,
+        desktopSession: null,
+        desktopRefresh: null,
+        profile: null,
+        userCenter: null,
+        pricing: null,
+      },
       source: {
         authBaseUrl: 'default',
         cookieDomain: 'default',
         cookieNames: 'default',
+        routes: 'default',
       },
     });
   });
@@ -67,6 +83,12 @@ describe('resolveAuthConfig', () => {
     process.env.VITE_AUTH_STATUS_COOKIE_NAME = 'custom_status';
     process.env.VITE_AUTH_USER_NAME_COOKIE_NAME = 'custom_name';
     process.env.VITE_AUTH_USER_EMAIL_COOKIE_NAME = 'custom_email';
+    process.env.VITE_AUTH_LOGIN_PATH = '/signin';
+    process.env.VITE_AUTH_DESKTOP_SESSION_PATH = '/desktop/session';
+    process.env.VITE_AUTH_DESKTOP_REFRESH_PATH = '/desktop/refresh';
+    process.env.VITE_AUTH_PROFILE_PATH = '/profile';
+    process.env.VITE_AUTH_USER_CENTER_PATH = '/account';
+    process.env.VITE_AUTH_PRICING_PATH = '/plans';
 
     expect(resolveAuthConfig()).toMatchObject({
       authBaseUrl: 'https://auth.example.com',
@@ -79,12 +101,28 @@ describe('resolveAuthConfig', () => {
         userName: 'custom_name',
         userEmail: 'custom_email',
       },
+      routes: {
+        login: '/signin',
+        desktopSession: '/desktop/session',
+        desktopRefresh: '/desktop/refresh',
+        profile: '/profile',
+        userCenter: '/account',
+        pricing: '/plans',
+      },
       source: {
         authBaseUrl: 'env',
         cookieDomain: 'env',
         cookieNames: 'env',
+        routes: 'env',
       },
     });
+  });
+
+  it('prefers runtime route aliases over VITE route values', () => {
+    process.env.APPLEPI_AUTH_DESKTOP_SESSION_PATH = '/runtime/session';
+    process.env.VITE_AUTH_DESKTOP_SESSION_PATH = '/vite/session';
+
+    expect(resolveAuthConfig().routes.desktopSession).toBe('/runtime/session');
   });
 
   it('keeps legacy env aliases for existing private builds', () => {

--- a/src/config/__tests__/runtimeUrls.test.ts
+++ b/src/config/__tests__/runtimeUrls.test.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { resolveRuntimeUrls } from '../runtimeUrls';
 
 const ENV_KEYS = [
+  'APPLEPI_AUTH_BASE_URL',
   'APPLEPI_HOME_PAGE_BASE_URL',
   'APPLEPI_BACKEND_API_BASE_URL',
+  'VITE_AUTH_BASE_URL',
   'VITE_HOME_PAGE_BASE_URL',
   'VITE_BACKEND_API_BASE_URL',
 ] as const;
@@ -30,11 +32,11 @@ describe('resolveRuntimeUrls', () => {
     originalEnv.clear();
   });
 
-  it('uses production defaults when no runtime env is set', () => {
+  it('leaves hosted auth unconfigured when no runtime env is set', () => {
     const urls = resolveRuntimeUrls();
 
     expect(urls).toMatchObject({
-      homePageBaseUrl: 'https://airepublic.com',
+      homePageBaseUrl: null,
       backendApiBaseUrl: null,
       llmApiUrl: '/api/llm',
       deeplinkRedirectUrl: 'applepi://auth/callback',
@@ -47,8 +49,8 @@ describe('resolveRuntimeUrls', () => {
     });
   });
 
-  it('prefers APPLEPI env values over VITE env values', () => {
-    process.env.APPLEPI_HOME_PAGE_BASE_URL = 'https://localhome.airepublic.com';
+  it('prefers APPLEPI auth env values over VITE env values', () => {
+    process.env.APPLEPI_AUTH_BASE_URL = 'https://auth.example.com';
     process.env.VITE_HOME_PAGE_BASE_URL = 'https://vite-home.example.com';
     process.env.APPLEPI_BACKEND_API_BASE_URL = 'https://backend.example.com';
     process.env.VITE_BACKEND_API_BASE_URL = 'https://vite-backend.example.com';
@@ -56,7 +58,7 @@ describe('resolveRuntimeUrls', () => {
     const urls = resolveRuntimeUrls();
 
     expect(urls).toMatchObject({
-      homePageBaseUrl: 'https://localhome.airepublic.com',
+      homePageBaseUrl: 'https://auth.example.com',
       backendApiBaseUrl: 'https://backend.example.com',
       llmApiUrl: 'https://backend.example.com/api/llm',
       source: {
@@ -67,14 +69,14 @@ describe('resolveRuntimeUrls', () => {
     });
   });
 
-  it('falls back to process VITE env values', () => {
-    process.env.VITE_HOME_PAGE_BASE_URL = 'https://vite-home.example.com';
+  it('falls back to process VITE auth env values', () => {
+    process.env.VITE_AUTH_BASE_URL = 'https://vite-auth.example.com';
     process.env.VITE_BACKEND_API_BASE_URL = 'https://vite-backend.example.com';
 
     const urls = resolveRuntimeUrls();
 
     expect(urls).toMatchObject({
-      homePageBaseUrl: 'https://vite-home.example.com',
+      homePageBaseUrl: 'https://vite-auth.example.com',
       backendApiBaseUrl: 'https://vite-backend.example.com',
       llmApiUrl: 'https://vite-backend.example.com/api/llm',
       source: {
@@ -83,5 +85,15 @@ describe('resolveRuntimeUrls', () => {
         llmApiUrl: 'env',
       },
     });
+  });
+
+  it('keeps legacy home page env aliases for existing builds', () => {
+    process.env.APPLEPI_HOME_PAGE_BASE_URL = 'https://legacy-runtime.example.com';
+    process.env.VITE_HOME_PAGE_BASE_URL = 'https://legacy-vite.example.com';
+
+    const urls = resolveRuntimeUrls();
+
+    expect(urls.homePageBaseUrl).toBe('https://legacy-runtime.example.com');
+    expect(urls.source.homePageBaseUrl).toBe('env');
   });
 });

--- a/src/config/authConfig.ts
+++ b/src/config/authConfig.ts
@@ -9,14 +9,25 @@ export interface AuthCookieNames {
   userEmail: string;
 }
 
+export interface AuthRoutePaths {
+  login: string | null;
+  desktopSession: string | null;
+  desktopRefresh: string | null;
+  profile: string | null;
+  userCenter: string | null;
+  pricing: string | null;
+}
+
 export interface AuthConfig {
   authBaseUrl: string | null;
   cookieDomain: string | null;
   cookieNames: AuthCookieNames;
+  routes: AuthRoutePaths;
   source: {
     authBaseUrl: AuthConfigSource;
     cookieDomain: AuthConfigSource;
     cookieNames: AuthConfigSource;
+    routes: AuthConfigSource;
   };
 }
 
@@ -41,6 +52,18 @@ function processEnv(): Record<string, string | undefined> {
 
 function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
   return values.find((value) => typeof value === 'string' && value.trim().length > 0);
+}
+
+function routePath(
+  env: Record<string, string | undefined>,
+  vite: Record<string, string | undefined>,
+  name: string,
+): string | null {
+  return firstNonEmpty(
+    env[`APPLEPI_AUTH_${name}_PATH`],
+    env[`VITE_AUTH_${name}_PATH`],
+    vite[`VITE_AUTH_${name}_PATH`],
+  ) ?? null;
 }
 
 export function resolveAuthConfig(): AuthConfig {
@@ -70,19 +93,30 @@ export function resolveAuthConfig(): AuthConfig {
     userName: firstNonEmpty(env.VITE_AUTH_USER_NAME_COOKIE_NAME, vite.VITE_AUTH_USER_NAME_COOKIE_NAME) ?? DEFAULT_COOKIE_NAMES.userName,
     userEmail: firstNonEmpty(env.VITE_AUTH_USER_EMAIL_COOKIE_NAME, vite.VITE_AUTH_USER_EMAIL_COOKIE_NAME) ?? DEFAULT_COOKIE_NAMES.userEmail,
   };
+  const routes: AuthRoutePaths = {
+    login: routePath(env, vite, 'LOGIN'),
+    desktopSession: routePath(env, vite, 'DESKTOP_SESSION'),
+    desktopRefresh: routePath(env, vite, 'DESKTOP_REFRESH'),
+    profile: routePath(env, vite, 'PROFILE'),
+    userCenter: routePath(env, vite, 'USER_CENTER'),
+    pricing: routePath(env, vite, 'PRICING'),
+  };
 
   const usesDefaultCookieNames = Object.entries(cookieNames).every(
     ([key, value]) => value === DEFAULT_COOKIE_NAMES[key as keyof AuthCookieNames],
   );
+  const usesDefaultRoutes = Object.values(routes).every((route) => route === null);
 
   return {
     authBaseUrl,
     cookieDomain,
     cookieNames,
+    routes,
     source: {
       authBaseUrl: authBaseUrl ? 'env' : 'default',
       cookieDomain: cookieDomain ? 'env' : 'default',
       cookieNames: usesDefaultCookieNames ? 'default' : 'env',
+      routes: usesDefaultRoutes ? 'default' : 'env',
     },
   };
 }

--- a/src/config/authConfig.ts
+++ b/src/config/authConfig.ts
@@ -1,0 +1,88 @@
+export type AuthConfigSource = 'env' | 'default';
+
+export interface AuthCookieNames {
+  access: string;
+  refresh: string;
+  csrf: string;
+  status: string;
+  userName: string;
+  userEmail: string;
+}
+
+export interface AuthConfig {
+  authBaseUrl: string | null;
+  cookieDomain: string | null;
+  cookieNames: AuthCookieNames;
+  source: {
+    authBaseUrl: AuthConfigSource;
+    cookieDomain: AuthConfigSource;
+    cookieNames: AuthConfigSource;
+  };
+}
+
+const DEFAULT_COOKIE_NAMES: AuthCookieNames = {
+  access: 'access_token',
+  refresh: 'refresh_token',
+  csrf: 'csrf_token',
+  status: 'auth_status',
+  userName: 'user_name',
+  userEmail: 'user_email',
+};
+
+function viteEnv(): Record<string, string | undefined> {
+  return typeof import.meta !== 'undefined'
+    ? ((import.meta as unknown as { env?: Record<string, string | undefined> }).env ?? {})
+    : {};
+}
+
+function processEnv(): Record<string, string | undefined> {
+  return typeof process !== 'undefined' ? process.env : {};
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  return values.find((value) => typeof value === 'string' && value.trim().length > 0);
+}
+
+export function resolveAuthConfig(): AuthConfig {
+  const env = processEnv();
+  const vite = viteEnv();
+
+  const authBaseUrl = firstNonEmpty(
+    env.APPLEPI_AUTH_BASE_URL,
+    env.APPLEPI_HOME_PAGE_BASE_URL,
+    env.VITE_AUTH_BASE_URL,
+    env.VITE_HOME_PAGE_BASE_URL,
+    vite.VITE_AUTH_BASE_URL,
+    vite.VITE_HOME_PAGE_BASE_URL,
+  ) ?? null;
+  const cookieDomain = firstNonEmpty(
+    env.VITE_AUTH_COOKIE_DOMAIN,
+    env.VITE_COOKIE_DOMAIN,
+    vite.VITE_AUTH_COOKIE_DOMAIN,
+    vite.VITE_COOKIE_DOMAIN,
+  ) ?? null;
+
+  const cookieNames: AuthCookieNames = {
+    access: firstNonEmpty(env.VITE_AUTH_ACCESS_COOKIE_NAME, vite.VITE_AUTH_ACCESS_COOKIE_NAME) ?? DEFAULT_COOKIE_NAMES.access,
+    refresh: firstNonEmpty(env.VITE_AUTH_REFRESH_COOKIE_NAME, vite.VITE_AUTH_REFRESH_COOKIE_NAME) ?? DEFAULT_COOKIE_NAMES.refresh,
+    csrf: firstNonEmpty(env.VITE_AUTH_CSRF_COOKIE_NAME, vite.VITE_AUTH_CSRF_COOKIE_NAME) ?? DEFAULT_COOKIE_NAMES.csrf,
+    status: firstNonEmpty(env.VITE_AUTH_STATUS_COOKIE_NAME, vite.VITE_AUTH_STATUS_COOKIE_NAME) ?? DEFAULT_COOKIE_NAMES.status,
+    userName: firstNonEmpty(env.VITE_AUTH_USER_NAME_COOKIE_NAME, vite.VITE_AUTH_USER_NAME_COOKIE_NAME) ?? DEFAULT_COOKIE_NAMES.userName,
+    userEmail: firstNonEmpty(env.VITE_AUTH_USER_EMAIL_COOKIE_NAME, vite.VITE_AUTH_USER_EMAIL_COOKIE_NAME) ?? DEFAULT_COOKIE_NAMES.userEmail,
+  };
+
+  const usesDefaultCookieNames = Object.entries(cookieNames).every(
+    ([key, value]) => value === DEFAULT_COOKIE_NAMES[key as keyof AuthCookieNames],
+  );
+
+  return {
+    authBaseUrl,
+    cookieDomain,
+    cookieNames,
+    source: {
+      authBaseUrl: authBaseUrl ? 'env' : 'default',
+      cookieDomain: cookieDomain ? 'env' : 'default',
+      cookieNames: usesDefaultCookieNames ? 'default' : 'env',
+    },
+  };
+}

--- a/src/config/runtimeUrls.ts
+++ b/src/config/runtimeUrls.ts
@@ -1,7 +1,9 @@
+import { resolveAuthConfig } from './authConfig';
+
 export type RuntimeUrlSource = 'env' | 'default';
 
 export interface RuntimeUrlConfig {
-  homePageBaseUrl: string;
+  homePageBaseUrl: string | null;
   backendApiBaseUrl: string | null;
   llmApiUrl: string | null;
   deeplinkRedirectUrl: 'applepi://auth/callback';
@@ -30,32 +32,26 @@ function firstNonEmpty(...values: Array<string | undefined>): string | undefined
 export function resolveRuntimeUrls(): RuntimeUrlConfig {
   const env = processEnv();
   const vite = viteEnv();
+  const authConfig = resolveAuthConfig();
 
-  const homeFromEnv = firstNonEmpty(
-    env.APPLEPI_HOME_PAGE_BASE_URL,
-    env.VITE_HOME_PAGE_BASE_URL,
-    vite.VITE_HOME_PAGE_BASE_URL,
-  );
   const backendFromEnv = firstNonEmpty(
     env.APPLEPI_BACKEND_API_BASE_URL,
     env.VITE_BACKEND_API_BASE_URL,
     vite.VITE_BACKEND_API_BASE_URL,
   );
 
-  const homePageBaseUrl = homeFromEnv ?? 'https://airepublic.com';
   const backendApiBaseUrl = backendFromEnv ?? null;
 
   return {
-    homePageBaseUrl,
+    homePageBaseUrl: authConfig.authBaseUrl,
     backendApiBaseUrl,
     llmApiUrl: backendApiBaseUrl ? `${backendApiBaseUrl}/api/llm` : '/api/llm',
     deeplinkRedirectUrl: 'applepi://auth/callback',
     source: {
-      homePageBaseUrl: homeFromEnv ? 'env' : 'default',
+      homePageBaseUrl: authConfig.source.authBaseUrl,
       backendApiBaseUrl: backendFromEnv ? 'env' : 'default',
       llmApiUrl: backendFromEnv ? 'env' : 'default',
       deeplinkRedirectUrl: 'default',
     },
   };
 }
-

--- a/src/desktop-runtime/auth/__tests__/runtimeProfileFetch.test.ts
+++ b/src/desktop-runtime/auth/__tests__/runtimeProfileFetch.test.ts
@@ -37,17 +37,17 @@ describe('profileFromAccessToken', () => {
 });
 
 describe('fetchUserProfileServerSide', () => {
-  const originalHomeUrl = process.env.VITE_HOME_PAGE_BASE_URL;
+  const originalHomeUrl = process.env.VITE_AUTH_BASE_URL;
 
   beforeEach(() => {
-    process.env.VITE_HOME_PAGE_BASE_URL = 'https://home.example.com';
+    process.env.VITE_AUTH_BASE_URL = 'https://home.example.com';
   });
 
   afterEach(() => {
     if (originalHomeUrl === undefined) {
-      delete process.env.VITE_HOME_PAGE_BASE_URL;
+      delete process.env.VITE_AUTH_BASE_URL;
     } else {
-      process.env.VITE_HOME_PAGE_BASE_URL = originalHomeUrl;
+      process.env.VITE_AUTH_BASE_URL = originalHomeUrl;
     }
     vi.unstubAllGlobals();
   });
@@ -114,17 +114,17 @@ describe('fetchUserProfileServerSide', () => {
 });
 
 describe('refreshDesktopAuthTokens', () => {
-  const originalHomeUrl = process.env.VITE_HOME_PAGE_BASE_URL;
+  const originalHomeUrl = process.env.VITE_AUTH_BASE_URL;
 
   beforeEach(() => {
-    process.env.VITE_HOME_PAGE_BASE_URL = 'https://home.example.com';
+    process.env.VITE_AUTH_BASE_URL = 'https://home.example.com';
   });
 
   afterEach(() => {
     if (originalHomeUrl === undefined) {
-      delete process.env.VITE_HOME_PAGE_BASE_URL;
+      delete process.env.VITE_AUTH_BASE_URL;
     } else {
-      process.env.VITE_HOME_PAGE_BASE_URL = originalHomeUrl;
+      process.env.VITE_AUTH_BASE_URL = originalHomeUrl;
     }
     vi.unstubAllGlobals();
   });

--- a/src/desktop-runtime/auth/__tests__/runtimeProfileFetch.test.ts
+++ b/src/desktop-runtime/auth/__tests__/runtimeProfileFetch.test.ts
@@ -37,18 +37,32 @@ describe('profileFromAccessToken', () => {
 });
 
 describe('fetchUserProfileServerSide', () => {
-  const originalHomeUrl = process.env.VITE_AUTH_BASE_URL;
+  const originalEnv = new Map<string, string | undefined>();
+  const envKeys = [
+    'VITE_AUTH_BASE_URL',
+    'VITE_AUTH_DESKTOP_SESSION_PATH',
+    'VITE_AUTH_PROFILE_PATH',
+  ];
 
   beforeEach(() => {
+    for (const key of envKeys) {
+      originalEnv.set(key, process.env[key]);
+    }
     process.env.VITE_AUTH_BASE_URL = 'https://home.example.com';
+    process.env.VITE_AUTH_DESKTOP_SESSION_PATH = '/desktop/session';
+    process.env.VITE_AUTH_PROFILE_PATH = '/profile';
   });
 
   afterEach(() => {
-    if (originalHomeUrl === undefined) {
-      delete process.env.VITE_AUTH_BASE_URL;
-    } else {
-      process.env.VITE_AUTH_BASE_URL = originalHomeUrl;
+    for (const key of envKeys) {
+      const original = originalEnv.get(key);
+      if (original === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original;
+      }
     }
+    originalEnv.clear();
     vi.unstubAllGlobals();
   });
 
@@ -65,7 +79,7 @@ describe('fetchUserProfileServerSide', () => {
     const profile = await fetchUserProfileServerSide('access-token');
 
     expect(fetchMock).toHaveBeenCalledOnce();
-    expect(fetchMock).toHaveBeenCalledWith('https://home.example.com/auth/desktop/session', expect.objectContaining({
+    expect(fetchMock).toHaveBeenCalledWith('https://home.example.com/desktop/session', expect.objectContaining({
       method: 'GET',
       headers: expect.objectContaining({ Authorization: 'Bearer access-token' }),
     }));
@@ -78,9 +92,9 @@ describe('fetchUserProfileServerSide', () => {
     });
   });
 
-  it('falls back to the legacy profile endpoint only when desktop session is missing', async () => {
+  it('falls back to the configured profile endpoint only when desktop session is missing', async () => {
     const fetchMock = vi.fn(async (url: string) => {
-      if (url.endsWith('/auth/desktop/session')) {
+      if (url.endsWith('/desktop/session')) {
         return new Response('', { status: 404, statusText: 'Not Found' });
       }
       return new Response(JSON.stringify({ id: 'u2', name: 'Fallback' }), { status: 200 });
@@ -90,7 +104,7 @@ describe('fetchUserProfileServerSide', () => {
     const profile = await fetchUserProfileServerSide('access-token');
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(fetchMock).toHaveBeenLastCalledWith('https://home.example.com/api/v1/users/profile', expect.objectContaining({
+    expect(fetchMock).toHaveBeenLastCalledWith('https://home.example.com/profile', expect.objectContaining({
       method: 'GET',
       headers: expect.objectContaining({ Authorization: 'Bearer access-token' }),
     }));
@@ -114,18 +128,30 @@ describe('fetchUserProfileServerSide', () => {
 });
 
 describe('refreshDesktopAuthTokens', () => {
-  const originalHomeUrl = process.env.VITE_AUTH_BASE_URL;
+  const originalEnv = new Map<string, string | undefined>();
+  const envKeys = [
+    'VITE_AUTH_BASE_URL',
+    'VITE_AUTH_DESKTOP_REFRESH_PATH',
+  ];
 
   beforeEach(() => {
+    for (const key of envKeys) {
+      originalEnv.set(key, process.env[key]);
+    }
     process.env.VITE_AUTH_BASE_URL = 'https://home.example.com';
+    process.env.VITE_AUTH_DESKTOP_REFRESH_PATH = '/desktop/refresh';
   });
 
   afterEach(() => {
-    if (originalHomeUrl === undefined) {
-      delete process.env.VITE_AUTH_BASE_URL;
-    } else {
-      process.env.VITE_AUTH_BASE_URL = originalHomeUrl;
+    for (const key of envKeys) {
+      const original = originalEnv.get(key);
+      if (original === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original;
+      }
     }
+    originalEnv.clear();
     vi.unstubAllGlobals();
   });
 
@@ -140,7 +166,7 @@ describe('refreshDesktopAuthTokens', () => {
 
     const tokens = await refreshDesktopAuthTokens('old-rt');
 
-    expect(fetchMock).toHaveBeenCalledWith('https://home.example.com/auth/desktop/refresh', expect.objectContaining({
+    expect(fetchMock).toHaveBeenCalledWith('https://home.example.com/desktop/refresh', expect.objectContaining({
       method: 'POST',
       headers: expect.objectContaining({ Authorization: 'Bearer old-rt' }),
       body: JSON.stringify({ refresh_token: 'old-rt' }),

--- a/src/desktop-runtime/auth/runtimeProfileFetch.ts
+++ b/src/desktop-runtime/auth/runtimeProfileFetch.ts
@@ -112,10 +112,9 @@ async function fetchJsonRecord(url: string, init: RequestInit): Promise<{
 }
 
 /**
- * Resolve the base URL for the auth backend. Identical default to the
- * webfront's `HOME_PAGE_BASE_URL`, overridable via env for tests / staging.
+ * Resolve the base URL for the hosted auth backend, when one is configured.
  */
-function resolveAuthBaseUrl(): string {
+function resolveAuthBaseUrl(): string | null {
   return resolveRuntimeUrls().homePageBaseUrl;
 }
 
@@ -130,6 +129,7 @@ export async function fetchUserProfileServerSide(
 ): Promise<RuntimeUserProfile | null> {
   if (!accessToken) return null;
   const baseUrl = resolveAuthBaseUrl();
+  if (!baseUrl) return profileFromAccessToken(accessToken);
   try {
     const desktopSession = await fetchJsonRecord(`${baseUrl}/auth/desktop/session`, {
       method: 'GET',
@@ -172,6 +172,7 @@ export async function refreshDesktopAuthTokens(
 ): Promise<RuntimeDesktopTokens | null> {
   if (!refreshToken) return null;
   const baseUrl = resolveAuthBaseUrl();
+  if (!baseUrl) return null;
   try {
     const response = await fetch(`${baseUrl}/auth/desktop/refresh`, {
       method: 'POST',

--- a/src/desktop-runtime/auth/runtimeProfileFetch.ts
+++ b/src/desktop-runtime/auth/runtimeProfileFetch.ts
@@ -10,6 +10,7 @@
  */
 
 import { resolveRuntimeUrls } from '@/config/runtimeUrls';
+import { resolveAuthConfig, type AuthRoutePaths } from '@/config/authConfig';
 
 export interface RuntimeUserProfile {
   id?: string;
@@ -118,6 +119,13 @@ function resolveAuthBaseUrl(): string | null {
   return resolveRuntimeUrls().homePageBaseUrl;
 }
 
+function resolveHostedAuthUrl(route: keyof AuthRoutePaths): string | null {
+  const baseUrl = resolveAuthBaseUrl();
+  const path = resolveAuthConfig().routes[route];
+  if (!baseUrl || !path) return null;
+  return new URL(path, baseUrl).toString();
+}
+
 /**
  * Fetch the authenticated user profile using a known-good access token.
  * Returns null on any error — callers treat null as "no profile available"
@@ -128,28 +136,32 @@ export async function fetchUserProfileServerSide(
   accessToken: string,
 ): Promise<RuntimeUserProfile | null> {
   if (!accessToken) return null;
-  const baseUrl = resolveAuthBaseUrl();
-  if (!baseUrl) return profileFromAccessToken(accessToken);
+  const desktopSessionUrl = resolveHostedAuthUrl('desktopSession');
+  const profileUrl = resolveHostedAuthUrl('profile');
+  if (!desktopSessionUrl && !profileUrl) return profileFromAccessToken(accessToken);
   try {
-    const desktopSession = await fetchJsonRecord(`${baseUrl}/auth/desktop/session`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
-      },
-    });
-    if (desktopSession.ok) {
-      return desktopSession.data ? normalizeProfile(desktopSession.data) : null;
+    if (desktopSessionUrl) {
+      const desktopSession = await fetchJsonRecord(desktopSessionUrl, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      });
+      if (desktopSession.ok) {
+        return desktopSession.data ? normalizeProfile(desktopSession.data) : null;
+      }
+
+      // Older hosted auth deployments may not expose a desktop session endpoint.
+      // Fall back only for that case; auth failures should remain auth failures.
+      if (desktopSession.status !== 404) {
+        console.warn(`[runtime-auth] desktop session fetch failed from ${desktopSessionUrl}: ${desktopSession.status} ${desktopSession.statusText}`);
+        return null;
+      }
     }
 
-    // Older home-page deployments did not expose the desktop session endpoint.
-    // Fall back only for that case; auth failures should remain auth failures.
-    if (desktopSession.status !== 404) {
-      console.warn(`[runtime-auth] desktop session fetch failed from ${baseUrl}: ${desktopSession.status} ${desktopSession.statusText}`);
-      return null;
-    }
-
-    const profileResponse = await fetchJsonRecord(`${baseUrl}/api/v1/users/profile`, {
+    if (!profileUrl) return null;
+    const profileResponse = await fetchJsonRecord(profileUrl, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -157,12 +169,12 @@ export async function fetchUserProfileServerSide(
       },
     });
     if (!profileResponse.ok) {
-      console.warn(`[runtime-auth] profile fetch failed from ${baseUrl}: ${profileResponse.status} ${profileResponse.statusText}`);
+      console.warn(`[runtime-auth] profile fetch failed from ${profileUrl}: ${profileResponse.status} ${profileResponse.statusText}`);
       return null;
     }
     return profileResponse.data ? normalizeProfile(profileResponse.data) : null;
   } catch (error) {
-    console.warn(`[runtime-auth] profile fetch threw from ${baseUrl}:`, error);
+    console.warn('[runtime-auth] profile fetch threw:', error);
     return profileFromAccessToken(accessToken);
   }
 }
@@ -171,10 +183,10 @@ export async function refreshDesktopAuthTokens(
   refreshToken: string,
 ): Promise<RuntimeDesktopTokens | null> {
   if (!refreshToken) return null;
-  const baseUrl = resolveAuthBaseUrl();
-  if (!baseUrl) return null;
+  const desktopRefreshUrl = resolveHostedAuthUrl('desktopRefresh');
+  if (!desktopRefreshUrl) return null;
   try {
-    const response = await fetch(`${baseUrl}/auth/desktop/refresh`, {
+    const response = await fetch(desktopRefreshUrl, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${refreshToken}`,
@@ -183,14 +195,14 @@ export async function refreshDesktopAuthTokens(
       body: JSON.stringify({ refresh_token: refreshToken }),
     });
     if (!response.ok) {
-      console.warn(`[runtime-auth] desktop token refresh failed from ${baseUrl}: ${response.status} ${response.statusText}`);
+      console.warn(`[runtime-auth] desktop token refresh failed from ${desktopRefreshUrl}: ${response.status} ${response.statusText}`);
       return null;
     }
     const data = await response.json() as Record<string, unknown>;
     const accessToken = pickString(data.access_token);
     const nextRefreshToken = pickString(data.refresh_token);
     if (!accessToken || !nextRefreshToken) {
-      console.warn(`[runtime-auth] desktop token refresh from ${baseUrl} returned incomplete tokens`);
+      console.warn(`[runtime-auth] desktop token refresh from ${desktopRefreshUrl} returned incomplete tokens`);
       return null;
     }
     return {
@@ -200,7 +212,7 @@ export async function refreshDesktopAuthTokens(
       expiresIn: typeof data.expires_in === 'number' ? data.expires_in : undefined,
     };
   } catch (error) {
-    console.warn(`[runtime-auth] desktop token refresh threw from ${baseUrl}:`, error);
+    console.warn(`[runtime-auth] desktop token refresh threw from ${desktopRefreshUrl}:`, error);
     return null;
   }
 }

--- a/src/webfront/App.svelte
+++ b/src/webfront/App.svelte
@@ -10,7 +10,7 @@
   import Doctor from './pages/diagnostics/Doctor.svelte';
   import Usage from './pages/usage/Usage.svelte';
   import { userStore } from './stores/userStore';
-  import { isAuthenticated } from './lib/utils/cookie';
+  import { AUTH_COOKIE_DOMAIN, AUTH_COOKIE_NAMES, isAuthenticated } from './lib/utils/cookie';
   import { fetchUserProfile } from './lib/apis';
   import { LLM_API_URL } from './lib/constants';
   import { AgentConfig } from '@/config/AgentConfig';
@@ -52,10 +52,6 @@
     // Catch-all route - redirect to chat
     '*': Chat,
   };
-
-  // Cookie domain for filtering cookie change events
-  const COOKIE_DOMAIN = import.meta.env.VITE_COOKIE_DOMAIN || '.airepublic.com';
-  const AUTH_COOKIE_NAME = 'ai_access';
 
   // Store the cookie change listener for cleanup
   let cookieChangeListener: ((changeInfo: chrome.cookies.CookieChangeInfo) => void) | null = $state(null);
@@ -263,8 +259,9 @@
 
         // Only react to auth cookie changes on our domain
         if (
-          cookie.name === AUTH_COOKIE_NAME &&
-          cookie.domain.includes(COOKIE_DOMAIN.replace(/^\./, ''))
+          AUTH_COOKIE_DOMAIN &&
+          cookie.name === AUTH_COOKIE_NAMES.access &&
+          cookie.domain.includes(AUTH_COOKIE_DOMAIN.replace(/^\./, ''))
         ) {
           console.log('[App] Auth cookie changed:', removed ? 'removed' : 'set');
           checkAndUpdateAuth();

--- a/src/webfront/components/common/UserLoginStatus.svelte
+++ b/src/webfront/components/common/UserLoginStatus.svelte
@@ -4,7 +4,7 @@
   import { userStore, userInitials, getDesktopLoginPageUrl, getLoginPageUrl } from '../../stores/userStore';
   import { uiTheme } from '../../stores/themeStore';
   import { platform } from '../../stores/platformStore';
-  import { HOME_PAGE_BASE_URL, LLM_API_URL } from '../../lib/constants';
+  import { AUTH_ROUTE_PATHS, HOME_PAGE_BASE_URL, LLM_API_URL, buildHostedAuthUrl } from '../../lib/constants';
   import Tooltip from './Tooltip.svelte';
   import PopupCard from './PopupCard.svelte';
   import { _t } from '../../lib/i18n';
@@ -17,7 +17,7 @@
   let showPromoTooltip = $state(false);
   let promoTooltipTimer: ReturnType<typeof setTimeout> | null = null;
   let hasShownPromoTooltip = $state(false);
-  const hasHostedAuth = HOME_PAGE_BASE_URL.length > 0;
+  const hasHostedAuth = Boolean(HOME_PAGE_BASE_URL && AUTH_ROUTE_PATHS.login);
 
   // Watch for user state changes to show promo tooltip when not logged in (only once)
   $effect(() => {
@@ -238,8 +238,8 @@
   async function openUserCenter(event: MouseEvent) {
     event.preventDefault();
     showMenu = false;
-    if (!hasHostedAuth) return;
-    const userCenterUrl = `${HOME_PAGE_BASE_URL}/user-center/info`;
+    const userCenterUrl = buildHostedAuthUrl(AUTH_ROUTE_PATHS.userCenter);
+    if (!userCenterUrl) return;
 
     if (platform.platformName === 'desktop') {
       // Desktop mode: use Tauri shell plugin to open in browser
@@ -298,7 +298,7 @@
       {#snippet content()}<div class="min-w-[180px]">
         <!-- User Info Section -->
         <a
-          href={hasHostedAuth ? `${HOME_PAGE_BASE_URL}/user-center/info` : undefined}
+          href={buildHostedAuthUrl(AUTH_ROUTE_PATHS.userCenter) ?? undefined}
           class="flex items-center gap-3 p-3 no-underline cursor-pointer rounded transition-colors duration-150
             {$uiTheme === 'modern'
               ? 'hover:bg-white/10'

--- a/src/webfront/components/common/UserLoginStatus.svelte
+++ b/src/webfront/components/common/UserLoginStatus.svelte
@@ -17,10 +17,11 @@
   let showPromoTooltip = $state(false);
   let promoTooltipTimer: ReturnType<typeof setTimeout> | null = null;
   let hasShownPromoTooltip = $state(false);
+  const hasHostedAuth = HOME_PAGE_BASE_URL.length > 0;
 
   // Watch for user state changes to show promo tooltip when not logged in (only once)
   $effect(() => {
-    if (!$userStore.isLoading && !$userStore.isLoggedIn && !hasShownPromoTooltip) {
+    if (hasHostedAuth && !$userStore.isLoading && !$userStore.isLoggedIn && !hasShownPromoTooltip) {
       showPromoTooltipWithTimer();
     } else if ($userStore.isLoggedIn) {
       hidePromoTooltip();
@@ -63,6 +64,11 @@
   });
 
   async function openLoginPage() {
+    if (!hasHostedAuth) {
+      console.warn('[UserLoginStatus] Hosted auth is not configured');
+      return;
+    }
+
     if (platform.platformName === 'desktop') {
       // Desktop mode: open the browser to /login, await the applepi-deeplink
       // deeplink (Rust → WebView event), and forward both tokens to the
@@ -91,6 +97,7 @@
         // home page handles both fresh Google login and already-authenticated
         // browser sessions.
         const loginUrl = getDesktopLoginPageUrl();
+        if (!loginUrl) throw new Error('Hosted auth is not configured');
 
         // 2. Subscribe to the applepi-deeplink event from Rust before opening the
         // browser — Rust emits it as soon as the OS hands us the URL.
@@ -200,7 +207,7 @@
     } else {
       // Extension mode: open login page in a new tab
       const loginUrl = getLoginPageUrl();
-      chrome.tabs.create({ url: loginUrl });
+      if (loginUrl) chrome.tabs.create({ url: loginUrl });
     }
   }
 
@@ -231,6 +238,7 @@
   async function openUserCenter(event: MouseEvent) {
     event.preventDefault();
     showMenu = false;
+    if (!hasHostedAuth) return;
     const userCenterUrl = `${HOME_PAGE_BASE_URL}/user-center/info`;
 
     if (platform.platformName === 'desktop') {
@@ -290,7 +298,7 @@
       {#snippet content()}<div class="min-w-[180px]">
         <!-- User Info Section -->
         <a
-          href="{HOME_PAGE_BASE_URL}/user-center/info"
+          href={hasHostedAuth ? `${HOME_PAGE_BASE_URL}/user-center/info` : undefined}
           class="flex items-center gap-3 p-3 no-underline cursor-pointer rounded transition-colors duration-150
             {$uiTheme === 'modern'
               ? 'hover:bg-white/10'
@@ -348,7 +356,7 @@
         </button>
       </div>{/snippet}
     </PopupCard>
-  {:else}
+  {:else if hasHostedAuth}
     <!-- Not logged in state - show login link -->
     <Tooltip content={isLoggingIn ? $_t("Click to cancel login") : (showPromoTooltip ? $_t("Login to get free credits") : $_t("Sign in to your account"))}>
       <button

--- a/src/webfront/components/layout/footbar/Credits.svelte
+++ b/src/webfront/components/layout/footbar/Credits.svelte
@@ -3,7 +3,7 @@
   import PopupCard from '../../common/PopupCard.svelte';
   import { userStore } from '../../../stores/userStore';
   import { uiTheme } from '../../../stores/themeStore';
-  import { HOME_PAGE_BASE_URL } from '../../../lib/constants';
+  import { AUTH_ROUTE_PATHS, buildHostedAuthUrl } from '../../../lib/constants';
   import { _t } from '../../../lib/i18n';
 
   const PLAN_NAMES: Record<number, string> = {
@@ -23,6 +23,7 @@
   };
 
   const PLAN_ID_PLUS = 2;
+  const pricingUrl = buildHostedAuthUrl(AUTH_ROUTE_PATHS.pricing);
 
   let showDetailsPopup = $state(false);
 
@@ -206,9 +207,9 @@
       </div>
 
       <!-- Upgrade Button -->
-      {#if credits.plan_id < PLAN_ID_PLUS && HOME_PAGE_BASE_URL}
+      {#if credits.plan_id < PLAN_ID_PLUS && pricingUrl}
         <a
-          href="{HOME_PAGE_BASE_URL}/pricing"
+          href={pricingUrl}
           target="_blank"
           rel="noopener noreferrer"
           class="flex items-center justify-center gap-2 w-full mt-3 p-2.5 bg-gradient-to-r from-violet-500 to-blue-500 text-white text-sm font-semibold no-underline rounded-md transition-all duration-200 hover:scale-[1.02] hover:shadow-lg hover:shadow-violet-500/30

--- a/src/webfront/components/layout/footbar/Credits.svelte
+++ b/src/webfront/components/layout/footbar/Credits.svelte
@@ -206,7 +206,7 @@
       </div>
 
       <!-- Upgrade Button -->
-      {#if credits.plan_id < PLAN_ID_PLUS}
+      {#if credits.plan_id < PLAN_ID_PLUS && HOME_PAGE_BASE_URL}
         <a
           href="{HOME_PAGE_BASE_URL}/pricing"
           target="_blank"

--- a/src/webfront/lib/apis/users/index.ts
+++ b/src/webfront/lib/apis/users/index.ts
@@ -3,7 +3,7 @@
  */
 
 import { getAccessToken } from '../../utils/cookie';
-import { HOME_PAGE_BASE_URL, BACKEND_GENERAL_API } from '../../constants';
+import { AUTH_ROUTE_PATHS, BACKEND_GENERAL_API, buildHostedAuthUrl } from '../../constants';
 
 export interface UserProfile {
   id?: string;
@@ -40,13 +40,13 @@ export async function fetchUserProfile(providedToken?: string): Promise<UserProf
       return null;
     }
 
-    const baseUrl = HOME_PAGE_BASE_URL;
-    if (!baseUrl) {
-      console.warn('[API] Hosted auth base URL is not configured for fetching user profile');
+    const profileUrl = buildHostedAuthUrl(AUTH_ROUTE_PATHS.profile);
+    if (!profileUrl) {
+      console.warn('[API] Hosted auth profile URL is not configured');
       return null;
     }
 
-    const response = await fetch(`${baseUrl}/api/v1/users/profile`, {
+    const response = await fetch(profileUrl, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${accessToken}`,

--- a/src/webfront/lib/apis/users/index.ts
+++ b/src/webfront/lib/apis/users/index.ts
@@ -41,6 +41,11 @@ export async function fetchUserProfile(providedToken?: string): Promise<UserProf
     }
 
     const baseUrl = HOME_PAGE_BASE_URL;
+    if (!baseUrl) {
+      console.warn('[API] Hosted auth base URL is not configured for fetching user profile');
+      return null;
+    }
+
     const response = await fetch(`${baseUrl}/api/v1/users/profile`, {
       method: 'GET',
       headers: {

--- a/src/webfront/lib/constants.ts
+++ b/src/webfront/lib/constants.ts
@@ -2,7 +2,7 @@ import { resolveRuntimeUrls } from '@/config/runtimeUrls';
 
 const runtimeUrls = resolveRuntimeUrls();
 
-export const HOME_PAGE_BASE_URL = runtimeUrls.homePageBaseUrl;
+export const HOME_PAGE_BASE_URL = runtimeUrls.homePageBaseUrl ?? '';
 export const BACKEND_API_BASE_URL = runtimeUrls.backendApiBaseUrl ?? '';
 
 export const BACKEND_GENERAL_API = `${BACKEND_API_BASE_URL}/api/v1`;

--- a/src/webfront/lib/constants.ts
+++ b/src/webfront/lib/constants.ts
@@ -1,9 +1,17 @@
 import { resolveRuntimeUrls } from '@/config/runtimeUrls';
+import { resolveAuthConfig } from '@/config/authConfig';
 
 const runtimeUrls = resolveRuntimeUrls();
+const authConfig = resolveAuthConfig();
 
 export const HOME_PAGE_BASE_URL = runtimeUrls.homePageBaseUrl ?? '';
 export const BACKEND_API_BASE_URL = runtimeUrls.backendApiBaseUrl ?? '';
+export const AUTH_ROUTE_PATHS = authConfig.routes;
 
 export const BACKEND_GENERAL_API = `${BACKEND_API_BASE_URL}/api/v1`;
 export const LLM_API_URL = runtimeUrls.llmApiUrl ?? `${BACKEND_API_BASE_URL}/api/llm`;
+
+export function buildHostedAuthUrl(path: string | null): string | null {
+  if (!HOME_PAGE_BASE_URL || !path) return null;
+  return new URL(path, HOME_PAGE_BASE_URL).toString();
+}

--- a/src/webfront/lib/utils/cookie/index.ts
+++ b/src/webfront/lib/utils/cookie/index.ts
@@ -1,7 +1,9 @@
-/**
- * Cookie utility functions for handling authentication cookies
- * Adapted for Chrome extension sidepanel - uses chrome.cookies API
- */
+import { resolveAuthConfig } from '@/config/authConfig';
+
+const authConfig = resolveAuthConfig();
+
+export const AUTH_COOKIE_NAMES = authConfig.cookieNames;
+export const AUTH_COOKIE_DOMAIN = authConfig.cookieDomain;
 
 /**
  * Get a cookie value by name using Chrome extension cookies API
@@ -10,7 +12,8 @@
  * @returns Cookie value or null if not found
  */
 export async function getCookie(name: string, domain?: string): Promise<string | null> {
-  const cookieDomain = domain || import.meta.env.VITE_COOKIE_DOMAIN || '.airepublic.com';
+  const cookieDomain = domain || AUTH_COOKIE_DOMAIN;
+  if (!cookieDomain) return null;
 
   try {
     // Use chrome.cookies API for extension context
@@ -46,10 +49,10 @@ export async function getCookie(name: string, domain?: string): Promise<string |
  */
 export async function isAuthenticated(): Promise<boolean> {
   // Check for the actual access token cookie (httpOnly, set by server)
-  // This is more reliable than checking the ai_auth_status indicator cookie
+  // This is more reliable than checking the auth status indicator cookie
   // which is set by client-side JavaScript on the website and may not exist
   // until the user visits the website in the current browser session
-  const accessToken = await getCookie('ai_access');
+  const accessToken = await getCookie(AUTH_COOKIE_NAMES.access);
   return accessToken !== null && accessToken.length > 0;
 }
 
@@ -58,7 +61,7 @@ export async function isAuthenticated(): Promise<boolean> {
  * @returns Access token or null
  */
 export async function getAccessToken(): Promise<string | null> {
-  return getCookie('ai_access');
+  return getCookie(AUTH_COOKIE_NAMES.access);
 }
 
 /**
@@ -66,7 +69,7 @@ export async function getAccessToken(): Promise<string | null> {
  * @returns Refresh token or null
  */
 export async function getRefreshToken(): Promise<string | null> {
-  return getCookie('ai_refresh');
+  return getCookie(AUTH_COOKIE_NAMES.refresh);
 }
 
 /**
@@ -74,7 +77,7 @@ export async function getRefreshToken(): Promise<string | null> {
  * @returns CSRF token or null
  */
 export async function getCsrfToken(): Promise<string | null> {
-  return getCookie('ai_csrf');
+  return getCookie(AUTH_COOKIE_NAMES.csrf);
 }
 
 /**
@@ -82,7 +85,7 @@ export async function getCsrfToken(): Promise<string | null> {
  * @returns User name or null
  */
 export async function getUserName(): Promise<string | null> {
-  return getCookie('ai_user_name');
+  return getCookie(AUTH_COOKIE_NAMES.userName);
 }
 
 /**
@@ -90,7 +93,7 @@ export async function getUserName(): Promise<string | null> {
  * @returns User email or null
  */
 export async function getUserEmail(): Promise<string | null> {
-  return getCookie('ai_user_email');
+  return getCookie(AUTH_COOKIE_NAMES.userEmail);
 }
 
 /**
@@ -98,12 +101,13 @@ export async function getUserEmail(): Promise<string | null> {
  * Note: In Chrome extension context, this requires the cookies permission
  */
 export async function clearAuthCookies(): Promise<void> {
-  const cookieDomain = import.meta.env.VITE_COOKIE_DOMAIN || '.airepublic.com';
+  const cookieDomain = AUTH_COOKIE_DOMAIN;
+  if (!cookieDomain) return;
   const url = `https://${cookieDomain.replace(/^\./, '')}`;
 
   try {
     if (typeof chrome !== 'undefined' && chrome.cookies) {
-      const cookieNames = ['ai_access', 'ai_refresh', 'ai_csrf', 'ai_auth_status', 'ai_user_name', 'ai_user_email'];
+      const cookieNames = Object.values(AUTH_COOKIE_NAMES);
 
       await Promise.all(
         cookieNames.map((name) =>
@@ -125,7 +129,8 @@ export async function clearAuthCookies(): Promise<void> {
  * @param days Number of days until expiration
  */
 export async function setCookie(name: string, value: string, days: number): Promise<void> {
-  const cookieDomain = import.meta.env.VITE_COOKIE_DOMAIN || '.airepublic.com';
+  const cookieDomain = AUTH_COOKIE_DOMAIN;
+  if (!cookieDomain) return;
   const url = `https://${cookieDomain.replace(/^\./, '')}`;
 
   try {

--- a/src/webfront/pages/chat/Main.svelte
+++ b/src/webfront/pages/chat/Main.svelte
@@ -90,7 +90,10 @@
       window.dispatchEvent(new CustomEvent('applepi:request-login'));
       return;
     }
-    window.open(getLoginPageUrl(), '_blank', 'noopener,noreferrer');
+    const loginUrl = getLoginPageUrl();
+    if (loginUrl) {
+      window.open(loginUrl, '_blank', 'noopener,noreferrer');
+    }
   }
   let compactionNotification: { show: boolean; tokensSaved: number; compactionCount: number; isWarning: boolean } = $state({
     show: false,

--- a/src/webfront/stores/__tests__/userStore.test.ts
+++ b/src/webfront/stores/__tests__/userStore.test.ts
@@ -23,10 +23,19 @@ describe('userStore login URL helpers', () => {
   it('builds the desktop login URL with the deeplink redirect', async () => {
     const { getDesktopLoginPageUrl } = await loadUserStoreWithHomeUrl('https://home.example.com/');
 
-    const url = new URL(getDesktopLoginPageUrl());
+    const desktopLoginPageUrl = getDesktopLoginPageUrl();
+    expect(desktopLoginPageUrl).not.toBeNull();
+    const url = new URL(desktopLoginPageUrl!);
     expect(url.origin).toBe('https://home.example.com');
     expect(url.pathname).toBe('/login');
     expect(url.searchParams.get('redirect_url')).toBe('applepi://auth/callback');
     expect(url.searchParams.get('desktop_login_ts')).toMatch(/^\d+$/);
+  });
+
+  it('returns null when hosted auth is not configured', async () => {
+    const { getLoginPageUrl, getDesktopLoginPageUrl } = await loadUserStoreWithHomeUrl('');
+
+    expect(getLoginPageUrl()).toBeNull();
+    expect(getDesktopLoginPageUrl()).toBeNull();
   });
 });

--- a/src/webfront/stores/__tests__/userStore.test.ts
+++ b/src/webfront/stores/__tests__/userStore.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-async function loadUserStoreWithHomeUrl(homeUrl: string) {
+async function loadUserStoreWithHomeUrl(homeUrl: string, loginPath: string | null = '/signin') {
   vi.resetModules();
   vi.doMock('../../lib/constants', () => ({
+    AUTH_ROUTE_PATHS: {
+      login: loginPath,
+    },
     HOME_PAGE_BASE_URL: homeUrl,
   }));
   return import('../userStore');
@@ -17,7 +20,7 @@ describe('userStore login URL helpers', () => {
   it('normalizes the standard login URL when the home URL has a trailing slash', async () => {
     const { getLoginPageUrl } = await loadUserStoreWithHomeUrl('https://home.example.com/');
 
-    expect(getLoginPageUrl()).toBe('https://home.example.com/login');
+    expect(getLoginPageUrl()).toBe('https://home.example.com/signin');
   });
 
   it('builds the desktop login URL with the deeplink redirect', async () => {
@@ -27,13 +30,20 @@ describe('userStore login URL helpers', () => {
     expect(desktopLoginPageUrl).not.toBeNull();
     const url = new URL(desktopLoginPageUrl!);
     expect(url.origin).toBe('https://home.example.com');
-    expect(url.pathname).toBe('/login');
+    expect(url.pathname).toBe('/signin');
     expect(url.searchParams.get('redirect_url')).toBe('applepi://auth/callback');
     expect(url.searchParams.get('desktop_login_ts')).toMatch(/^\d+$/);
   });
 
   it('returns null when hosted auth is not configured', async () => {
     const { getLoginPageUrl, getDesktopLoginPageUrl } = await loadUserStoreWithHomeUrl('');
+
+    expect(getLoginPageUrl()).toBeNull();
+    expect(getDesktopLoginPageUrl()).toBeNull();
+  });
+
+  it('returns null when hosted auth login path is not configured', async () => {
+    const { getLoginPageUrl, getDesktopLoginPageUrl } = await loadUserStoreWithHomeUrl('https://home.example.com', null);
 
     expect(getLoginPageUrl()).toBeNull();
     expect(getDesktopLoginPageUrl()).toBeNull();

--- a/src/webfront/stores/userStore.ts
+++ b/src/webfront/stores/userStore.ts
@@ -6,7 +6,7 @@
  */
 
 import { writable, type Writable, derived, type Readable } from 'svelte/store';
-import { HOME_PAGE_BASE_URL } from '../lib/constants';
+import { AUTH_ROUTE_PATHS, HOME_PAGE_BASE_URL } from '../lib/constants';
 
 export interface UserState {
   isLoggedIn: boolean;
@@ -106,13 +106,13 @@ export const userInitials: Readable<string> = derived(userStore, ($user) =>
 
 // Get the login page URL derived from HOME_PAGE_BASE_URL
 export function getLoginPageUrl(): string | null {
-  if (!HOME_PAGE_BASE_URL) return null;
-  return new URL('/login', HOME_PAGE_BASE_URL).toString();
+  if (!HOME_PAGE_BASE_URL || !AUTH_ROUTE_PATHS.login) return null;
+  return new URL(AUTH_ROUTE_PATHS.login, HOME_PAGE_BASE_URL).toString();
 }
 
 export function getDesktopLoginPageUrl(): string | null {
-  if (!HOME_PAGE_BASE_URL) return null;
-  const loginUrl = new URL('/login', HOME_PAGE_BASE_URL);
+  if (!HOME_PAGE_BASE_URL || !AUTH_ROUTE_PATHS.login) return null;
+  const loginUrl = new URL(AUTH_ROUTE_PATHS.login, HOME_PAGE_BASE_URL);
   loginUrl.searchParams.set('redirect_url', 'applepi://auth/callback');
   loginUrl.searchParams.set('desktop_login_ts', Date.now().toString());
   return loginUrl.toString();

--- a/src/webfront/stores/userStore.ts
+++ b/src/webfront/stores/userStore.ts
@@ -105,11 +105,13 @@ export const userInitials: Readable<string> = derived(userStore, ($user) =>
 );
 
 // Get the login page URL derived from HOME_PAGE_BASE_URL
-export function getLoginPageUrl(): string {
+export function getLoginPageUrl(): string | null {
+  if (!HOME_PAGE_BASE_URL) return null;
   return new URL('/login', HOME_PAGE_BASE_URL).toString();
 }
 
-export function getDesktopLoginPageUrl(): string {
+export function getDesktopLoginPageUrl(): string | null {
+  if (!HOME_PAGE_BASE_URL) return null;
   const loginUrl = new URL('/login', HOME_PAGE_BASE_URL);
   loginUrl.searchParams.set('redirect_url', 'applepi://auth/callback');
   loginUrl.searchParams.set('desktop_login_ts', Date.now().toString());

--- a/tauri/Cargo.toml
+++ b/tauri/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["AI Republic"]
 license = "UNLICENSED"
 repository = ""
 edition = "2021"
+default-run = "pi"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -5,7 +5,7 @@
  * Without it, TypeScript doesn't know what properties exist on `import.meta.env`.
  *
  * Example usage in code:
- *   const domain = import.meta.env.VITE_COOKIE_DOMAIN; // TypeScript knows this is a string
+ *   const domain = import.meta.env.VITE_AUTH_COOKIE_DOMAIN; // TypeScript knows this is a string
  *
  * To add new environment variables:
  *   1. Add the variable to .env and .env.example (prefixed with VITE_)
@@ -19,10 +19,20 @@
  * All VITE_* prefixed variables from .env files should be declared here
  */
 interface ImportMetaEnv {
-  /** Cookie domain for reading auth cookies (e.g., '.airepublic.com') */
-  readonly VITE_COOKIE_DOMAIN: string;
-  /** Home page base URL (e.g., 'https://airepublic.com') */
+  /** Hosted auth base URL (e.g., 'https://auth.example.com') */
+  readonly VITE_AUTH_BASE_URL: string;
+  /** Cookie domain for reading auth cookies (e.g., '.example.com') */
+  readonly VITE_AUTH_COOKIE_DOMAIN: string;
+  /** Legacy hosted auth base URL alias */
   readonly VITE_HOME_PAGE_BASE_URL: string;
+  /** Legacy auth cookie domain alias */
+  readonly VITE_COOKIE_DOMAIN: string;
+  readonly VITE_AUTH_ACCESS_COOKIE_NAME: string;
+  readonly VITE_AUTH_REFRESH_COOKIE_NAME: string;
+  readonly VITE_AUTH_CSRF_COOKIE_NAME: string;
+  readonly VITE_AUTH_STATUS_COOKIE_NAME: string;
+  readonly VITE_AUTH_USER_NAME_COOKIE_NAME: string;
+  readonly VITE_AUTH_USER_EMAIL_COOKIE_NAME: string;
   /** API base URL for fetching user profile */
   readonly VITE_API_BASE_URL: string;
   /** Vault secret for wrapping the encryption key (32+ characters, from .env) */

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -33,6 +33,12 @@ interface ImportMetaEnv {
   readonly VITE_AUTH_STATUS_COOKIE_NAME: string;
   readonly VITE_AUTH_USER_NAME_COOKIE_NAME: string;
   readonly VITE_AUTH_USER_EMAIL_COOKIE_NAME: string;
+  readonly VITE_AUTH_LOGIN_PATH: string;
+  readonly VITE_AUTH_DESKTOP_SESSION_PATH: string;
+  readonly VITE_AUTH_DESKTOP_REFRESH_PATH: string;
+  readonly VITE_AUTH_PROFILE_PATH: string;
+  readonly VITE_AUTH_USER_CENTER_PATH: string;
+  readonly VITE_AUTH_PRICING_PATH: string;
   /** API base URL for fetching user profile */
   readonly VITE_API_BASE_URL: string;
   /** Vault secret for wrapping the encryption key (32+ characters, from .env) */


### PR DESCRIPTION
## Summary
- add a neutral hosted-auth config resolver with `VITE_AUTH_*` / `APPLEPI_AUTH_*` env names
- remove AI Republic auth URL, route paths, cookie domain, and `ai_*` cookie-name defaults from public BrowserX
- keep legacy env aliases for existing builds while docs/release env prefer neutral names
- make hosted-login/profile/account/upgrade UI paths tolerate auth being unconfigured
- set the Tauri package default binary so desktop release builds work with the helper test binary present

## Validation
- `npx vitest run src/config/__tests__/authConfig.test.ts src/config/__tests__/runtimeUrls.test.ts src/desktop-runtime/auth/__tests__/runtimeProfileFetch.test.ts src/webfront/stores/__tests__/userStore.test.ts`
- `npm run type-check`
- `npm run build`
- private desktop release binary built and launched from private-browserx pinned checkout