### PR TITLE
Design doc: improve web-operation tools from Codex extension analysis

### DIFF
--- a/.ai_design/improve_webtool_from_codex/design.md
+++ b/.ai_design/improve_webtool_from_codex/design.md
@@ -1,10 +1,10 @@
-# Improving workx Web-Operation Tools — Lessons from the OpenAI Codex Chrome Extension
+# Improving WorkX Web-Operation Tools — Lessons from the OpenAI Codex Chrome Extension
 
 **Status:** Reviewed — ready to implement (v2)
 **Date:** 2026-06-12 (v1 analysis; v2 design review same day)
 **Sources analyzed:**
 - OpenAI Codex Chrome extension v1.1.5 (store build, deobfuscated). Line references in this doc point to the prettified bundles (`background.pretty.js` ~7,100 lines, `codex-content.pretty.js` ~1,350 lines) produced with `js-beautify` from `/Users/irichard/Downloads/1.1.5_0/`.
-- workx extension source at HEAD (`37a092dd`).
+- WorkX extension source at HEAD (`37a092dd`).
 
 ---
 
@@ -12,7 +12,7 @@
 
 Codex's extension and ours solve the same problem — letting an LLM agent operate Chrome tabs — with **opposite architectures**:
 
-| | **Codex** | **workx** |
+| | **Codex** | **WorkX** |
 |---|---|---|
 | Intelligence location | Local CLI process; extension is a thin bridge | Inside the extension (tools, DOM serializer, agent loop) |
 | Transport | Native messaging (`com.openai.codexextension`), JSON-RPC 2.0 | In-process tool calls |
@@ -20,7 +20,7 @@ Codex's extension and ours solve the same problem — letting an LLM agent opera
 | Page reading | None in extension (CLI drives `DOMSnapshot`/`Page.captureScreenshot` itself over the passthrough) | `DomService` builds VirtualDOM from `DOM.getDocument` + `Accessibility.getFullAXTree` + `DOMSnapshot.captureSnapshot`, serialized for the LLM |
 | Events | All `chrome.debugger.onEvent` CDP events + download state changes pushed to the CLI (bg:6984) | Pull-only; no event push into agent loop |
 
-We should **not** copy the thin-bridge architecture — being self-contained is a workx product feature. But Codex's extension is production-hardened in exactly the layer where we are weakest: **debugger lifecycle, input dispatch correctness, viewport determinism, tab ownership/cleanup, and overlay robustness**. This doc enumerates 10 concrete improvements, each with their implementation details and a ready-to-implement plan for ours.
+We should **not** copy the thin-bridge architecture — being self-contained is a WorkX product feature. But Codex's extension is production-hardened in exactly the layer where we are weakest: **debugger lifecycle, input dispatch correctness, viewport determinism, tab ownership/cleanup, and overlay robustness**. This doc enumerates 10 concrete improvements, each with their implementation details and a ready-to-implement plan for ours.
 
 Priority summary (details in §4):
 
@@ -45,7 +45,7 @@ Every claim in §3 was re-verified against the code during review. Results, corr
 - **Duplicate service trees:** `src/tools/screenshot/{ScreenshotService,CoordinateActionService}.ts` and `src/tools/PageVisionTool.ts` are near-copies of the `src/extension/tools/*` versions, and `src/tools/PageVisionTool.ts:255-376` calls its own tree's `forTab()` — both trees attach `chrome.debugger` independently. **Decision:** the registry is defined by interface in `src/core/tools/browser/` (next to `DebuggerClient.ts`) with the Chrome implementation in `src/extension/tools/browser/`; both tool trees import the same singleton. Consolidating the duplicated trees is desirable but explicitly out of scope here — PR-1 only repoints both trees' attach calls.
 
 **Integration points pinned (replaces the loose references in v1):**
-- *Tab binding:* a workx session binds **one tab at a time** via `Session.setTabId` → `sessionState` (`src/core/Session.ts:1081-1082`, cleared at `:995`); tasks carry `scopedTabIds` and `Session.abortTasksForTab(tabId, reason)` exists (`Session.ts:2310-2313`). The §3.6 lease design is therefore *simpler* than Codex's multi-tab session: lease lifecycle hooks into `setTabId` (claim on bind, release+detach on rebind/clear) and into task completion/abort paths, not into a multi-tab finalize protocol. `finalizeTabs(keep[])`-style multi-tab semantics become relevant only if/when multi-tab sessions ship; the lease store schema below already supports it.
+- *Tab binding:* a WorkX session binds **one tab at a time** via `Session.setTabId` → `sessionState` (`src/core/Session.ts:1081-1082`, cleared at `:995`); tasks carry `scopedTabIds` and `Session.abortTasksForTab(tabId, reason)` exists (`Session.ts:2310-2313`). The §3.6 lease design is therefore *simpler* than Codex's multi-tab session: lease lifecycle hooks into `setTabId` (claim on bind, release+detach on rebind/clear) and into task completion/abort paths, not into a multi-tab finalize protocol. `finalizeTabs(keep[])`-style multi-tab semantics become relevant only if/when multi-tab sessions ship; the lease store schema below already supports it.
 - *Turn-end hook:* `TurnManager` (`src/core/TurnManager.ts`) runs turns; session cleanup at `Session.ts:995` is where leases/debuggers must be released. DownloadWatcher and dialog events (§3.8/§3.9) surface through the existing session event path used by tool progress (`BaseToolOptions.onProgress`) rather than a new bus.
 - *Tool registration:* new `browser_viewport` tool registers in `src/extension/tools/registerExtensionTools.ts` alongside `dom_tool` (`:129`) and `page_vision` (`:304`).
 - *Feature gating:* compile-time flags (`vite.featureFlags.mjs`) are deliberately heavyweight (rebuild-only, registry-synced). **Decision:** behavior switches in this work use `ServiceConfig` runtime options instead — `useContentQuads` (default true, `getBoxModel` fallback), `useLifecycleReadiness` (default true, heuristic fallback), `viewportOverride` (default off except `page_vision` flows).
@@ -128,7 +128,7 @@ with a default of **1280x720** (the viewport tool description, bg:3967, says: "o
 
 ---
 
-## 3. Findings: what Codex does better, and what to change in workx
+## 3. Findings: what Codex does better, and what to change in WorkX
 
 ### 3.1 [P0] Centralize debugger attachment — one registry, per-tab locks, refcounts
 
@@ -232,9 +232,9 @@ class DebuggerSessionRegistry {
 
 **Our current state:** `TabManager` (`src/core/TabManager.ts:28-67`) maintains one global "workx" tab group and closure callbacks; there is no ownership record distinguishing agent-created tabs from user tabs the agent borrowed, no turn-end contract (tools just leave tabs open and debuggers attached — `ScreenshotService`/`CoordinateActionService` never detach), and no persistence, so a service-worker restart forgets which tabs were ours.
 
-**Proposed change (incremental, not a full port — adjusted in review for workx's single-tab session model, §1.5):**
+**Proposed change (incremental, not a full port — adjusted in review for WorkX's single-tab session model, §1.5):**
 
-A workx session binds one tab at a time (`Session.setTabId`, `src/core/Session.ts:1081`), so we don't need Codex's multi-tab finalize protocol yet — but we do need ownership records, guaranteed detach, and stale-state GC. The store schema is multi-tab-ready so multi-tab sessions later only change the callers.
+A WorkX session binds one tab at a time (`Session.setTabId`, `src/core/Session.ts:1081`), so we don't need Codex's multi-tab finalize protocol yet — but we do need ownership records, guaranteed detach, and stale-state GC. The store schema is multi-tab-ready so multi-tab sessions later only change the callers.
 
 1. `TabLeaseStore` (chrome.storage.session): `{ tabId, sessionId, turnId, origin: 'agent'|'user', claimedAt }`. Claim inside `Session.setTabId` (origin `user` when binding an existing tab, `agent` when a tool created it); reject claiming tabs leased to another live session; reject `chrome://`/`chrome-extension://` (we already validate URLs for navigation at `NavigationTool.ts:560+` — extend to claiming).
 2. Per-session `lifecycleQueue` promise chain so claim/release/cleanup don't interleave (Codex `runLifecycle`, bg:6230-6237) — lives next to the lease store, invoked from `Session`.
@@ -293,7 +293,7 @@ Smaller Codex behaviors worth copying:
 
 ## 4. What we already do better (keep, don't regress)
 
-For fairness and to scope the doc: Codex's extension contains **no page-reading intelligence** — no DOM serializer, no a11y-tree fusion, no token-budgeted compaction; all of that lives in their CLI where we can't see it. Things workx should keep:
+For fairness and to scope the doc: Codex's extension contains **no page-reading intelligence** — no DOM serializer, no a11y-tree fusion, no token-budgeted compaction; all of that lives in their CLI where we can't see it. Things WorkX should keep:
 
 - The `DomService` snapshot fusion (DOM tree + per-frame a11y tree + DOMSnapshot paint-order/layout) and the serialization pipeline with filters/simplifiers/compaction metrics — this is the core IP of `browser_dom` v3 and has no counterpart in the Codex extension.
 - The rich `type()` engine (text-anchored `insertAfter/insertBefore/replace/replaceAll`, rich-text editor detection for Quill/Slate/ProseMirror/Lexical, paste-vs-char-by-char strategies, formatting shortcuts) — far beyond `Input.insertText`.
@@ -342,7 +342,7 @@ Phasing: **PR-1** = items 1–3 + 3b. **PR-2** = items 4–6. **PR-3** = 7–8. 
 ## 6. Risks
 
 - **Emulation overrides are user-visible** if the agent operates a tab the user is watching; mitigation in §3.3 (match current CSS viewport, always clear on release; never apply to user-claimed tabs unless a vision flow needs it).
-- **Refcounted detach changes timing** of the Chrome debugger infobar ("workx is debugging this browser") — it will now disappear at turn end rather than lingering; verify the UX and that re-attach latency (~50ms) per turn is acceptable.
+- **Refcounted detach changes timing** of the Chrome debugger infobar ("WorkX is debugging this browser") — it will now disappear at turn end rather than lingering; verify the UX and that re-attach latency (~50ms) per turn is acceptable.
 - **`getContentQuads` migration** changes click coordinates on transformed/inline elements; gate behind a config flag for one release with fallback to `getBoxModel`.
 - **OOPIF attachment** raises the number of debugger targets; Chrome shows one infobar regardless, but cleanup paths must include targets (registry handles via `targetId → tabId` map, mirroring Codex `Fe`).
 

--- a/.ai_design/improve_webtool_from_codex/design.md
+++ b/.ai_design/improve_webtool_from_codex/design.md
@@ -1,0 +1,295 @@
+# Improving workx Web-Operation Tools — Lessons from the OpenAI Codex Chrome Extension
+
+**Status:** Proposed
+**Date:** 2026-06-12
+**Sources analyzed:**
+- OpenAI Codex Chrome extension v1.1.5 (store build, deobfuscated). Line references in this doc point to the prettified bundles (`background.pretty.js` ~7,100 lines, `codex-content.pretty.js` ~1,350 lines) produced with `js-beautify` from `/Users/irichard/Downloads/1.1.5_0/`.
+- workx extension source at HEAD (`37a092dd`).
+
+---
+
+## 1. Executive summary
+
+Codex's extension and ours solve the same problem — letting an LLM agent operate Chrome tabs — with **opposite architectures**:
+
+| | **Codex** | **workx** |
+|---|---|---|
+| Intelligence location | Local CLI process; extension is a thin bridge | Inside the extension (tools, DOM serializer, agent loop) |
+| Transport | Native messaging (`com.openai.codexextension`), JSON-RPC 2.0 | In-process tool calls |
+| Page operation | Raw CDP passthrough — CLI sends arbitrary `{method, params, target}` via `chrome.debugger.sendCommand` (bg:6571) | Structured tools (`browser_dom`, `page_vision`, `browser_navigate`, …) that compose CDP calls in-extension |
+| Page reading | None in extension (CLI drives `DOMSnapshot`/`Page.captureScreenshot` itself over the passthrough) | `DomService` builds VirtualDOM from `DOM.getDocument` + `Accessibility.getFullAXTree` + `DOMSnapshot.captureSnapshot`, serialized for the LLM |
+| Events | All `chrome.debugger.onEvent` CDP events + download state changes pushed to the CLI (bg:6984) | Pull-only; no event push into agent loop |
+
+We should **not** copy the thin-bridge architecture — being self-contained is a workx product feature. But Codex's extension is production-hardened in exactly the layer where we are weakest: **debugger lifecycle, input dispatch correctness, viewport determinism, tab ownership/cleanup, and overlay robustness**. This doc enumerates 10 concrete improvements, each with their implementation details and a ready-to-implement plan for ours.
+
+Priority summary (details in §4):
+
+- **P0 (correctness bugs):** central debugger session registry (§3.1), CDP command timeouts (§3.2), keyboard dispatch key-definition table (§3.4), click option plumbing + `mouseMoved` precursor (§3.4), coordinate-space normalization (§3.3/§3.4).
+- **P1 (capability gaps):** viewport emulation override + agent viewport tool (§3.3), tab lease/turn lifecycle with finalize semantics (§3.6), event-driven page-readiness (§3.8), download tracking (§3.9).
+- **P2 (polish):** overlay self-healing + ping-or-inject (§3.5), OOPIF target attachment (§3.7), favicon badging / tab-group session UX (§3.6), deferred-update reload (§3.10).
+
+---
+
+## 2. How Codex's extension works (reference)
+
+A condensed map, so the per-finding sections below have context.
+
+### 2.1 Transport and command surface
+
+- Connects with `chrome.runtime.connectNative("com.openai.codexextension")` (bg:6638; `.dev`/`.internal` channel variants bg:6964–6966). JSON-RPC 2.0 with request/response correlation; pending requests are rejected when the port closes (`rejectPendingRequests`, bg:4016).
+- Reconnect: 5s timeout constant `kt = 5e3` (bg:6616), plus a redundant `chrome.alarms` ("native-transport-reconnect", bg:6615) so reconnection survives service-worker suspension.
+- Handler registry (bg:5859–5990): `attach`, `attachTarget`, `detach`, `detachTarget`, `getTabs`, `getUserTabs`, `getUserHistory`, `claimUserTab`, `createTab`, `finalizeTabs`, `nameSession`, `moveMouse`, `executeCdp`, `turnEnded`, `getInfo`, plus viewport set/reset tools (bg:3935–3990). Every command carries `session_id` + `turn_id`.
+- Unknown commands throw a typed error via `executeUnhandledCommand` (bg:5895) — explicit capability negotiation also exists (`getInfo` returns `capabilities` + `extensionInstanceId` UUID, bg:5947–5961).
+
+### 2.2 Debugger lifecycle (the part worth stealing)
+
+Global module state (not per-service):
+
+- `se: Set<tabId>` — attached tabs; `Ze: Set<targetId>` + `Fe: Map<targetId, tabId>` — attached child targets (OOPIFs/workers).
+- **Per-resource async locks** `xt(tabId, fn)` / `Ea(targetId, fn)` serialize attach/detach per tab/target so concurrent commands can't race `chrome.debugger.attach`.
+- Attach (`cn`, bg:6239–6252): idempotent — checks `se`, attaches with protocol `"1.3"`, **tolerates "already attached" errors** (`Ma(e)` filter), then immediately applies viewport emulation (`un`, see §2.3), then records in `se`.
+- Detach paths: graceful (`ka`/`Ca`, bg:6290–6310) always clear the registry in `finally`; force-detach (`hn`, bg:6311–6320) clears registry *first* then ignores detach errors — used when a CDP command times out and the session may be wedged.
+- Session-end cleanup `detachAttachedDebuggersBestEffort` (bg:6195–6198) detaches both tab attachments and any child-target attachments whose `Fe` entry maps to the session's tabs, with `Promise.allSettled`.
+- `chrome.debugger.onDetach` listener (bg:5835) reconciles registries when the user cancels the debugger infobar or the tab dies.
+
+### 2.3 CDP passthrough with timeouts
+
+- `La(t)` (bg:6571–6577): special-cases `Target.getTargets` (returns `chrome.debugger.getTargets()`), otherwise `chrome.debugger.sendCommand(target, method, commandParams)` where target is `{targetId}` or `{tabId}`.
+- `En(t)` (bg:6579–6592): wraps every command in `Promise.race` with a timer. Default timeout `an = 1e4` (10s, bg:5830); callers can pass `timeoutMs`. Timeout throws typed `CdpCommandTimeoutError` (bg:6597).
+- `executeCdp` (bg:6052–6060): refuses if tab not in session or not attached ("Debugger unattached"), and **on timeout force-detaches the tab** (`$n(a) && await hn(e)`) so the next attach starts clean.
+
+### 2.4 Viewport determinism
+
+On every tab attach, `un(tabId)` (bg:6253–6266) runs:
+
+```js
+Emulation.setDeviceMetricsOverride({ width, height, deviceScaleFactor: 1, mobile: false })
+```
+
+with a default of **1280x720** (the viewport tool description, bg:3967, says: "otherwise leave it unset so the browser uses its normal 1280x720 viewport"). `deviceScaleFactor: 1` means **screenshot pixels == CSS pixels == input coordinates** — no DPR math anywhere downstream. A dedicated agent tool pair `browser_viewport_set` / `browser_viewport_reset` (bg:3935–3990) handles responsive/breakpoint testing, with explicit instructions to reset overrides before finishing.
+
+### 2.5 Tab leases, turns, and finalize semantics
+
+- `TabLeases` (`Be`, persistent via storage) records per-tab: owning `sessionId`, `turnId`, `origin: "agent" | "user"`. `claimUserTab` rejects `chrome://` tabs (bg:6097–6099) and tabs owned by another session (bg:6101).
+- All session mutations run through `lifecycleQueue` — a per-session promise chain (`runLifecycle`/`runTurnMutation`, bg:6230–6237) so turn transitions, claims, and finalizes can't interleave.
+- `finalizeTabs(turnId, keep[])` (bg:6115–6160) implements end-of-turn semantics with a `keep` map of `tabId -> "handoff" | "deliverable"`:
+  1. badge favicons of deliverable/handoff tabs (`tabFavicons.markFinalized`),
+  2. best-effort detach all debuggers,
+  3. release deliverable tabs from the managed tab group (they stay open for the user),
+  4. **close agent-origin tabs** not kept (`Pn(d)` → `chrome.tabs.remove`),
+  5. untrack overlays, release leases,
+  6. convert "handoff" tabs into handoff leases storing `activeTabId` + `groupId` so the **next turn can resume them** (`resumeHandoffIfPresent`, bg:6166–6193, which also garbage-collects leases whose tab no longer exists).
+- Session tabs live in a named Chrome **tab group** (`ensureAgentTabGroup`; `nameSession` retitles the group, bg:6161–6164). Favicons are badged with an SVG data-URI marker (`data-codex-favicon-badge`, bg:4180–4195) with states `active | deliverable | handoff`.
+- Logical "active tab" is tracked per session and reconciled against real tab state (`resolveLogicalActiveTabId`, bg:6213–6215).
+
+### 2.6 Cursor overlay (content script)
+
+- **Injection:** ping-or-inject. `bt(tabId)` sends `{type:"CONTENT_PING"}` (bg:4148–4155); on no reply, `kr` injects `content-scripts/codex.js` via `chrome.scripting.executeScript({files, injectImmediately: true})` (bg:4166–4178) then re-pings. In-flight injections are deduped through a `Map<tabId, Promise>` (bg:4140–4146). Manifest `content_scripts` is empty; registration metadata says `runAt: "document_start"`, `matchAboutBlank: true` (content:1199–1204).
+- **Mounting:** a `<div id=...>` on `documentElement` with a **closed shadow root**; stylesheet is `.codex-agent-overlay{all:initial;z-index:2147483646;pointer-events:none;position:fixed;inset:0}@media print{...display:none}` (content:1109).
+- **Self-healing:** a `MutationObserver` on `documentElement` (+ parent) `childList` re-mounts the overlay if the page removes it, and detects impostor nodes by a `dataset` marker (content:1152–1190).
+- **Animation:** spring physics per axis (`dampingFraction` presets .82–.94, `response`-based stiffness, content:594–618, 960–980) plus a bezier "motion mode" that picks among 20 candidate curved paths (content:734–743), tilts the cursor (−44°) while moving, and applies a blue glow (`drop-shadow(0 0 6px rgba(51,156,255,.9))…`, content:1026).
+- **Arrival handshake:** `moveMouse` (bg:5897–5930) assigns a monotonically increasing `moveSequence`, the content script reports `AGENT_CURSOR_ARRIVED {sessionId, turnId, moveSequence}` via `chrome.runtime.sendMessage` (bg:7008–7022), and the background resolves a keyed waiter — so the CLI can synchronize "cursor visually arrived" before dispatching the real click. Skipped when the tab isn't observed or `waitForArrival === false`.
+
+### 2.7 Eventing & downloads
+
+- Every `chrome.debugger.onEvent` is forwarded to the CLI as `sendCdpEvent({source, method, params})` (bg:6984–6989) — the CLI gets `Page.lifecycleEvent`, `Network.*`, dialogs, etc. for free.
+- `chrome.downloads.onCreated/onChanged` are tracked into a small state machine and pushed as `{id, filename, url, status: started|completed|...}` change events (bg:5963–5990, 6990–6996) — only while browser control is active.
+- Extension update handling: when an update is pending, reload is **deferred until browser control is inactive** (`maybeReloadForPendingUpdate`, bg:6972) so an in-flight agent turn isn't killed by an extension restart.
+
+---
+
+## 3. Findings: what Codex does better, and what to change in workx
+
+### 3.1 [P0] Centralize debugger attachment — one registry, per-tab locks, refcounts
+
+**Their implementation:** §2.2 — module-global attach sets, per-tab/per-target async mutexes, idempotent attach tolerant of "already attached", `finally`-guaranteed registry cleanup, one global `onDetach` reconciler.
+
+**Our current state:** three uncoordinated attach paths:
+
+- `DomService.forTab()` creates a per-tab `ChromeDebuggerClient` and attaches (`src/extension/tools/dom/DomService.ts:74-93`), cached in `DomService.instances`.
+- `ScreenshotService.forTab()` probes attachment by **executing `Runtime.evaluate('1+1')`** and attaches if it throws (`src/extension/tools/screenshot/ScreenshotService.ts:124-154`). It never detaches.
+- `CoordinateActionService.forTab()` duplicates the same probe/attach (`src/extension/tools/screenshot/CoordinateActionService.ts:215-253`). Also never detaches.
+
+Problems: (a) the `1+1` probe is a race — between probe and attach another service can attach, and "Another debugger is already attached" is then swallowed with a comment saying "this is OK", leaving ambiguous ownership; (b) nobody refcounts, so `DomService.detach()` can yank the connection out from under an in-flight screenshot; (c) each `ChromeDebuggerClient.attach` adds its own `chrome.debugger.onEvent` listener (`src/extension/tools/browser/ChromeDebuggerClient.ts:83`) — N listeners filtering for their tab; (d) no per-tab serialization, so concurrent `forTab` calls can double-attach and one rejects.
+
+**Proposed change:** new `src/extension/tools/browser/DebuggerSessionRegistry.ts`:
+
+```ts
+class DebuggerSessionRegistry {
+  private attachedTabs = new Map<number, { refs: number; enabledDomains: Set<string> }>();
+  private locks = new Map<number, Promise<unknown>>();      // per-tab mutex, Codex xt()
+  private eventSubs = new Map<number, Set<CDPEventCallback>>();
+
+  async withTabLock<T>(tabId: number, fn: () => Promise<T>): Promise<T>;
+  async acquire(tabId: number): Promise<DebuggerHandle>;    // attach if needed, refs++
+  // DebuggerHandle: { sendCommand, onEvent, release() }    // release(): refs--, detach at 0
+}
+```
+
+- Single `chrome.debugger.onEvent` + `onDetach` listener pair registered once; dispatch by `source.tabId`.
+- Attach is idempotent and tolerates "already attached" only when *we* hold the registry entry; otherwise surface the DevTools-conflict error (keep the existing `ALREADY_ATTACHED: DevTools is open` UX from `DomService.forTab`).
+- `onDetach` clears registry state and notifies subscribers (replaces `DomService.handleDebuggerDetach`, `DomService.ts:742-755`).
+- Port `DomService`, `ScreenshotService`, `CoordinateActionService`, and `ExtensionBrowserController` onto `acquire()/release()`; delete both `1+1` probes.
+- Domain enabling moves into the registry (`enabledDomains` per tab) so `Page.enable`/`DOM.enable` aren't re-sent per service.
+
+### 3.2 [P0] Per-command CDP timeouts with force-detach recovery
+
+**Their implementation:** §2.3 — every command raced against 10s default, typed `CdpCommandTimeoutError`, force-detach on timeout so the next command re-attaches cleanly.
+
+**Our current state:** `ChromeDebuggerClient.sendCommand` (`ChromeDebuggerClient.ts:121-140`) has **no timeout**. Only the whole snapshot has one (`config.snapshotTimeout`, `DomService.ts:378-380`). A single wedged command — `Page.captureScreenshot` on a crashed renderer, `Runtime.evaluate` on a hung page, `DOM.getBoxModel` during navigation — hangs the tool call (and the agent turn) indefinitely. `DomService.sendCommandWithRetry` exists (`DomService.ts:719`) but retries can't fire if the first call never resolves.
+
+**Proposed change:**
+
+- In `ChromeDebuggerClient.sendCommand`, wrap in `Promise.race` with `timeoutMs` (new optional param; default 10_000; export `CdpCommandTimeoutError`). Mirror Codex's `Mn()` validation: only positive finite numbers override the default.
+- Per-call overrides where warranted: `Accessibility.getFullAXTree` and `DOMSnapshot.captureSnapshot` get `snapshotTimeout`-derived budgets; `Input.*` keeps a short 5s.
+- On timeout, the `DebuggerSessionRegistry` (§3.1) marks the tab wedged and force-detaches (Codex `hn`): clear registry first, `chrome.debugger.detach` wrapped in try/ignore. Next `acquire()` re-attaches.
+
+### 3.3 [P1] Viewport emulation: `deviceScaleFactor: 1` + agent-facing viewport tool
+
+**Their implementation:** §2.4 — `Emulation.setDeviceMetricsOverride({..., deviceScaleFactor: 1, mobile: false})` applied at attach; 1280x720 default; dedicated `browser_viewport_set/reset` tools for breakpoint testing.
+
+**Our current state:** we fight DPR everywhere instead of normalizing it:
+
+- `DomService.buildSnapshot` reads `window.devicePixelRatio` via `Runtime.evaluate` and divides every DOMSnapshot rect (`DomService.ts:445-461`, `buildLayoutMap` at :765).
+- `Page.captureScreenshot` output is in device pixels (`ScreenshotService.ts:37-41`), so on a 2x display the vision model sees a 2x image while `CoordinateActionService.clickAt` dispatches in CSS pixels — a model that reads coordinates off the screenshot will click at 2x the intended position unless something downstream halves them. There is a `ViewportDetector` (`src/extension/tools/screenshot/ViewportDetector.ts`) but no normalization at capture time.
+- No way for the agent to test responsive layouts.
+
+**Proposed change:**
+
+- New `ViewportOverrideService` invoked from registry attach (opt-in per tool, default on for `page_vision` flows): `Emulation.setDeviceMetricsOverride({ width: <current CSS viewport w>, height: <h>, deviceScaleFactor: 1, mobile: false })`. Restore with `Emulation.clearDeviceMetricsOverride` on release/turn end. Note: unlike Codex we should default width/height to the tab's real CSS viewport (not 1280x720) to avoid visibly resizing the user's page — Codex can afford a fixed size because its tabs live in a dedicated agent group.
+- With DPR forced to 1, delete the `devicePixelRatio` division path in `buildLayoutMap` (keep it as fallback when override fails, e.g. `chrome://` or PDF viewers).
+- Add a `browser_viewport` tool (`set {width}x{height}` / `reset`), copying Codex's prompt language about resetting overrides before finishing (bg:3967).
+
+### 3.4 [P0] Input dispatch correctness (keyboard table, click options, mouseMoved, coordinate space)
+
+**Their implementation:** input synthesis lives CLI-side, but the extension contributes: visual `moveMouse` with arrival handshake *before* the CLI dispatches `Input.*` (§2.6), and DPR-free coordinates (§2.4). The CLI follows the standard CDP automation recipe (same as Playwright/Puppeteer): `mouseMoved` → `mousePressed` → `mouseReleased` with full key definitions.
+
+**Our current state — four concrete defects:**
+
+1. **Wrong `code` for non-letter keys.** Both `DomService.keypress` (`DomService.ts:2680-2691`) and `CoordinateActionService.keypressAt` (`CoordinateActionService.ts:154-167`) compute `code: \`Key${key.toUpperCase()}\`` — producing `KeyENTER`, `KeyTAB`, `KeyARROWDOWN`. Correct values are `Enter`, `Tab`, `ArrowDown`, `KeyA`, `Digit1`, etc. We also never send `windowsVirtualKeyCode`/`nativeVirtualKeyCode`, which many sites (and all `keyCode`-based handlers) need, nor `text` for printable keys, so `keypress` frequently does nothing on real pages.
+2. **Click options silently dropped.** `DOMTool` advertises `options: { button: "left"|"right"|"middle", scrollIntoView }` (`DOMTool.ts:190`), but `executeClick` ignores `options` (`DOMTool.ts:366-375`) and `DomService.click(nodeId)` hardcodes `button: 'left', clickCount: 1` (`DomService.ts:1128-1141`). Right-click/double-click don't exist despite being documented to the model.
+3. **No `mouseMoved` precursor.** We dispatch `mousePressed` directly (`DomService.ts:1128`). Hover-revealed controls (menus, tooltips, row actions) never see `mouseenter`, and some frameworks gate `click` on a prior `mousemove`. Sequence should be `mouseMoved` → `mousePressed` → `mouseReleased`, optionally with the visual cursor animation synchronized (§3.5).
+4. **Coordinate-space ambiguity.** `DomService.click` derives coordinates from `DOM.getBoxModel` content quads and then compares them against `scrollX/scrollY + innerWidth/Height` as if they were *document* coordinates (`DomService.ts:1084-1117`), while `Input.dispatchMouseEvent` expects **viewport CSS coordinates**. `DOM.getBoxModel` returns main-frame viewport-relative quads, so the in-viewport check is wrong on scrolled pages (it compares viewport coords against document bounds — usually accidentally true near the top, wrong after scrolling). Prefer `DOM.getContentQuads` (handles inline/transformed/SVG elements — also fixes the `SVG_CLICK_NOT_SUPPORTED` carve-out at `DomService.ts:1063-1069`) and validate visibility by intersecting quads with `{0,0,innerWidth,innerHeight}`.
+
+**Proposed change:** new shared module `src/extension/tools/input/InputDispatcher.ts`:
+
+- `keyDefinitions.ts`: US-layout table mapping `key` → `{ code, keyCode, key, text?, location? }` (port Puppeteer's `USKeyboardLayout` shape; ~250 entries, MIT-licensed reference). `dispatchKey(handle, key, modifiers)` emits `keyDown` (with `windowsVirtualKeyCode`, `code`, `text` when printable) + `keyUp`. `rawKeyDown` for modifier-only presses.
+- `click(handle, {x, y, button = 'left', clickCount = 1, modifiers})`: `mouseMoved` → `mousePressed` → `mouseReleased`, with `buttons` bitmask set during press.
+- `insertText` fast-path retained for bulk typing (current `typePaste`/`Input.insertText` logic in `DomService.ts:1682` stays).
+- `DomService.click/keypress`, `CoordinateActionService.*`, and `FormAutomationTool` all route through it; `DOMTool.executeClick` forwards `options`.
+- Element targeting switches `DOM.getBoxModel` → `DOM.getContentQuads` with quad-area selection (largest visible quad), viewport intersection check, and `DOM.scrollIntoViewIfNeeded` fallback (existing call at `DomService.ts:1106` kept).
+
+### 3.5 [P2] Overlay robustness: ping-or-inject, self-healing, arrival sync
+
+**Their implementation:** §2.6.
+
+**Our current state:**
+
+- Visual effects are triggered by `Runtime.evaluate` dispatching a `workx:show-visual-effect` CustomEvent (`DomService.ts:971-1008`), which **silently no-ops if the content script never loaded** (CSP-blocked at document_start, pre-existing tabs from before install, `file://` etc.). `ensureVisualEffectsInitialized` is a stub whose entire body is commented out (`DomService.ts:913-956`) — dead code.
+- The Svelte overlay mounts a closed shadow root at z-index 2147483647 (`src/extension/content/content-script.ts:111-122`) — good — but there is **no MutationObserver re-mount**: any page that prunes unknown DOM nodes (several SPAs do on hydration) permanently removes our overlay.
+- Effects are fire-and-forget; the ripple may render after the click already navigated.
+
+**Proposed change:**
+
+- Add `ensureContentScript(tabId)` to the extension platform layer implementing Codex's ping-or-inject: `chrome.tabs.sendMessage(tabId, {type:'WORKX_PING'})` with a short race-timeout (Codex `Oe`, bg:4156-4165) → on failure `chrome.scripting.executeScript({files:[contentScript], injectImmediately:true, target:{tabId}})` → re-ping; dedupe concurrent injections with a `Map<tabId, Promise<boolean>>`. Call it from `DomService.triggerVisualEffect` and delete the dead `ensureVisualEffectsInitialized`.
+- In `content-script.ts`, watch `documentElement` with `MutationObserver({childList:true})` and re-mount the shadow host if disconnected; tag the host with a `dataset` marker to detect/replace impostor nodes (Codex content:1152-1190).
+- Optional (pairs with §3.4): animate cursor to target and await an arrival ack (sequence-numbered `chrome.runtime.sendMessage`, Codex's `AGENT_CURSOR_ARRIVED` protocol, bg:7008-7022) before dispatching `mousePressed`, capped by a ~1.5s timeout so a broken overlay never blocks the action.
+
+### 3.6 [P1] Tab ownership: leases, turn finalization, and user-visible state
+
+**Their implementation:** §2.5 — persistent leases with `agent|user` origin, per-session mutation queue, `finalizeTabs(keep)` with `deliverable`/`handoff` semantics, handoff resume with stale-lease GC, named tab groups, favicon badging.
+
+**Our current state:** `TabManager` (`src/core/TabManager.ts:28-67`) maintains one global "workx" tab group and closure callbacks; there is no ownership record distinguishing agent-created tabs from user tabs the agent borrowed, no turn-end contract (tools just leave tabs open and debuggers attached — `ScreenshotService`/`CoordinateActionService` never detach), and no persistence, so a service-worker restart forgets which tabs were ours.
+
+**Proposed change (incremental, not a full port):**
+
+1. `TabLeaseStore` (chrome.storage.session): `{ tabId, sessionId, turnId, origin: 'agent'|'user', claimedAt }`. Claim on first tool use against a tab; reject claiming tabs leased to another session; reject `chrome://`/`chrome-extension://` (we already validate URLs for navigation at `NavigationTool.ts:560+` — extend to claiming).
+2. Per-session `lifecycleQueue` promise chain in the session object so claim/finalize/cleanup don't interleave (Codex `runLifecycle`, bg:6230-6237).
+3. `finalizeSession(keep?: Record<tabId, 'keep'>)` hook in the agent loop's turn-end: best-effort detach all debuggers for leased tabs (fixes the §3.1 leak even before refcounting lands), close agent-origin tabs not kept, release user-origin leases. Deliverable/handoff distinction can come later; "detach + close agent tabs + release" is the 80%.
+4. Stale-lease GC at session start: drop leases whose `chrome.tabs.get` throws (Codex `resumeHandoffIfPresent`, bg:6166-6193).
+5. UX polish (P2): badge favicons of agent-controlled tabs (SVG data-URI overlay, Codex bg:4180-4195) and name the session tab group from the task title (`nameSession`).
+
+### 3.7 [P2] Cross-origin iframe (OOPIF) support via target attachment
+
+**Their implementation:** `attachTarget`/`detachTarget` attach the debugger to child targets by `{targetId}` (bg:6253-6264), track `targetId → tabId` (`Fe`) for cleanup, and the passthrough addresses commands at `{targetId}` (bg:6574-6576). The CLI can therefore read and operate cross-process iframes.
+
+**Our current state:** `DOM.getDocument({pierce: true})` only pierces same-process iframes; OOPIFs (cross-origin ads, embedded checkout/payment frames, auth widgets) are invisible to snapshots and unreachable by actions. We also cap per-frame a11y fetches at `MAX_IFRAMES = 5` (`DomService.ts:420-443`) and skip iframe depth > 1 entirely (`DomService.ts:479-482`).
+
+**Proposed change:**
+
+- Extend `DebuggerSessionRegistry` with target attachment: enumerate `chrome.debugger.getTargets()`, attach to `type === 'iframe'` targets belonging to the tab, maintain `targetId → tabId` for cleanup (Codex `Fe`).
+- `DomService.buildSnapshot`: for each attached OOPIF target, run the same `DOM.getDocument`/`getFullAXTree`/`DOMSnapshot.captureSnapshot` triple against the target and graft the subtree under the owning `<iframe>` VirtualNode. The existing `frameId:backendNodeId` node-id scheme (`DOMTool.ts:452-478`, `FrameRegistry`) extends naturally: frame index already disambiguates; the frame registry gains a `targetId` column so actions route commands to the right debuggee.
+- Actions: `DomService.click/type` look up the node's frame's `targetId` and send `Input.*`/`DOM.*` to `{targetId}` instead of `{tabId}`. Note `Input.dispatchMouseEvent` coordinates for OOPIFs are relative to the OOPIF's viewport — translate via the iframe element's content quad in the parent frame.
+- Raise/remove `MAX_IFRAMES` with a byte-budget instead of a count cap (serializer already tracks metrics via `CompactionMetrics`).
+
+### 3.8 [P1] Event-driven page readiness (replace polling heuristics)
+
+**Their implementation:** the extension forwards all CDP events to the CLI (§2.7); the CLI uses standard `Page.lifecycleEvent` waiting. Nothing in the extension sleeps or polls.
+
+**Our current state:** two layered heuristics:
+
+- `NavigationTool.waitForTabToLoad` polls `chrome.tabs.get(tabId).status` every 100ms (`NavigationTool.ts:536-552`).
+- `DomService.waitForPageLoad` (`DomService.ts:227-326`) evaluates `document.readyState`, then runs an SPA heuristic loop — counting buttons/links/inputs and `innerText.length`, sniffing `[class*="loading"]` spinners — polling every 1s up to 15s, fail-open. It costs up to 15s on legitimately sparse pages and is fooled by skeleton screens without "loading" class names.
+
+**Proposed change:**
+
+- On attach (registry, §3.1), `Page.setLifecycleEventsEnabled({enabled: true})`. New `PageReadiness` helper subscribes to forwarded events and exposes `waitFor(tabId, {until: 'load'|'DOMContentLoaded'|'networkAlmostIdle'|'networkIdle', timeoutMs})` — `networkAlmostIdle`/`networkIdle` come free with lifecycle events (no `Network.enable` needed).
+- `NavigationTool.navigateToUrl` switches `chrome.tabs.update` + status polling → `Page.navigate` via the registry handle (returns `frameId`/`loaderId` for correlation) + `waitFor('load' | 'networkAlmostIdle')`.
+- `DomService.waitForPageLoad` becomes: `waitFor('networkAlmostIdle', {timeoutMs: 8000})` fail-open, keeping a *single* cheap content check before returning (one `Runtime.evaluate`) instead of the 1s polling loop. Keep the heuristic loop only as fallback when lifecycle events are unavailable.
+- Forward `Page.javascriptDialogOpening` to the agent loop and auto-respond or surface it as a tool result — today a `confirm()` dialog deadlocks any pending CDP evaluate.
+
+### 3.9 [P1] Download tracking
+
+**Their implementation:** §2.7 — `chrome.downloads.onCreated/onChanged` → `{id, filename, url, status}` events pushed to the agent, gated on browser-control-active.
+
+**Our current state:** no download awareness. An agent that clicks "Export CSV" cannot learn whether/where the file landed.
+
+**Proposed change:** `DownloadWatcher` in the background service worker mirroring Codex's state machine (`handleDownloadCreated`/`handleDownloadChanged`, bg:5963-5990): track `id → {filename, url}`, emit `started/completed/interrupted` into the session event bus, expose last-N downloads via a small `browser_downloads` tool action or fold into navigation tool results ("download started: report.csv"). Requires adding the `downloads` permission to `manifest.json`.
+
+### 3.10 [P2] Operational hardening grab-bag
+
+Smaller Codex behaviors worth copying:
+
+- **Deferred update reload** (bg:6972): if `chrome.runtime.onUpdateAvailable` fires mid-session, defer `chrome.runtime.reload()` until no agent session is active. Today an extension update can kill a turn.
+- **Instance identity** (bg:6979-6983): persist an `extensionInstanceId` UUID at install; include it in telemetry/session metadata to disambiguate multiple Chrome profiles.
+- **Typed unsupported-command errors** (bg:5895, `executeUnhandledCommand`): our `DOMTool.validateRequest` returns strings; standardize on typed error codes end-to-end (the `DOMToolErrorCode` enum exists, `DOMTool.ts:60-69`, but `handleError`'s string-sniffing mapper at `DOMTool.ts:514-541` is fragile — set codes at throw sites instead).
+- **Race-timeout helper** (`Oe`, bg:4156-4165): a shared `withTimeout(promise, ms, fallback)` utility instead of ad-hoc `setTimeout` races scattered across services.
+
+---
+
+## 4. What we already do better (keep, don't regress)
+
+For fairness and to scope the doc: Codex's extension contains **no page-reading intelligence** — no DOM serializer, no a11y-tree fusion, no token-budgeted compaction; all of that lives in their CLI where we can't see it. Things workx should keep:
+
+- The `DomService` snapshot fusion (DOM tree + per-frame a11y tree + DOMSnapshot paint-order/layout) and the serialization pipeline with filters/simplifiers/compaction metrics — this is the core IP of `browser_dom` v3 and has no counterpart in the Codex extension.
+- The rich `type()` engine (text-anchored `insertAfter/insertBefore/replace/replaceAll`, rich-text editor detection for Quill/Slate/ProseMirror/Lexical, paste-vs-char-by-char strategies, formatting shortcuts) — far beyond `Input.insertText`.
+- Structured per-tool LLM affordances (observe-act loop guidance, scrollability annotation, viewport filtering) baked into tool descriptions.
+- Self-contained operation: no native host installation, works on any Chrome with just the extension.
+
+---
+
+## 5. Implementation plan
+
+Ordered by dependency; see `tasks.md` for the checklist form.
+
+| # | Work item | Sections | Size | Key files |
+|---|---|---|---|---|
+| 1 | `DebuggerSessionRegistry` (locks, refcounts, single event dispatch, force-detach) | §3.1, §3.2 | M | new `browser/DebuggerSessionRegistry.ts`; rewire `DomService.ts`, `ScreenshotService.ts`, `CoordinateActionService.ts`, `ChromeDebuggerClient.ts` |
+| 2 | CDP command timeouts + `CdpCommandTimeoutError` | §3.2 | S | `ChromeDebuggerClient.ts`, registry |
+| 3 | `InputDispatcher` + key definitions table + click option plumbing + `getContentQuads` targeting | §3.4 | M | new `input/InputDispatcher.ts`, `input/keyDefinitions.ts`; `DomService.ts` click/keypress, `CoordinateActionService.ts`, `DOMTool.ts` |
+| 4 | Viewport override service + `browser_viewport` tool + DPR simplification | §3.3 | M | new `browser/ViewportOverrideService.ts`, new tool, `DomService.buildLayoutMap`, `ScreenshotService.ts` |
+| 5 | Tab leases + turn finalization + stale GC | §3.6 | M | new `core/TabLeaseStore.ts`, `TabManager.ts`, agent session lifecycle |
+| 6 | Lifecycle-event page readiness; rewire navigation + snapshot waiting; dialog handling | §3.8 | M | new `browser/PageReadiness.ts`, `NavigationTool.ts`, `DomService.waitForPageLoad` |
+| 7 | Download watcher + permission | §3.9 | S | new `background/DownloadWatcher.ts`, `manifest.json` |
+| 8 | Overlay ping-or-inject + MutationObserver self-heal (+ optional arrival sync) | §3.5 | S–M | `content-script.ts`, platform adapter, `DomService.triggerVisualEffect` |
+| 9 | OOPIF target attachment + snapshot grafting + per-target input routing | §3.7 | L | registry, `DomService.ts`, `DomSnapshot.ts`, `FrameRegistry` |
+| 10 | Hardening grab-bag (deferred reload, instance id, typed errors, `withTimeout`) | §3.10 | S | service worker, `DOMTool.ts`, utils |
+
+Suggested phasing: **PR-1** = items 1–3 (pure correctness, no tool-surface changes, existing tests must pass; add unit tests for lock/refcount semantics and key table). **PR-2** = items 4–6. **PR-3** = 7–8. **PR-4** = 9 (largest, riskiest). Item 10 can ride along any PR.
+
+## 6. Risks
+
+- **Emulation overrides are user-visible** if the agent operates a tab the user is watching; mitigation in §3.3 (match current CSS viewport, always clear on release; never apply to user-claimed tabs unless a vision flow needs it).
+- **Refcounted detach changes timing** of the Chrome debugger infobar ("workx is debugging this browser") — it will now disappear at turn end rather than lingering; verify the UX and that re-attach latency (~50ms) per turn is acceptable.
+- **`getContentQuads` migration** changes click coordinates on transformed/inline elements; gate behind a config flag for one release with fallback to `getBoxModel`.
+- **OOPIF attachment** raises the number of debugger targets; Chrome shows one infobar regardless, but cleanup paths must include targets (registry handles via `targetId → tabId` map, mirroring Codex `Fe`).

--- a/.ai_design/improve_webtool_from_codex/design.md
+++ b/.ai_design/improve_webtool_from_codex/design.md
@@ -1,7 +1,7 @@
 # Improving WorkX Web-Operation Tools — Lessons from the OpenAI Codex Chrome Extension
 
-**Status:** Reviewed — ready to implement (v2)
-**Date:** 2026-06-12 (v1 analysis; v2 design review same day)
+**Status:** Reviewed — ready to implement (v3)
+**Date:** 2026-06-12 (v1 analysis; v2 design review same day); 2026-06-20 (v3 implementation-readiness corrections)
 **Sources analyzed:**
 - OpenAI Codex Chrome extension v1.1.5 (store build, deobfuscated). Line references in this doc point to the prettified bundles (`background.pretty.js` ~7,100 lines, `codex-content.pretty.js` ~1,350 lines) produced with `js-beautify` from `/Users/irichard/Downloads/1.1.5_0/`.
 - WorkX extension source at HEAD (`37a092dd`).
@@ -45,18 +45,46 @@ Every claim in §3 was re-verified against the code during review. Results, corr
 - **Duplicate service trees:** `src/tools/screenshot/{ScreenshotService,CoordinateActionService}.ts` and `src/tools/PageVisionTool.ts` are near-copies of the `src/extension/tools/*` versions, and `src/tools/PageVisionTool.ts:255-376` calls its own tree's `forTab()` — both trees attach `chrome.debugger` independently. **Decision:** the registry is defined by interface in `src/core/tools/browser/` (next to `DebuggerClient.ts`) with the Chrome implementation in `src/extension/tools/browser/`; both tool trees import the same singleton. Consolidating the duplicated trees is desirable but explicitly out of scope here — PR-1 only repoints both trees' attach calls.
 
 **Integration points pinned (replaces the loose references in v1):**
-- *Tab binding:* a WorkX session binds **one tab at a time** via `Session.setTabId` → `sessionState` (`src/core/Session.ts:1081-1082`, cleared at `:995`); tasks carry `scopedTabIds` and `Session.abortTasksForTab(tabId, reason)` exists (`Session.ts:2310-2313`). The §3.6 lease design is therefore *simpler* than Codex's multi-tab session: lease lifecycle hooks into `setTabId` (claim on bind, release+detach on rebind/clear) and into task completion/abort paths, not into a multi-tab finalize protocol. `finalizeTabs(keep[])`-style multi-tab semantics become relevant only if/when multi-tab sessions ship; the lease store schema below already supports it.
-- *Turn-end hook:* `TurnManager` (`src/core/TurnManager.ts`) runs turns; session cleanup at `Session.ts:995` is where leases/debuggers must be released. DownloadWatcher and dialog events (§3.8/§3.9) surface through the existing session event path used by tool progress (`BaseToolOptions.onProgress`) rather than a new bus.
+- *Tab binding:* a WorkX session binds **one tab at a time** via `Session.setTabId` → `sessionState` (`src/core/Session.ts:1081-1082`, cleared at `:995`); tasks carry `scopedTabIds` and `Session.abortTasksForTab(tabId, reason)` exists (`Session.ts:2310-2313`). The §3.6 lease design is therefore *simpler* than Codex's multi-tab session. **Lease lifecycle hooks into `RepublicAgent.handleTabBinding` (CASES 1/2/3), not the `Session.setTabId` leaf setter** — `setTabId` is synchronous, is bypassed by several bind paths, and runs *after* the tab has already switched, so it cannot `await` a claim or reject a bind (see §1.6 #7). Release+detach hook into the rebind/clear and task completion/abort paths, not a multi-tab finalize protocol. `finalizeTabs(keep[])`-style multi-tab semantics become relevant only if/when multi-tab sessions ship; the lease store schema below already supports it.
+- *Turn-end hook:* `TurnManager` (`src/core/TurnManager.ts`) runs turns; session cleanup at `Session.ts:995` is where leases/debuggers must be released. DownloadWatcher and dialog events (§3.8/§3.9) surface through `Session.emitEvent`/`setEventEmitter` — the session-level background-event bus — **not** `BaseToolOptions.onProgress` (which is scoped to a single tool call and dies when that call returns, so it cannot deliver an async download completion; see §1.6 #9).
 - *Tool registration:* new `browser_viewport` tool registers in `src/extension/tools/registerExtensionTools.ts` alongside `dom_tool` (`:129`) and `page_vision` (`:304`).
 - *Feature gating:* compile-time flags (`vite.featureFlags.mjs`) are deliberately heavyweight (rebuild-only, registry-synced). **Decision:** behavior switches in this work use `ServiceConfig` runtime options instead — `useContentQuads` (default true, `getBoxModel` fallback), `useLifecycleReadiness` (default true, heuristic fallback), `viewportOverride` (default off except `page_vision` flows).
 
 **Scope decisions locked during review:**
-1. Viewport override (§3.3) is **not** applied at every attach (Codex can; their tabs live in a dedicated agent group). It is applied: (a) during `page_vision` screenshot+action turns, and (b) when the agent explicitly calls `browser_viewport set`. It is cleared on tab release and at session unbind. Until §3.3 lands, the immediate P0 fix for the vision DPR bug is one line in `ScreenshotService.captureViewport`: read DPR once and downscale the PNG to CSS pixels (or set `clip: {x:0,y:0,width,height,scale:1/dpr}` on `Page.captureScreenshot`) — ship this in PR-1 with the input fixes.
+1. Viewport override (§3.3) is **not** applied at every attach (Codex can; their tabs live in a dedicated agent group). It is applied: (a) during `page_vision` screenshot+action turns, and (b) when the agent explicitly calls `browser_viewport set`. It is cleared on tab release and at session unbind. Until §3.3 lands, the immediate P0 fix for the vision DPR bug is one change in `ScreenshotService.captureViewport`: read `devicePixelRatio` at capture time and **downscale the captured PNG to `innerWidth × innerHeight` CSS pixels** — ship this in PR-1 with the input fixes. (Do **not** use `Page.captureScreenshot` `clip.scale = 1/dpr`: `clip.scale` is the page-scale factor, not a DPR override, and is version-dependent and lossy on fractional DPR — see §1.6 #1.)
 2. Cursor arrival handshake (§3.5 optional part) is deferred indefinitely — we don't animate a cursor before clicks today, so there is nothing to synchronize. Ping-or-inject + self-healing overlay stay in PR-3.
 3. OOPIF (§3.7) stays last (PR-4) and starts with **read-only** support (snapshot grafting); per-target input routing ships only after snapshot support proves stable in dogfood.
 4. The 10 findings hold after review; no Codex behavior examined was found *worse* than ours in a way that changes the recommendations.
 
 **Acceptance criteria per PR** are added to §5 and mirrored in `tasks.md`.
+
+---
+
+## 1.6 v3 corrections (implementation-readiness pass)
+
+A second verification pass (2026-06-20) cross-checked every proposed *solution* — not just the bugs — against the code at HEAD and against CDP semantics. The diagnoses all held (including the subtle coordinate-space one in §3.4); the corrections below are folded into §3/§5/§7 and are **binding** where they conflict with older prose.
+
+1. **DPR hotfix — drop the `clip.scale = 1/dpr` option.** `Page.captureScreenshot`'s `clip.scale` is the *page-scale* factor, not a `deviceScaleFactor` override; in the current `captureBeyondViewport:false` capture mode its interaction with device DPR is Chrome-version-dependent and lossy on fractional DPR (1.25/1.5/1.75). The hotfix is **downscale the captured PNG to `innerWidth × innerHeight`**, reading `devicePixelRatio` at capture time. The structural fix is unchanged: `Emulation.setDeviceMetricsOverride({deviceScaleFactor:1})`. (§3.3, item 3b, T08)
+
+2. **Registry concurrency contract pinned.** `forceDetach` MUST run inside `withTabLock` and reset the tab entry (refcount → 0, `enabledDomains` cleared) so a concurrent `acquire` re-attaches cleanly instead of reusing a dying client; stale handles' `release()` become no-ops. The per-tab mutex MUST chain with `.catch`/`.finally` so a rejected operation cannot poison the lock. A single command timeout force-detaches the *shared* tab and therefore collaterally fails every concurrent command on it — acceptable, but call it out (consider gating force-detach on an actual wedged check rather than firing on every timeout). The single `onEvent`/`onDetach` listener pair also fixes a real listener *leak*, not just N-listener overhead. (§3.1, §3.2, §7.1)
+
+3. **`page_vision` acquires once per action, not per service.** `Screenshot`/`Coordinate` services are constructed per call, so the migration must `acquire(tabId)` once at the start of a vision action and `release()` at the end (passing one handle to both services) — otherwise the refcount churns attach→detach *between* the screenshot and the click. (§7.1, T03)
+
+4. **Keyboard table — shifted chars and keypad.** Capital/shifted characters (`A`, `!`) must set the Shift modifier bit and use the table's `shiftKey`/`shiftKeyCode`; keypad keys must forward `location`. (§3.4, §7.2, T04)
+
+5. **Mouse `buttons` bookkeeping.** `mouseReleased` clears the released button from the `buttons` bitmask (`buttons:0` for a simple click release); the `mouseMoved` precursor uses `button:'none'`, `buttons:0`. Double-click = two press/release pairs (`clickCount` 1 then 2); right-click sets `button:'right'` + `buttons:2`. Note `ClickOptions` exposes `clickType:'single'|'double'` (not `clickCount`) — map at the boundary. (§3.4, §7.2, T05/T06)
+
+6. **Coordinate fix clicks the clipped point.** Intersect the content quad with `{0,0,innerWidth,innerHeight}` and dispatch at the *intersection's* center, not the whole quad's center (matters for partially-scrolled elements). Transformed/rotated quads and active pinch-zoom remain edge cases — kept behind the `useContentQuads` flag with `getBoxModel` fallback. (§3.4)
+
+7. **Tab-lease hook moves to `RepublicAgent.handleTabBinding`, not `Session.setTabId`.** `setTabId` is a synchronous leaf setter that several bind paths bypass and that runs *after* the tab switch — it cannot `await` a claim or reject a bind. Claim/release belong in `handleTabBinding` (`src/core/RepublicAgent.ts`, CASES 1/2/3). GC and live claims must share the per-session `lifecycleQueue` to avoid a startup-GC-vs-claim race. Agent-origin tabs are auto-closed on release **only while still unfocused/inactive** — never close a tab the user has since focused (the deliverable/handoff semantics that would generalize this stay deferred). Reuse the blocked-scheme list from `NavigationTool.validateAndNormalizeUrl` by *extracting/sharing* it (it is a private instance method on `NavigationTool` today), not by reaching into it. (§3.6, §7.4, T12)
+
+8. **Page-readiness prerequisites.** `Page.enable` is required before `Page.setLifecycleEventsEnabled` and before `Page.javascriptDialogOpening` fires (§7.3 already states this; §3.8 prose now does too). `NavigationTool` attaches **no** debugger today, so switching to `Page.navigate` adds an attach + a debugger infobar to a previously un-debugged tab — a real UX cost; keep `chrome.tabs.update`+poll as the no-debugger fallback. Specify the dialog auto-response default (dismiss / `false` unless a tool opts in). (§3.8)
+
+9. **Downloads.** The `downloads` permission is **already present** in `manifest.json` (added 2025-11) — no manifest change. Download/dialog events MUST surface via `Session.emitEvent`/`setEventEmitter` (the session-level background-event bus), **not** `BaseToolOptions.onProgress`, which lives only for the duration of one tool call and cannot receive an async download completion that arrives after the click tool already returned. (§1.5, §3.9, T19)
+
+10. **OOPIF (§3.7) is a substantial rewrite, not a natural extension** — kept last, read-only first. The node-id scheme does *not* extend cleanly: `frameId` is a synthetic 0–5 index unrelated to CDP `targetId`, and `backendNodeId`s collide across targets. `ChromeDebuggerClient.sendCommand` currently hard-rejects any non-`tabId` target, so target-addressed sends need a new routing path first. Mouse input is dispatched to the **page** session with translated coordinates, not to `{targetId}`. One-shot `getTargets()` races late-loading OOPIFs — prefer `Target.setAutoAttach({flatten:true})`. (`FrameRegistry` lives in `DomSnapshot.ts`, not `DOMTool.ts`.) (§3.7, T22–T24)
+
+Minor drift corrected throughout: WorkX's content script is statically registered (`run_at:"document_idle"`, `all_frames:false`), not Codex's empty-`content_scripts`/`document_start` model; the overlay host mounts on `document.body` (not `documentElement`); ping-or-inject idempotency is already provided by the `window.__workx_content_script_loaded__` guard.
 
 ---
 
@@ -160,8 +188,10 @@ class DebuggerSessionRegistry {
 - Single `chrome.debugger.onEvent` + `onDetach` listener pair registered once; dispatch by `source.tabId`.
 - Attach is idempotent and tolerates "already attached" only when *we* hold the registry entry; otherwise surface the DevTools-conflict error (keep the existing `ALREADY_ATTACHED: DevTools is open` UX from `DomService.forTab`).
 - `onDetach` clears registry state and notifies subscribers (replaces `DomService.handleDebuggerDetach`, `DomService.ts:742-755`).
-- Port `DomService`, `ScreenshotService`, `CoordinateActionService`, and `ExtensionBrowserController` onto `acquire()/release()`; delete both `1+1` probes.
-- Domain enabling moves into the registry (`enabledDomains` per tab) so `Page.enable`/`DOM.enable` aren't re-sent per service.
+- Port `DomService`, `ScreenshotService`, `CoordinateActionService`, and `ExtensionBrowserController` onto `acquire()/release()`; delete both `1+1` probes. **`page_vision` acquires once per action and releases at the end** (one handle shared by both services), since those services are constructed per call — otherwise the refcount churns attach→detach between screenshot and click (§1.6 #3).
+- Domain enabling moves into the registry (`enabledDomains` per tab) so `Page.enable`/`DOM.enable` aren't re-sent per service. The registry MUST clear `enabledDomains` on every detach path (including `forceDetach`/`onDetach`) or a re-attach silently runs with no domains enabled.
+
+**Concurrency contract (pinned, §1.6 #2):** `acquire`, `release`, and `forceDetach` all run inside `withTabLock`. `forceDetach` resets the tab entry (refcount → 0, `enabledDomains` cleared) so a concurrent `acquire` re-attaches a clean client rather than reusing a dying one; stale handles' `release()` then no-op. Implement the per-tab mutex as a promise chain built with `.catch`/`.finally` so a rejected operation can't poison the lock for subsequent waiters. The consolidated single `onEvent`/`onDetach` pair also removes a current listener *leak* (today `DomService` adds a global `onDetach` listener per instance that the `handleDebuggerDetach` path never removes), not just N-listener overhead.
 
 ### 3.2 [P0] Per-command CDP timeouts with force-detach recovery
 
@@ -173,7 +203,8 @@ class DebuggerSessionRegistry {
 
 - In `ChromeDebuggerClient.sendCommand`, wrap in `Promise.race` with `timeoutMs` (new optional param; default 10_000; export `CdpCommandTimeoutError`). Mirror Codex's `Mn()` validation: only positive finite numbers override the default.
 - Per-call overrides where warranted: `Accessibility.getFullAXTree` and `DOMSnapshot.captureSnapshot` get `snapshotTimeout`-derived budgets; `Input.*` keeps a short 5s.
-- On timeout, the `DebuggerSessionRegistry` (§3.1) marks the tab wedged and force-detaches (Codex `hn`): clear registry first, `chrome.debugger.detach` wrapped in try/ignore. Next `acquire()` re-attaches.
+- On timeout, the `DebuggerSessionRegistry` (§3.1) marks the tab wedged and force-detaches (Codex `hn`): under `withTabLock`, clear registry first, then `chrome.debugger.detach` wrapped in try/ignore. Next `acquire()` re-attaches.
+- **Blast radius (note, §1.6 #2):** force-detaching the shared tab abandons *all* in-flight commands on it, so one slow `Accessibility.getFullAXTree` timing out will also fail a concurrent `Page.captureScreenshot` from `page_vision`. This is acceptable, but document it — and consider gating force-detach on an actual wedged check (Codex's `$n(a)`) rather than firing on every timeout. The late `chrome.debugger.sendCommand` callback that fires *after* the race lost is harmless: a JS Promise can't settle twice, so it's a silent no-op; force-detach is what neutralizes the stale in-flight CDP op (which CDP itself cannot cancel).
 
 ### 3.3 [P1] Viewport emulation: `deviceScaleFactor: 1` + agent-facing viewport tool
 
@@ -182,7 +213,7 @@ class DebuggerSessionRegistry {
 **Our current state:** we fight DPR everywhere instead of normalizing it:
 
 - `DomService.buildSnapshot` reads `window.devicePixelRatio` via `Runtime.evaluate` and divides every DOMSnapshot rect (`DomService.ts:445-461`, `buildLayoutMap` at :765).
-- `Page.captureScreenshot` output is in device pixels (`ScreenshotService.ts:37-41`), so on a 2x display the vision model sees a 2x image while `CoordinateActionService.clickAt` dispatches in CSS pixels. **Confirmed active bug, not a risk** (see §1.5): the `page_vision` prompt explicitly tells the model to provide image-pixel coordinates (`PageVisionTool.ts:75-83`), which are dispatched unscaled (`PageVisionTool.ts:293-296`) — on DPR>1 displays every vision-driven click lands at DPR× the intended position, and the bounds-clipping at `PageVisionTool.ts:393` masks it. Immediate fix ships in PR-1 (capture at `scale: 1/dpr` via the `clip` param, or downscale the PNG); the emulation override below is the structural fix. There is a `ViewportDetector` (`src/extension/tools/screenshot/ViewportDetector.ts`) but no normalization at capture time.
+- `Page.captureScreenshot` output is in device pixels (`ScreenshotService.ts:37-41`), so on a 2x display the vision model sees a 2x image while `CoordinateActionService.clickAt` dispatches in CSS pixels. **Confirmed active bug, not a risk** (see §1.5): the `page_vision` prompt explicitly tells the model to provide image-pixel coordinates (`PageVisionTool.ts:75-83`), which are dispatched unscaled (`PageVisionTool.ts:293-296`) — on DPR>1 displays every vision-driven click lands at DPR× the intended position, and the bounds-clipping at `PageVisionTool.ts:393` masks it. Immediate fix ships in PR-1 (**downscale the captured PNG to `innerWidth × innerHeight`**, reading `devicePixelRatio` at capture time — *not* `clip.scale = 1/dpr`, see §1.6 #1); the emulation override below is the structural fix. There is a `ViewportDetector` (`src/extension/tools/screenshot/ViewportDetector.ts`) but no normalization at capture time.
 - No way for the agent to test responsive layouts.
 
 **Proposed change:**
@@ -204,11 +235,11 @@ class DebuggerSessionRegistry {
 
 **Proposed change:** new shared module `src/extension/tools/input/InputDispatcher.ts`:
 
-- `keyDefinitions.ts`: US-layout table mapping `key` → `{ code, keyCode, key, text?, location? }` (port Puppeteer's `USKeyboardLayout` shape; ~250 entries, MIT-licensed reference). `dispatchKey(handle, key, modifiers)` emits `keyDown` (with `windowsVirtualKeyCode`, `code`, `text` when printable) + `keyUp`. `rawKeyDown` for modifier-only presses.
-- `click(handle, {x, y, button = 'left', clickCount = 1, modifiers})`: `mouseMoved` → `mousePressed` → `mouseReleased`, with `buttons` bitmask set during press.
+- `keyDefinitions.ts`: US-layout table mapping `key` → `{ code, keyCode, key, text?, shiftKey?, shiftKeyCode?, location? }` (port Puppeteer's `USKeyboardLayout` shape; ~250 entries, MIT-licensed reference). `dispatchKey(handle, key, modifiers)` emits `keyDown` (with `windowsVirtualKeyCode`, `code`, `text` when printable) + `keyUp`. `rawKeyDown` for modifier-only presses. **Shifted/capital characters** (`A`, `!`) must set the Shift modifier bit and use the table's `shiftKey`/`shiftKeyCode`; **keypad keys** must forward `location` (§1.6 #4).
+- `click(handle, {x, y, button = 'left', clickCount = 1, modifiers})`: `mouseMoved` → `mousePressed` → `mouseReleased`. `mouseMoved` uses `button:'none'`, `buttons:0`; `mousePressed` sets the button's bit in `buttons`; **`mouseReleased` clears it (`buttons:0` for a simple click)**. Double-click = two press/release pairs with `clickCount` 1 then 2; right-click sets `button:'right'` + `buttons:2` (§1.6 #5).
 - `insertText` fast-path retained for bulk typing (current `typePaste`/`Input.insertText` logic in `DomService.ts:1682` stays).
 - `DomService.click/keypress`, `CoordinateActionService.*`, and `FormAutomationTool` all route through it; `DOMTool.executeClick` forwards `options`.
-- Element targeting switches `DOM.getBoxModel` → `DOM.getContentQuads` with quad-area selection (largest visible quad), viewport intersection check, and `DOM.scrollIntoViewIfNeeded` fallback (existing call at `DomService.ts:1106` kept).
+- Element targeting switches `DOM.getBoxModel` → `DOM.getContentQuads` with quad-area selection (largest visible quad), viewport intersection check, and `DOM.scrollIntoViewIfNeeded` fallback (existing call at `DomService.ts:1106` kept). **Dispatch at the center of the quad∩viewport *intersection*, not the whole quad's center** — otherwise a partially-scrolled element clicks an off-screen point (§1.6 #6). Rotated/transformed quads (non-axis-aligned) and active pinch-zoom (`window.innerWidth` ≠ visual viewport) remain edge cases; the `useContentQuads` flag keeps `getBoxModel` as a fallback for one release. Note this fix is consistent with §3.3's `deviceScaleFactor:1` only when no visual-viewport scale is in play — implement them together.
 
 ### 3.5 [P2] Overlay robustness: ping-or-inject, self-healing, arrival sync
 
@@ -217,13 +248,13 @@ class DebuggerSessionRegistry {
 **Our current state:**
 
 - Visual effects are triggered by `Runtime.evaluate` dispatching a `workx:show-visual-effect` CustomEvent (`DomService.ts:971-1008`), which **silently no-ops if the content script never loaded** (CSP-blocked at document_start, pre-existing tabs from before install, `file://` etc.). `ensureVisualEffectsInitialized` is a stub whose entire body is commented out (`DomService.ts:913-956`) — dead code.
-- The Svelte overlay mounts a closed shadow root at z-index 2147483647 (`src/extension/content/content-script.ts:111-122`) — good — but there is **no MutationObserver re-mount**: any page that prunes unknown DOM nodes (several SPAs do on hydration) permanently removes our overlay.
+- The Svelte overlay mounts a closed shadow-root host on **`document.body`** (`src/extension/content/content-script.ts:126`) at z-index 2147483647 — good — but there is **no MutationObserver re-mount**: any page that prunes unknown DOM nodes (several SPAs do on hydration) permanently removes our overlay. (Idempotency on re-injection is already handled by the `window.__workx_content_script_loaded__` guard and the existing `#workx-visual-effects-host` dedupe, so ping-or-inject below is safe to call repeatedly.)
 - Effects are fire-and-forget; the ripple may render after the click already navigated.
 
 **Proposed change:**
 
 - Add `ensureContentScript(tabId)` to the extension platform layer implementing Codex's ping-or-inject: `chrome.tabs.sendMessage(tabId, {type:'WORKX_PING'})` with a short race-timeout (Codex `Oe`, bg:4156-4165) → on failure `chrome.scripting.executeScript({files:[contentScript], injectImmediately:true, target:{tabId}})` → re-ping; dedupe concurrent injections with a `Map<tabId, Promise<boolean>>`. Call it from `DomService.triggerVisualEffect` and delete the dead `ensureVisualEffectsInitialized`.
-- In `content-script.ts`, watch `documentElement` with `MutationObserver({childList:true})` and re-mount the shadow host if disconnected; tag the host with a `dataset` marker to detect/replace impostor nodes (Codex content:1152-1190).
+- In `content-script.ts`, watch the host's parent (`document.body`, where the host actually mounts — or `documentElement` with `subtree:true`) with `MutationObserver({childList:true})` and re-mount the shadow host if `!host.isConnected`; tag the host with a `dataset` marker to detect/replace impostor nodes (Codex content:1152-1190). **Guard against re-entrancy:** the re-mount is itself a `childList` mutation, so check `host.isConnected` before re-appending (or disconnect the observer around the re-append) to avoid a tight loop.
 - Optional (pairs with §3.4): animate cursor to target and await an arrival ack (sequence-numbered `chrome.runtime.sendMessage`, Codex's `AGENT_CURSOR_ARRIVED` protocol, bg:7008-7022) before dispatching `mousePressed`, capped by a ~1.5s timeout so a broken overlay never blocks the action.
 
 ### 3.6 [P1] Tab ownership: leases, turn finalization, and user-visible state
@@ -234,12 +265,12 @@ class DebuggerSessionRegistry {
 
 **Proposed change (incremental, not a full port — adjusted in review for WorkX's single-tab session model, §1.5):**
 
-A WorkX session binds one tab at a time (`Session.setTabId`, `src/core/Session.ts:1081`), so we don't need Codex's multi-tab finalize protocol yet — but we do need ownership records, guaranteed detach, and stale-state GC. The store schema is multi-tab-ready so multi-tab sessions later only change the callers.
+A WorkX session binds one tab at a time, so we don't need Codex's multi-tab finalize protocol yet — but we do need ownership records, guaranteed detach, and stale-state GC. The store schema is multi-tab-ready so multi-tab sessions later only change the callers.
 
-1. `TabLeaseStore` (chrome.storage.session): `{ tabId, sessionId, turnId, origin: 'agent'|'user', claimedAt }`. Claim inside `Session.setTabId` (origin `user` when binding an existing tab, `agent` when a tool created it); reject claiming tabs leased to another live session; reject `chrome://`/`chrome-extension://` (we already validate URLs for navigation at `NavigationTool.ts:560+` — extend to claiming).
-2. Per-session `lifecycleQueue` promise chain so claim/release/cleanup don't interleave (Codex `runLifecycle`, bg:6230-6237) — lives next to the lease store, invoked from `Session`.
-3. Release hooks: `Session.setTabId(-1)` / session cleanup (`Session.ts:995`) and `abortTasksForTab` (`Session.ts:2310`) release the lease and best-effort detach the tab's debugger via the registry (fixes the §3.1 leak even before refcounting lands). Agent-origin tabs are closed on release unless the turn result marked them as deliverables; user-origin tabs are always left open.
-4. Stale-lease GC at service-worker start and session start: drop leases whose `chrome.tabs.get` throws (Codex `resumeHandoffIfPresent`, bg:6166-6193) — this is what makes leases safe across MV3 service-worker restarts.
+1. `TabLeaseStore` (chrome.storage.session): `{ tabId, sessionId, turnId, origin: 'agent'|'user', claimedAt }`. Claim inside **`RepublicAgent.handleTabBinding` (CASES 1/2/3), not the `Session.setTabId` leaf setter** (§1.6 #7 — `setTabId` is sync, bypassed, and runs after the tab switch, so it can't `await` a claim or reject a bind): origin `user` when binding an existing tab, `agent` when a tool created it; reject claiming tabs leased to another live session; reject `chrome://`/`chrome-extension://`. Reuse the blocked-scheme list from `NavigationTool.validateAndNormalizeUrl` (a private instance method today) by **extracting it into a shared helper** — don't reach into `NavigationTool`.
+2. Per-session `lifecycleQueue` promise chain so claim/release/cleanup don't interleave (Codex `runLifecycle`, bg:6230-6237) — lives next to the lease store, invoked from `RepublicAgent`/`Session`. **The startup `gcStale()` (item 4) must run through this same queue** so a sweep can't drop a lease that an in-flight claim is concurrently writing.
+3. Release hooks: session cleanup (`Session.ts:995`) and `abortTasksForTab` (`Session.ts:2310`) release the lease and best-effort detach the tab's debugger via the registry (fixes the §3.1 leak even before refcounting lands). Agent-origin tabs are closed on release **only while still inactive/unfocused** — re-check the tab's focused/active state at release time and never close a tab the user has since adopted and is viewing (origin is fixed at claim time, so it alone is not sufficient; the deliverable/handoff semantics that would generalize this are deferred, §3.6.6). User-origin tabs are always left open.
+4. Stale-lease GC at service-worker start and session start: drop leases whose `chrome.tabs.get` throws (Codex `resumeHandoffIfPresent`, bg:6166-6193) — this is what makes leases safe across MV3 service-worker restarts. Runs under the `lifecycleQueue` (see item 2).
 5. UX polish (P2): badge favicons of agent-controlled tabs (SVG data-URI overlay, Codex bg:4180-4195) and name the existing `TabManager` "workx" tab group from the task title (`nameSession`).
 6. Deferred until multi-tab sessions exist: `finalizeTabs(keep[])` deliverable/handoff semantics and handoff-resume across turns.
 
@@ -252,8 +283,9 @@ A WorkX session binds one tab at a time (`Session.setTabId`, `src/core/Session.t
 **Proposed change:**
 
 - Extend `DebuggerSessionRegistry` with target attachment: enumerate `chrome.debugger.getTargets()`, attach to `type === 'iframe'` targets belonging to the tab, maintain `targetId → tabId` for cleanup (Codex `Fe`).
-- `DomService.buildSnapshot`: for each attached OOPIF target, run the same `DOM.getDocument`/`getFullAXTree`/`DOMSnapshot.captureSnapshot` triple against the target and graft the subtree under the owning `<iframe>` VirtualNode. The existing `frameId:backendNodeId` node-id scheme (`DOMTool.ts:452-478`, `FrameRegistry`) extends naturally: frame index already disambiguates; the frame registry gains a `targetId` column so actions route commands to the right debuggee.
-- Actions: `DomService.click/type` look up the node's frame's `targetId` and send `Input.*`/`DOM.*` to `{targetId}` instead of `{tabId}`. Note `Input.dispatchMouseEvent` coordinates for OOPIFs are relative to the OOPIF's viewport — translate via the iframe element's content quad in the parent frame.
+- `DomService.buildSnapshot`: for each attached OOPIF target, run the same `DOM.getDocument`/`getFullAXTree`/`DOMSnapshot.captureSnapshot` triple against the target and graft the subtree under the owning `<iframe>` VirtualNode. **This is not a "natural extension" of the node-id scheme (§1.6 #10) — it is a substantial cross-cutting change.** `frameId` in the `frameId:backendNodeId` id is a *synthetic 0–5 index* (`FrameRegistry` in `DomSnapshot.ts`, capped at 5) with no relation to CDP `targetId`, and `backendNodeId`s are unique only *per target*, so they collide across OOPIFs. The frame registry must gain a real `targetId` column, and every `DOM.getBoxModel`/`scrollIntoViewIfNeeded`/`Input.*` call site (4+ in `DomService`) must become target-aware. Prerequisite: `ChromeDebuggerClient.sendCommand` currently *hard-rejects* any non-`tabId` target — a target-addressed send path must land first.
+- Discovery: prefer `Target.setAutoAttach({autoAttach:true, waitForDebuggerOnStart:false, flatten:true})` + `Target.attachedToTarget` events over a one-shot `getTargets()` enumeration, which races OOPIFs that finish loading after the snapshot (silently missing subtree).
+- Actions: input is dispatched to the **page session** using main-frame coordinates = (iframe content-quad offset in the parent) + (element offset within the OOPIF), **not** `Input.*` sent to `{targetId}` (that targets the wrong session and mis-places clicks). DOM/AX *reads* are per-target; mouse *input* is page-session with translated coordinates. Account for nested-iframe scroll, iframe CSS `transform`, and pinch-zoom (`Page.getLayoutMetrics.visualViewport`) when translating.
 - Raise/remove `MAX_IFRAMES` with a byte-budget instead of a count cap (serializer already tracks metrics via `CompactionMetrics`).
 
 ### 3.8 [P1] Event-driven page readiness (replace polling heuristics)
@@ -267,10 +299,10 @@ A WorkX session binds one tab at a time (`Session.setTabId`, `src/core/Session.t
 
 **Proposed change:**
 
-- On attach (registry, §3.1), `Page.setLifecycleEventsEnabled({enabled: true})`. New `PageReadiness` helper subscribes to forwarded events and exposes `waitFor(tabId, {until: 'load'|'DOMContentLoaded'|'networkAlmostIdle'|'networkIdle', timeoutMs})` — `networkAlmostIdle`/`networkIdle` come free with lifecycle events (no `Network.enable` needed).
-- `NavigationTool.navigateToUrl` switches `chrome.tabs.update` + status polling → `Page.navigate` via the registry handle (returns `frameId`/`loaderId` for correlation) + `waitFor('load' | 'networkAlmostIdle')`.
+- On attach (registry, §3.1), `Page.enable` **then** `Page.setLifecycleEventsEnabled({enabled: true})` (the latter requires the Page domain enabled). New `PageReadiness` helper subscribes to forwarded events and exposes `waitFor(tabId, {until: 'load'|'DOMContentLoaded'|'networkAlmostIdle'|'networkIdle', timeoutMs})` — `networkAlmostIdle`/`networkIdle` are *lifecycle* signals that come free with lifecycle events (no `Network.enable` needed; only raw `Network.*` domain events would require it).
+- `NavigationTool.navigateToUrl` switches `chrome.tabs.update` + status polling → `Page.navigate` via the registry handle (returns `frameId`/`loaderId` for correlation) + `waitFor('load' | 'networkAlmostIdle')`. **Cost to weigh (§1.6 #8):** `NavigationTool` attaches no debugger today, so `Page.navigate` newly attaches one (and shows the debugger infobar) just to navigate. Keep `chrome.tabs.update` + the readiness wait as a no-debugger fallback; an existing `Page.navigate` path lives in `ExtensionBrowserController` for reference.
 - `DomService.waitForPageLoad` becomes: `waitFor('networkAlmostIdle', {timeoutMs: 8000})` fail-open, keeping a *single* cheap content check before returning (one `Runtime.evaluate`) instead of the 1s polling loop. Keep the heuristic loop only as fallback when lifecycle events are unavailable.
-- Forward `Page.javascriptDialogOpening` to the agent loop and auto-respond or surface it as a tool result — today a `confirm()` dialog deadlocks any pending CDP evaluate.
+- Forward `Page.javascriptDialogOpening` (fires once `Page.enable` is on) to the agent loop and respond via `Page.handleJavaScriptDialog` — today a `confirm()` dialog deadlocks any pending CDP evaluate. Specify the default: auto-dismiss (`accept: false`) unless a tool opts into accepting, since the chosen response becomes the page's `confirm()`/`alert()` return value.
 
 ### 3.9 [P1] Download tracking
 
@@ -278,7 +310,7 @@ A WorkX session binds one tab at a time (`Session.setTabId`, `src/core/Session.t
 
 **Our current state:** no download awareness. An agent that clicks "Export CSV" cannot learn whether/where the file landed.
 
-**Proposed change:** `DownloadWatcher` in the background service worker mirroring Codex's state machine (`handleDownloadCreated`/`handleDownloadChanged`, bg:5963-5990): track `id → {filename, url}`, emit `started/completed/interrupted` into the session event bus, expose last-N downloads via a small `browser_downloads` tool action or fold into navigation tool results ("download started: report.csv"). Requires adding the `downloads` permission to `manifest.json`.
+**Proposed change:** `DownloadWatcher` in the background service worker mirroring Codex's state machine (`handleDownloadCreated`/`handleDownloadChanged`, bg:5963-5990): track `id → {filename, url}`, emit `started/completed/interrupted` via **`Session.emitEvent`** — the session-level background-event bus — **not** `BaseToolOptions.onProgress` (§1.6 #9: `onProgress` is scoped to a single tool call and is already gone by the time an async download completes). Expose last-N downloads via a small `browser_downloads` tool action or fold into navigation tool results ("download started: report.csv"). The `downloads` permission is **already present** in `manifest.json` (added 2025-11) — no manifest change needed.
 
 ### 3.10 [P2] Operational hardening grab-bag
 
@@ -311,11 +343,11 @@ Ordered by dependency; see `tasks.md` for the checklist form.
 | 1 | `DebuggerSessionRegistry` (locks, refcounts, single event dispatch, force-detach); deprecate `ExtensionBrowserController` | §3.1, §3.2, §1.5 | M | new `core/tools/browser/DebuggerSessionRegistry.ts` (interface) + `extension/tools/browser/ChromeDebuggerSessionRegistry.ts` (impl); rewire `DomService.ts`, both `ScreenshotService.ts` / `CoordinateActionService.ts` trees, `ChromeDebuggerClient.ts` |
 | 2 | CDP command timeouts + `CdpCommandTimeoutError` | §3.2 | S | `ChromeDebuggerClient.ts`, registry |
 | 3 | `InputDispatcher` + key definitions table + click option plumbing + `getContentQuads` targeting (`useContentQuads` config, fallback `getBoxModel`) | §3.4 | M | new `input/InputDispatcher.ts`, `input/keyDefinitions.ts`; `DomService.ts` click/keypress, `CoordinateActionService.ts`, `DOMTool.ts` |
-| 3b | **Vision DPR hotfix**: capture screenshots at CSS-pixel scale (`Page.captureScreenshot` `clip.scale = 1/dpr`) | §3.3, §1.5 | XS | `ScreenshotService.ts` (both trees) |
+| 3b | **Vision DPR hotfix**: downscale the captured PNG to `innerWidth × innerHeight` CSS pixels (read `devicePixelRatio` at capture time — **not** `clip.scale`, §1.6 #1) | §3.3, §1.5 | XS | `ScreenshotService.ts` (both trees) |
 | 4 | Viewport override service + `browser_viewport` tool; DPR simplification in snapshot path | §3.3 | M | new `browser/ViewportOverrideService.ts`, new tool in `registerExtensionTools.ts`, `DomService.buildLayoutMap`, `ScreenshotService.ts` |
-| 5 | Tab leases (claim in `Session.setTabId`, release at `Session.ts:995` / `abortTasksForTab`) + stale GC | §3.6 | M | new `core/TabLeaseStore.ts`, `Session.ts`, `TabManager.ts` |
+| 5 | Tab leases (claim in `RepublicAgent.handleTabBinding` — §1.6 #7; release at `Session.ts:995` / `abortTasksForTab`) + shared-`lifecycleQueue` stale GC; close agent tabs only if unfocused | §3.6 | M | new `core/TabLeaseStore.ts`, `RepublicAgent.ts`, `Session.ts`, `TabManager.ts` |
 | 6 | Lifecycle-event page readiness; rewire navigation + snapshot waiting; dialog handling | §3.8 | M | new `browser/PageReadiness.ts`, `NavigationTool.ts`, `DomService.waitForPageLoad` |
-| 7 | Download watcher + permission | §3.9 | S | new `background/DownloadWatcher.ts`, `manifest.json` |
+| 7 | Download watcher (emit via `Session.emitEvent`, §1.6 #9; `downloads` permission already present) | §3.9 | S | new `background/DownloadWatcher.ts` |
 | 8 | Overlay ping-or-inject + MutationObserver self-heal (arrival sync deferred, §1.5) | §3.5 | S | `content-script.ts`, platform adapter, `DomService.triggerVisualEffect` |
 | 9 | OOPIF: target attachment + read-only snapshot grafting first; input routing after dogfood | §3.7 | L | registry, `DomService.ts`, `DomSnapshot.ts`, `FrameRegistry` |
 | 10 | Hardening grab-bag (deferred reload, instance id, typed errors, `withTimeout`) | §3.10 | S | service worker, `DOMTool.ts`, utils |
@@ -344,11 +376,13 @@ Phasing: **PR-1** = items 1–3 + 3b. **PR-2** = items 4–6. **PR-3** = 7–8. 
 - **Emulation overrides are user-visible** if the agent operates a tab the user is watching; mitigation in §3.3 (match current CSS viewport, always clear on release; never apply to user-claimed tabs unless a vision flow needs it).
 - **Refcounted detach changes timing** of the Chrome debugger infobar ("WorkX is debugging this browser") — it will now disappear at turn end rather than lingering; verify the UX and that re-attach latency (~50ms) per turn is acceptable.
 - **`getContentQuads` migration** changes click coordinates on transformed/inline elements; gate behind a config flag for one release with fallback to `getBoxModel`.
-- **OOPIF attachment** raises the number of debugger targets; Chrome shows one infobar regardless, but cleanup paths must include targets (registry handles via `targetId → tabId` map, mirroring Codex `Fe`).
+- **OOPIF attachment** raises the number of debugger targets; Chrome shows one infobar regardless, but cleanup paths must include targets (registry handles via `targetId → tabId` map, mirroring Codex `Fe`). Scope is larger than a "natural extension" — see §1.6 #10 / §3.7.
+- **Lease auto-close** could close a tab the user has adopted; mitigation in §3.6.3 (re-check focused/active state at release; never close a focused tab).
+- **Timeout force-detach blast radius:** one command timeout fails all concurrent commands on the shared tab (§1.6 #2 / §3.2); gate on a wedged check if this proves disruptive in dogfood.
 
 ---
 
-## 7. Appendix: implementation contracts (v2)
+## 7. Appendix: implementation contracts (v3)
 
 Authoritative interfaces for PR-1/PR-2. Implementations may add private members but must not change these shapes without updating this doc.
 
@@ -380,12 +414,17 @@ export interface DebuggerSessionRegistry {
 }
 // Singleton impl: src/extension/tools/browser/ChromeDebuggerSessionRegistry.ts
 // - one chrome.debugger.onEvent + onDetach listener total, dispatch by source.tabId
-// - per-tab async mutex serializing attach/detach (Codex xt())
-// - per-tab Set<string> enabledDomains; ensureDomain sends `${domain}.enable` once
+// - per-tab async mutex serializing attach/detach (Codex xt()); promise-chain built
+//   with .catch/.finally so a rejected op cannot poison the lock for later waiters
+// - acquire/release/forceDetach ALL run inside withTabLock; forceDetach resets the
+//   tab entry (refs->0, enabledDomains cleared) so concurrent acquire re-attaches clean;
+//   stale handles' release() then no-op
+// - per-tab Set<string> enabledDomains; ensureDomain sends `${domain}.enable` once;
+//   cleared on EVERY detach path (release-at-0, forceDetach, onDetach)
 // - default command timeout 10_000ms (Codex an); timeout => forceDetach + rethrow typed error
 ```
 
-Migration notes: `ChromeDebuggerClient` becomes a thin adapter over a `DebuggerHandle` (kept because `DomService`/core code consumes the `DebuggerClient` interface); `DomService.instances` cache stays, but `DomService.detach()` calls `handle.release()` instead of `chrome.debugger.detach`. `ScreenshotService.forTab`/`CoordinateActionService.forTab` (both trees) replace probe-attach with `registry.acquire(tabId)` and must `release()` — they hold the handle on the service instance; `PageVisionTool` releases at the end of each action since these services are constructed per call.
+Migration notes: `ChromeDebuggerClient` becomes a thin adapter over a `DebuggerHandle` (kept because `DomService`/core code consumes the `DebuggerClient` interface); `DomService.instances` cache stays, but `DomService.detach()` calls `handle.release()` instead of `chrome.debugger.detach`. `ScreenshotService.forTab`/`CoordinateActionService.forTab` (both trees) replace probe-attach with `registry.acquire(tabId)` and must `release()`. **`PageVisionTool` acquires the handle ONCE at the start of a vision action and `release()`s after the whole screenshot→click sequence (§1.6 #3), passing that one handle to both services** — not one acquire/release per service call, which would detach the tab between screenshot and click. Both service trees must import the *same* singleton registry module (single source-of-truth import path) or the coordination is defeated by two registries.
 
 ### 7.2 InputDispatcher
 
@@ -408,7 +447,7 @@ export const InputDispatcher: {
 };
 ```
 
-Dispatch rules (from CDP/Playwright convention): `keyDown` carries `key`, `code`, `windowsVirtualKeyCode`, and `text` when the key produces a character (so `Enter` sends `text: "\r"`); use `rawKeyDown` when no text should be produced (modifier-held navigation); `keyUp` mirrors `keyDown` minus `text`. `click` sets `buttons` bitmask during press and `pointerType: 'mouse'`.
+Dispatch rules (from CDP/Playwright convention): `keyDown` carries `key`, `code`, `windowsVirtualKeyCode`, and `text` when the key produces a character (so `Enter` sends `text: "\r"`); use `rawKeyDown` when no text should be produced (modifier-held navigation); `keyUp` mirrors `keyDown` minus `text`. Shifted/capital chars set the Shift modifier bit + `shiftKey`/`shiftKeyCode`; keypad keys forward `location` (§1.6 #4). `click`: `mouseMoved` (`button:'none'`, `buttons:0`) → `mousePressed` (button bit set in `buttons`) → `mouseReleased` (released button **cleared** from `buttons`); `pointerType: 'mouse'` (§1.6 #5).
 
 ### 7.3 PageReadiness
 
@@ -439,4 +478,4 @@ export interface TabLeaseStore {
 }
 ```
 
-Call sites: `Session.setTabId` (`src/core/Session.ts:1081`) claims/releases on rebind; session cleanup (`Session.ts:995`) and `abortTasksForTab` (`Session.ts:2310`) release + `registry.forceDetach`; service-worker startup runs `gcStale()`.
+Call sites: `RepublicAgent.handleTabBinding` (CASES 1/2/3) claims/releases on rebind (**not** `Session.setTabId` — §1.6 #7); session cleanup (`Session.ts:995`) and `abortTasksForTab` (`Session.ts:2310`) release + `registry.forceDetach`; service-worker startup runs `gcStale()` through the per-session `lifecycleQueue`.

--- a/.ai_design/improve_webtool_from_codex/design.md
+++ b/.ai_design/improve_webtool_from_codex/design.md
@@ -1,7 +1,7 @@
 # Improving workx Web-Operation Tools — Lessons from the OpenAI Codex Chrome Extension
 
-**Status:** Proposed
-**Date:** 2026-06-12
+**Status:** Reviewed — ready to implement (v2)
+**Date:** 2026-06-12 (v1 analysis; v2 design review same day)
 **Sources analyzed:**
 - OpenAI Codex Chrome extension v1.1.5 (store build, deobfuscated). Line references in this doc point to the prettified bundles (`background.pretty.js` ~7,100 lines, `codex-content.pretty.js` ~1,350 lines) produced with `js-beautify` from `/Users/irichard/Downloads/1.1.5_0/`.
 - workx extension source at HEAD (`37a092dd`).
@@ -27,6 +27,36 @@ Priority summary (details in §4):
 - **P0 (correctness bugs):** central debugger session registry (§3.1), CDP command timeouts (§3.2), keyboard dispatch key-definition table (§3.4), click option plumbing + `mouseMoved` precursor (§3.4), coordinate-space normalization (§3.3/§3.4).
 - **P1 (capability gaps):** viewport emulation override + agent viewport tool (§3.3), tab lease/turn lifecycle with finalize semantics (§3.6), event-driven page-readiness (§3.8), download tracking (§3.9).
 - **P2 (polish):** overlay self-healing + ping-or-inject (§3.5), OOPIF target attachment (§3.7), favicon badging / tab-group session UX (§3.6), deferred-update reload (§3.10).
+
+---
+
+## 1.5 Design review (v2): verification results and locked decisions
+
+Every claim in §3 was re-verified against the code during review. Results, corrections, and decisions that make this implementable as-is:
+
+**Verified bugs (re-confirmed at the cited lines):**
+- Keyboard `code: \`Key${key.toUpperCase()}\`` defect confirmed in both `DomService.ts:2682,2689` and `CoordinateActionService.ts:157,165`; neither sends `windowsVirtualKeyCode` or `text`.
+- `DOMTool.executeClick` confirmed to drop `options` (`DOMTool.ts:366-375`); `DomService.click` hardcodes left/single click (`DomService.ts:1128-1141`).
+- `page_vision` DPR mismatch confirmed end-to-end: the tool prompt instructs the model to give "coordinates in pixels … from edge of image" (`PageVisionTool.ts:75-83`), the screenshot is captured at device pixels (`ScreenshotService.ts:37-41`, no `clip`/scale), and `executeClick` passes those coordinates straight to `CoordinateActionService.clickAt` (`PageVisionTool.ts:293-296`) which dispatches CSS-pixel `Input` events. On any DPR>1 display, vision clicks land at `DPR×` the intended position (then get clipped to viewport bounds at `PageVisionTool.ts:393`, masking the failure as "clicked wrong element" instead of "out of bounds"). This upgrades §3.3 from "risk" to **active P0 bug**.
+- Coordinate-space claim in §3.4 refined for accuracy: `DOM.getBoxModel` quads are main-frame **viewport-relative** CSS pixels, so the dispatched click coordinates are actually correct; what's wrong is the in-viewport *check* (`DomService.ts:1098-1102`), which compares viewport-relative coords against `scrollX/scrollY`-offset document bounds. Practical effect: after the page is scrolled, visible elements are misclassified as off-screen → spurious `scrollIntoViewIfNeeded` + 100ms sleep + re-fetch on most clicks, and the zero-size visibility gate can pass for elements that are actually outside the viewport. The fix (intersect `getContentQuads` against `{0,0,innerWidth,innerHeight}`) is unchanged.
+
+**New findings from review (incorporated into §3.1):**
+- There is a **fourth** uncoordinated attach path: `ExtensionBrowserController` (`src/extension/tools/browser/ExtensionBrowserController.ts:58`) creates its own `ChromeDebuggerClient` and attaches independently — and contains its own char-by-char `Input.dispatchKeyEvent` typing loop (`:181-205`). However, nothing outside its own module and tests instantiates it. **Decision:** deprecate it in PR-1 (mark `@deprecated`, exclude from the registry migration) rather than rewire dead code; delete in PR-4 if still unused. Its core-layer interface (`src/core/tools/browser/BrowserController.ts`) stays, since desktop mode implements it separately.
+- **Duplicate service trees:** `src/tools/screenshot/{ScreenshotService,CoordinateActionService}.ts` and `src/tools/PageVisionTool.ts` are near-copies of the `src/extension/tools/*` versions, and `src/tools/PageVisionTool.ts:255-376` calls its own tree's `forTab()` — both trees attach `chrome.debugger` independently. **Decision:** the registry is defined by interface in `src/core/tools/browser/` (next to `DebuggerClient.ts`) with the Chrome implementation in `src/extension/tools/browser/`; both tool trees import the same singleton. Consolidating the duplicated trees is desirable but explicitly out of scope here — PR-1 only repoints both trees' attach calls.
+
+**Integration points pinned (replaces the loose references in v1):**
+- *Tab binding:* a workx session binds **one tab at a time** via `Session.setTabId` → `sessionState` (`src/core/Session.ts:1081-1082`, cleared at `:995`); tasks carry `scopedTabIds` and `Session.abortTasksForTab(tabId, reason)` exists (`Session.ts:2310-2313`). The §3.6 lease design is therefore *simpler* than Codex's multi-tab session: lease lifecycle hooks into `setTabId` (claim on bind, release+detach on rebind/clear) and into task completion/abort paths, not into a multi-tab finalize protocol. `finalizeTabs(keep[])`-style multi-tab semantics become relevant only if/when multi-tab sessions ship; the lease store schema below already supports it.
+- *Turn-end hook:* `TurnManager` (`src/core/TurnManager.ts`) runs turns; session cleanup at `Session.ts:995` is where leases/debuggers must be released. DownloadWatcher and dialog events (§3.8/§3.9) surface through the existing session event path used by tool progress (`BaseToolOptions.onProgress`) rather than a new bus.
+- *Tool registration:* new `browser_viewport` tool registers in `src/extension/tools/registerExtensionTools.ts` alongside `dom_tool` (`:129`) and `page_vision` (`:304`).
+- *Feature gating:* compile-time flags (`vite.featureFlags.mjs`) are deliberately heavyweight (rebuild-only, registry-synced). **Decision:** behavior switches in this work use `ServiceConfig` runtime options instead — `useContentQuads` (default true, `getBoxModel` fallback), `useLifecycleReadiness` (default true, heuristic fallback), `viewportOverride` (default off except `page_vision` flows).
+
+**Scope decisions locked during review:**
+1. Viewport override (§3.3) is **not** applied at every attach (Codex can; their tabs live in a dedicated agent group). It is applied: (a) during `page_vision` screenshot+action turns, and (b) when the agent explicitly calls `browser_viewport set`. It is cleared on tab release and at session unbind. Until §3.3 lands, the immediate P0 fix for the vision DPR bug is one line in `ScreenshotService.captureViewport`: read DPR once and downscale the PNG to CSS pixels (or set `clip: {x:0,y:0,width,height,scale:1/dpr}` on `Page.captureScreenshot`) — ship this in PR-1 with the input fixes.
+2. Cursor arrival handshake (§3.5 optional part) is deferred indefinitely — we don't animate a cursor before clicks today, so there is nothing to synchronize. Ping-or-inject + self-healing overlay stay in PR-3.
+3. OOPIF (§3.7) stays last (PR-4) and starts with **read-only** support (snapshot grafting); per-target input routing ships only after snapshot support proves stable in dogfood.
+4. The 10 findings hold after review; no Codex behavior examined was found *worse* than ours in a way that changes the recommendations.
+
+**Acceptance criteria per PR** are added to §5 and mirrored in `tasks.md`.
 
 ---
 
@@ -104,11 +134,12 @@ with a default of **1280x720** (the viewport tool description, bg:3967, says: "o
 
 **Their implementation:** §2.2 — module-global attach sets, per-tab/per-target async mutexes, idempotent attach tolerant of "already attached", `finally`-guaranteed registry cleanup, one global `onDetach` reconciler.
 
-**Our current state:** three uncoordinated attach paths:
+**Our current state:** four uncoordinated attach paths (the fourth found in design review, §1.5):
 
 - `DomService.forTab()` creates a per-tab `ChromeDebuggerClient` and attaches (`src/extension/tools/dom/DomService.ts:74-93`), cached in `DomService.instances`.
-- `ScreenshotService.forTab()` probes attachment by **executing `Runtime.evaluate('1+1')`** and attaches if it throws (`src/extension/tools/screenshot/ScreenshotService.ts:124-154`). It never detaches.
-- `CoordinateActionService.forTab()` duplicates the same probe/attach (`src/extension/tools/screenshot/CoordinateActionService.ts:215-253`). Also never detaches.
+- `ScreenshotService.forTab()` probes attachment by **executing `Runtime.evaluate('1+1')`** and attaches if it throws (`src/extension/tools/screenshot/ScreenshotService.ts:124-154`). It never detaches. The near-identical copy in `src/tools/screenshot/` is called by `src/tools/PageVisionTool.ts:255` and attaches independently as well.
+- `CoordinateActionService.forTab()` duplicates the same probe/attach (`src/extension/tools/screenshot/CoordinateActionService.ts:215-253`). Also never detaches. Same duplicate-tree caveat.
+- `ExtensionBrowserController.initialize()` attaches its own client (`src/extension/tools/browser/ExtensionBrowserController.ts:58`) — currently dormant (no production instantiation); deprecated in PR-1 per §1.5.
 
 Problems: (a) the `1+1` probe is a race — between probe and attach another service can attach, and "Another debugger is already attached" is then swallowed with a comment saying "this is OK", leaving ambiguous ownership; (b) nobody refcounts, so `DomService.detach()` can yank the connection out from under an in-flight screenshot; (c) each `ChromeDebuggerClient.attach` adds its own `chrome.debugger.onEvent` listener (`src/extension/tools/browser/ChromeDebuggerClient.ts:83`) — N listeners filtering for their tab; (d) no per-tab serialization, so concurrent `forTab` calls can double-attach and one rejects.
 
@@ -151,7 +182,7 @@ class DebuggerSessionRegistry {
 **Our current state:** we fight DPR everywhere instead of normalizing it:
 
 - `DomService.buildSnapshot` reads `window.devicePixelRatio` via `Runtime.evaluate` and divides every DOMSnapshot rect (`DomService.ts:445-461`, `buildLayoutMap` at :765).
-- `Page.captureScreenshot` output is in device pixels (`ScreenshotService.ts:37-41`), so on a 2x display the vision model sees a 2x image while `CoordinateActionService.clickAt` dispatches in CSS pixels — a model that reads coordinates off the screenshot will click at 2x the intended position unless something downstream halves them. There is a `ViewportDetector` (`src/extension/tools/screenshot/ViewportDetector.ts`) but no normalization at capture time.
+- `Page.captureScreenshot` output is in device pixels (`ScreenshotService.ts:37-41`), so on a 2x display the vision model sees a 2x image while `CoordinateActionService.clickAt` dispatches in CSS pixels. **Confirmed active bug, not a risk** (see §1.5): the `page_vision` prompt explicitly tells the model to provide image-pixel coordinates (`PageVisionTool.ts:75-83`), which are dispatched unscaled (`PageVisionTool.ts:293-296`) — on DPR>1 displays every vision-driven click lands at DPR× the intended position, and the bounds-clipping at `PageVisionTool.ts:393` masks it. Immediate fix ships in PR-1 (capture at `scale: 1/dpr` via the `clip` param, or downscale the PNG); the emulation override below is the structural fix. There is a `ViewportDetector` (`src/extension/tools/screenshot/ViewportDetector.ts`) but no normalization at capture time.
 - No way for the agent to test responsive layouts.
 
 **Proposed change:**
@@ -169,7 +200,7 @@ class DebuggerSessionRegistry {
 1. **Wrong `code` for non-letter keys.** Both `DomService.keypress` (`DomService.ts:2680-2691`) and `CoordinateActionService.keypressAt` (`CoordinateActionService.ts:154-167`) compute `code: \`Key${key.toUpperCase()}\`` — producing `KeyENTER`, `KeyTAB`, `KeyARROWDOWN`. Correct values are `Enter`, `Tab`, `ArrowDown`, `KeyA`, `Digit1`, etc. We also never send `windowsVirtualKeyCode`/`nativeVirtualKeyCode`, which many sites (and all `keyCode`-based handlers) need, nor `text` for printable keys, so `keypress` frequently does nothing on real pages.
 2. **Click options silently dropped.** `DOMTool` advertises `options: { button: "left"|"right"|"middle", scrollIntoView }` (`DOMTool.ts:190`), but `executeClick` ignores `options` (`DOMTool.ts:366-375`) and `DomService.click(nodeId)` hardcodes `button: 'left', clickCount: 1` (`DomService.ts:1128-1141`). Right-click/double-click don't exist despite being documented to the model.
 3. **No `mouseMoved` precursor.** We dispatch `mousePressed` directly (`DomService.ts:1128`). Hover-revealed controls (menus, tooltips, row actions) never see `mouseenter`, and some frameworks gate `click` on a prior `mousemove`. Sequence should be `mouseMoved` → `mousePressed` → `mouseReleased`, optionally with the visual cursor animation synchronized (§3.5).
-4. **Coordinate-space ambiguity.** `DomService.click` derives coordinates from `DOM.getBoxModel` content quads and then compares them against `scrollX/scrollY + innerWidth/Height` as if they were *document* coordinates (`DomService.ts:1084-1117`), while `Input.dispatchMouseEvent` expects **viewport CSS coordinates**. `DOM.getBoxModel` returns main-frame viewport-relative quads, so the in-viewport check is wrong on scrolled pages (it compares viewport coords against document bounds — usually accidentally true near the top, wrong after scrolling). Prefer `DOM.getContentQuads` (handles inline/transformed/SVG elements — also fixes the `SVG_CLICK_NOT_SUPPORTED` carve-out at `DomService.ts:1063-1069`) and validate visibility by intersecting quads with `{0,0,innerWidth,innerHeight}`.
+4. **Broken in-viewport check (coordinate-space mix-up).** `DOM.getBoxModel` quads are main-frame **viewport-relative** CSS pixels, so the coordinates `DomService.click` dispatches are correct — but its visibility check compares those viewport-relative coords against `scrollX/scrollY`-offset document bounds (`DomService.ts:1098-1102`). On any scrolled page, visible elements are misclassified as off-screen, causing a spurious `DOM.scrollIntoViewIfNeeded` + 100ms sleep + box-model re-fetch on most clicks (`DomService.ts:1104-1118`), and the check can pass for elements genuinely outside the viewport. Fix: switch to `DOM.getContentQuads` (also handles inline/transformed/SVG elements — removes the `SVG_CLICK_NOT_SUPPORTED` carve-out at `DomService.ts:1063-1069`) and test visibility by intersecting quads with `{0, 0, innerWidth, innerHeight}` — no scroll offsets involved.
 
 **Proposed change:** new shared module `src/extension/tools/input/InputDispatcher.ts`:
 
@@ -201,13 +232,16 @@ class DebuggerSessionRegistry {
 
 **Our current state:** `TabManager` (`src/core/TabManager.ts:28-67`) maintains one global "workx" tab group and closure callbacks; there is no ownership record distinguishing agent-created tabs from user tabs the agent borrowed, no turn-end contract (tools just leave tabs open and debuggers attached — `ScreenshotService`/`CoordinateActionService` never detach), and no persistence, so a service-worker restart forgets which tabs were ours.
 
-**Proposed change (incremental, not a full port):**
+**Proposed change (incremental, not a full port — adjusted in review for workx's single-tab session model, §1.5):**
 
-1. `TabLeaseStore` (chrome.storage.session): `{ tabId, sessionId, turnId, origin: 'agent'|'user', claimedAt }`. Claim on first tool use against a tab; reject claiming tabs leased to another session; reject `chrome://`/`chrome-extension://` (we already validate URLs for navigation at `NavigationTool.ts:560+` — extend to claiming).
-2. Per-session `lifecycleQueue` promise chain in the session object so claim/finalize/cleanup don't interleave (Codex `runLifecycle`, bg:6230-6237).
-3. `finalizeSession(keep?: Record<tabId, 'keep'>)` hook in the agent loop's turn-end: best-effort detach all debuggers for leased tabs (fixes the §3.1 leak even before refcounting lands), close agent-origin tabs not kept, release user-origin leases. Deliverable/handoff distinction can come later; "detach + close agent tabs + release" is the 80%.
-4. Stale-lease GC at session start: drop leases whose `chrome.tabs.get` throws (Codex `resumeHandoffIfPresent`, bg:6166-6193).
-5. UX polish (P2): badge favicons of agent-controlled tabs (SVG data-URI overlay, Codex bg:4180-4195) and name the session tab group from the task title (`nameSession`).
+A workx session binds one tab at a time (`Session.setTabId`, `src/core/Session.ts:1081`), so we don't need Codex's multi-tab finalize protocol yet — but we do need ownership records, guaranteed detach, and stale-state GC. The store schema is multi-tab-ready so multi-tab sessions later only change the callers.
+
+1. `TabLeaseStore` (chrome.storage.session): `{ tabId, sessionId, turnId, origin: 'agent'|'user', claimedAt }`. Claim inside `Session.setTabId` (origin `user` when binding an existing tab, `agent` when a tool created it); reject claiming tabs leased to another live session; reject `chrome://`/`chrome-extension://` (we already validate URLs for navigation at `NavigationTool.ts:560+` — extend to claiming).
+2. Per-session `lifecycleQueue` promise chain so claim/release/cleanup don't interleave (Codex `runLifecycle`, bg:6230-6237) — lives next to the lease store, invoked from `Session`.
+3. Release hooks: `Session.setTabId(-1)` / session cleanup (`Session.ts:995`) and `abortTasksForTab` (`Session.ts:2310`) release the lease and best-effort detach the tab's debugger via the registry (fixes the §3.1 leak even before refcounting lands). Agent-origin tabs are closed on release unless the turn result marked them as deliverables; user-origin tabs are always left open.
+4. Stale-lease GC at service-worker start and session start: drop leases whose `chrome.tabs.get` throws (Codex `resumeHandoffIfPresent`, bg:6166-6193) — this is what makes leases safe across MV3 service-worker restarts.
+5. UX polish (P2): badge favicons of agent-controlled tabs (SVG data-URI overlay, Codex bg:4180-4195) and name the existing `TabManager` "workx" tab group from the task title (`nameSession`).
+6. Deferred until multi-tab sessions exist: `finalizeTabs(keep[])` deliverable/handoff semantics and handoff-resume across turns.
 
 ### 3.7 [P2] Cross-origin iframe (OOPIF) support via target attachment
 
@@ -274,18 +308,36 @@ Ordered by dependency; see `tasks.md` for the checklist form.
 
 | # | Work item | Sections | Size | Key files |
 |---|---|---|---|---|
-| 1 | `DebuggerSessionRegistry` (locks, refcounts, single event dispatch, force-detach) | §3.1, §3.2 | M | new `browser/DebuggerSessionRegistry.ts`; rewire `DomService.ts`, `ScreenshotService.ts`, `CoordinateActionService.ts`, `ChromeDebuggerClient.ts` |
+| 1 | `DebuggerSessionRegistry` (locks, refcounts, single event dispatch, force-detach); deprecate `ExtensionBrowserController` | §3.1, §3.2, §1.5 | M | new `core/tools/browser/DebuggerSessionRegistry.ts` (interface) + `extension/tools/browser/ChromeDebuggerSessionRegistry.ts` (impl); rewire `DomService.ts`, both `ScreenshotService.ts` / `CoordinateActionService.ts` trees, `ChromeDebuggerClient.ts` |
 | 2 | CDP command timeouts + `CdpCommandTimeoutError` | §3.2 | S | `ChromeDebuggerClient.ts`, registry |
-| 3 | `InputDispatcher` + key definitions table + click option plumbing + `getContentQuads` targeting | §3.4 | M | new `input/InputDispatcher.ts`, `input/keyDefinitions.ts`; `DomService.ts` click/keypress, `CoordinateActionService.ts`, `DOMTool.ts` |
-| 4 | Viewport override service + `browser_viewport` tool + DPR simplification | §3.3 | M | new `browser/ViewportOverrideService.ts`, new tool, `DomService.buildLayoutMap`, `ScreenshotService.ts` |
-| 5 | Tab leases + turn finalization + stale GC | §3.6 | M | new `core/TabLeaseStore.ts`, `TabManager.ts`, agent session lifecycle |
+| 3 | `InputDispatcher` + key definitions table + click option plumbing + `getContentQuads` targeting (`useContentQuads` config, fallback `getBoxModel`) | §3.4 | M | new `input/InputDispatcher.ts`, `input/keyDefinitions.ts`; `DomService.ts` click/keypress, `CoordinateActionService.ts`, `DOMTool.ts` |
+| 3b | **Vision DPR hotfix**: capture screenshots at CSS-pixel scale (`Page.captureScreenshot` `clip.scale = 1/dpr`) | §3.3, §1.5 | XS | `ScreenshotService.ts` (both trees) |
+| 4 | Viewport override service + `browser_viewport` tool; DPR simplification in snapshot path | §3.3 | M | new `browser/ViewportOverrideService.ts`, new tool in `registerExtensionTools.ts`, `DomService.buildLayoutMap`, `ScreenshotService.ts` |
+| 5 | Tab leases (claim in `Session.setTabId`, release at `Session.ts:995` / `abortTasksForTab`) + stale GC | §3.6 | M | new `core/TabLeaseStore.ts`, `Session.ts`, `TabManager.ts` |
 | 6 | Lifecycle-event page readiness; rewire navigation + snapshot waiting; dialog handling | §3.8 | M | new `browser/PageReadiness.ts`, `NavigationTool.ts`, `DomService.waitForPageLoad` |
 | 7 | Download watcher + permission | §3.9 | S | new `background/DownloadWatcher.ts`, `manifest.json` |
-| 8 | Overlay ping-or-inject + MutationObserver self-heal (+ optional arrival sync) | §3.5 | S–M | `content-script.ts`, platform adapter, `DomService.triggerVisualEffect` |
-| 9 | OOPIF target attachment + snapshot grafting + per-target input routing | §3.7 | L | registry, `DomService.ts`, `DomSnapshot.ts`, `FrameRegistry` |
+| 8 | Overlay ping-or-inject + MutationObserver self-heal (arrival sync deferred, §1.5) | §3.5 | S | `content-script.ts`, platform adapter, `DomService.triggerVisualEffect` |
+| 9 | OOPIF: target attachment + read-only snapshot grafting first; input routing after dogfood | §3.7 | L | registry, `DomService.ts`, `DomSnapshot.ts`, `FrameRegistry` |
 | 10 | Hardening grab-bag (deferred reload, instance id, typed errors, `withTimeout`) | §3.10 | S | service worker, `DOMTool.ts`, utils |
 
-Suggested phasing: **PR-1** = items 1–3 (pure correctness, no tool-surface changes, existing tests must pass; add unit tests for lock/refcount semantics and key table). **PR-2** = items 4–6. **PR-3** = 7–8. **PR-4** = 9 (largest, riskiest). Item 10 can ride along any PR.
+Phasing: **PR-1** = items 1–3 + 3b. **PR-2** = items 4–6. **PR-3** = 7–8. **PR-4** = 9. Item 10 rides along any PR.
+
+### 5.1 Acceptance criteria
+
+**PR-1 (correctness):**
+- No tool-surface changes; all existing tests pass unmodified except those asserting the buggy behaviors (wrong key `code`, dropped click options) — update those.
+- New unit tests: registry concurrent `acquire`/`release` (no double-attach, detach only at refcount 0, `onDetach` reconciliation), per-command timeout firing + force-detach + clean re-attach, key-definition table (`Enter`→`code:"Enter"`,`keyCode:13`; `a`→`code:"KeyA"`,`text:"a"`; modifier combinations), click option plumbing (right/middle/double reach `Input.dispatchMouseEvent`).
+- Manual verification (`/verify`-style): on a DPR-2 display, `page_vision` click on a known element lands correctly; `browser_dom` keypress Enter submits a real form; concurrent `browser_dom` + `page_vision` on the same tab no longer race attach.
+- Exactly one `chrome.debugger.onEvent` listener registered process-wide (assert via registry test).
+
+**PR-2 (capabilities):**
+- `browser_viewport set 375x667` renders mobile layout; `reset` restores; override never applied to a user-bound tab outside a vision flow; `Emulation.clearDeviceMetricsOverride` confirmed on release.
+- Lease invariants: rebinding a session's tab releases the old lease and detaches; killing the service worker and reloading leaves no orphan leases (GC test); a tab leased to session A cannot be bound by session B.
+- Navigation on a slow page completes on `load` event (no 100ms polling in the trace); `DomService` snapshot after navigation waits ≤ `networkAlmostIdle` + one content check; a page calling `confirm()` no longer hangs the turn.
+
+**PR-3:** download of a file via agent click surfaces `started`/`completed` with filename in tool results; overlay survives a hostile `document.documentElement.replaceChildren()` and re-mounts; visual effects appear on a tab opened before extension install (ping-or-inject path).
+
+**PR-4:** snapshot of a page with a cross-origin iframe (e.g. embedded Stripe checkout) contains the iframe's interactive elements with frame-scoped node ids; detach cleanup verified for child targets (no orphaned debugger infobars).
 
 ## 6. Risks
 
@@ -293,3 +345,98 @@ Suggested phasing: **PR-1** = items 1–3 (pure correctness, no tool-surface cha
 - **Refcounted detach changes timing** of the Chrome debugger infobar ("workx is debugging this browser") — it will now disappear at turn end rather than lingering; verify the UX and that re-attach latency (~50ms) per turn is acceptable.
 - **`getContentQuads` migration** changes click coordinates on transformed/inline elements; gate behind a config flag for one release with fallback to `getBoxModel`.
 - **OOPIF attachment** raises the number of debugger targets; Chrome shows one infobar regardless, but cleanup paths must include targets (registry handles via `targetId → tabId` map, mirroring Codex `Fe`).
+
+---
+
+## 7. Appendix: implementation contracts (v2)
+
+Authoritative interfaces for PR-1/PR-2. Implementations may add private members but must not change these shapes without updating this doc.
+
+### 7.1 DebuggerSessionRegistry
+
+```ts
+// src/core/tools/browser/DebuggerSessionRegistry.ts (interface, platform-neutral)
+export class CdpCommandTimeoutError extends Error {
+  constructor(public method: string, public timeoutMs: number);
+}
+
+export interface DebuggerHandle {
+  readonly tabId: number;
+  sendCommand<T = unknown>(method: string, params?: object, opts?: { timeoutMs?: number }): Promise<T>;
+  ensureDomain(domain: 'DOM' | 'Page' | 'Runtime' | 'Accessibility' | 'Network'): Promise<void>;
+  onEvent(cb: (method: string, params: unknown) => void): () => void; // returns unsubscribe
+  /** refcount--; detaches the tab at zero. Idempotent. NEVER throws. */
+  release(): Promise<void>;
+}
+
+export interface DebuggerSessionRegistry {
+  /** Attach if needed (idempotent, per-tab lock), refcount++. Throws ALREADY_ATTACHED
+   *  only when a foreign debugger (DevTools) holds the tab. */
+  acquire(tabId: number): Promise<DebuggerHandle>;
+  /** Codex `hn`: clear state first, then detach ignoring errors. Used on
+   *  CdpCommandTimeoutError and onDetach reconciliation. */
+  forceDetach(tabId: number): Promise<void>;
+  isAttached(tabId: number): boolean;
+}
+// Singleton impl: src/extension/tools/browser/ChromeDebuggerSessionRegistry.ts
+// - one chrome.debugger.onEvent + onDetach listener total, dispatch by source.tabId
+// - per-tab async mutex serializing attach/detach (Codex xt())
+// - per-tab Set<string> enabledDomains; ensureDomain sends `${domain}.enable` once
+// - default command timeout 10_000ms (Codex an); timeout => forceDetach + rethrow typed error
+```
+
+Migration notes: `ChromeDebuggerClient` becomes a thin adapter over a `DebuggerHandle` (kept because `DomService`/core code consumes the `DebuggerClient` interface); `DomService.instances` cache stays, but `DomService.detach()` calls `handle.release()` instead of `chrome.debugger.detach`. `ScreenshotService.forTab`/`CoordinateActionService.forTab` (both trees) replace probe-attach with `registry.acquire(tabId)` and must `release()` — they hold the handle on the service instance; `PageVisionTool` releases at the end of each action since these services are constructed per call.
+
+### 7.2 InputDispatcher
+
+```ts
+// src/extension/tools/input/keyDefinitions.ts
+export interface KeyDefinition {
+  key: string; code: string; keyCode: number;       // windowsVirtualKeyCode
+  text?: string; shiftKey?: string; shiftKeyCode?: number; location?: number;
+}
+export const keyDefinitions: Record<string, KeyDefinition>; // US layout, ported shape from Puppeteer USKeyboardLayout (MIT)
+
+// src/extension/tools/input/InputDispatcher.ts — stateless; takes a sender, works for tab or OOPIF target
+type CdpSend = <T>(method: string, params: object) => Promise<T>;
+export const InputDispatcher: {
+  click(send: CdpSend, opts: { x: number; y: number; button?: 'left'|'right'|'middle';
+    clickCount?: number; modifiers?: number }): Promise<void>;     // mouseMoved → mousePressed → mouseReleased
+  dispatchKey(send: CdpSend, key: string, opts?: { modifiers?: number; commands?: string[] }): Promise<void>;
+  insertText(send: CdpSend, text: string): Promise<void>;
+  encodeModifiers(m?: { alt?: boolean; ctrl?: boolean; meta?: boolean; shift?: boolean }): number; // Alt=1 Ctrl=2 Meta=4 Shift=8
+};
+```
+
+Dispatch rules (from CDP/Playwright convention): `keyDown` carries `key`, `code`, `windowsVirtualKeyCode`, and `text` when the key produces a character (so `Enter` sends `text: "\r"`); use `rawKeyDown` when no text should be produced (modifier-held navigation); `keyUp` mirrors `keyDown` minus `text`. `click` sets `buttons` bitmask during press and `pointerType: 'mouse'`.
+
+### 7.3 PageReadiness
+
+```ts
+// src/extension/tools/browser/PageReadiness.ts
+export type ReadinessState = 'DOMContentLoaded' | 'load' | 'networkAlmostIdle' | 'networkIdle';
+export class PageReadiness {
+  constructor(handle: DebuggerHandle);                  // calls Page.enable + Page.setLifecycleEventsEnabled
+  waitFor(state: ReadinessState, opts?: { timeoutMs?: number; failOpen?: boolean }): Promise<void>;
+  navigate(url: string, waitUntil?: ReadinessState): Promise<{ frameId: string; loaderId?: string }>;
+  onDialog(cb: (info: { type: string; message: string }) => void): () => void; // Page.javascriptDialogOpening
+}
+```
+
+Lifecycle events arrive per `loaderId`; `navigate()` correlates so a `load` from the *previous* document can't satisfy the wait. Default `failOpen: true` with `timeoutMs: 8000` for snapshot waits, `30000` for navigation (matches current `NavigationTool` default).
+
+### 7.4 TabLeaseStore
+
+```ts
+// src/core/TabLeaseStore.ts — backed by chrome.storage.session in extension mode
+export interface TabLease { tabId: number; sessionId: string; turnId?: string;
+  origin: 'agent' | 'user'; claimedAt: number; }
+export interface TabLeaseStore {
+  claim(lease: Omit<TabLease, 'claimedAt'>): Promise<void>;   // throws TabLeasedError if other live session owns it
+  release(sessionId: string, tabId: number): Promise<void>;
+  getOwner(tabId: number): Promise<string | null>;
+  gcStale(): Promise<number>;                                 // drop leases whose chrome.tabs.get fails
+}
+```
+
+Call sites: `Session.setTabId` (`src/core/Session.ts:1081`) claims/releases on rebind; session cleanup (`Session.ts:995`) and `abortTasksForTab` (`Session.ts:2310`) release + `registry.forceDetach`; service-worker startup runs `gcStale()`.

--- a/.ai_design/improve_webtool_from_codex/tasks.md
+++ b/.ai_design/improve_webtool_from_codex/tasks.md
@@ -5,26 +5,27 @@ See `design.md` (v2, reviewed) for full technical detail. Section references (§
 ## PR-1: Debugger + input correctness (P0)
 
 - [ ] **T01** Create `DebuggerSessionRegistry` per §7.1 — interface in `src/core/tools/browser/`, singleton impl `ChromeDebuggerSessionRegistry` in `src/extension/tools/browser/` (§3.1)
-  - [ ] Per-tab async mutex serializing attach/detach
+  - [ ] Per-tab async mutex serializing attach/detach; promise-chain with `.catch`/`.finally` so a rejected op can't poison the lock (§1.6 #2)
   - [ ] Refcounted `acquire(tabId) → DebuggerHandle` / `handle.release()`; detach at refcount 0; `release()` never throws
-  - [ ] ONE global `chrome.debugger.onEvent`/`onDetach` listener pair; dispatch by `source.tabId`
+  - [ ] ONE global `chrome.debugger.onEvent`/`onDetach` listener pair; dispatch by `source.tabId` (also fixes the per-instance `onDetach` listener leak)
   - [ ] Idempotent attach; `ALREADY_ATTACHED` thrown only for foreign (DevTools) attachment
-  - [ ] Per-tab `enabledDomains` set; `ensureDomain` sends `.enable` once
-  - [ ] `forceDetach` (clear state first, ignore detach errors)
-  - [ ] Unit tests: concurrent acquire, release-at-zero only, onDetach reconciliation, single-listener assertion
-- [ ] **T02** Per-command timeout in `sendCommand` (default 10s, typed `CdpCommandTimeoutError`); timeout → `forceDetach` → clean re-attach on next acquire; longer budgets for `Accessibility.getFullAXTree` / `DOMSnapshot.captureSnapshot` (§3.2)
+  - [ ] Per-tab `enabledDomains` set; `ensureDomain` sends `.enable` once; **cleared on every detach path** (release-at-0, forceDetach, onDetach)
+  - [ ] `forceDetach` runs **inside `withTabLock`**; clears state first (refs→0, enabledDomains cleared), ignores detach errors; concurrent `acquire` re-attaches clean (§1.6 #2)
+  - [ ] Unit tests: concurrent acquire, release-at-zero only, onDetach reconciliation, single-listener assertion, forceDetach-then-acquire re-attach
+- [ ] **T02** Per-command timeout in `sendCommand` (default 10s, typed `CdpCommandTimeoutError`); timeout → `forceDetach` → clean re-attach on next acquire; longer budgets for `Accessibility.getFullAXTree` / `DOMSnapshot.captureSnapshot`; document the force-detach blast radius / consider a wedged-check gate (§3.2, §1.6 #2)
 - [ ] **T03** Migrate callers to the registry (§3.1, §1.5):
   - [ ] `DomService` (`ChromeDebuggerClient` becomes thin adapter over `DebuggerHandle`)
-  - [ ] `ScreenshotService` + `CoordinateActionService` — **both** trees (`src/extension/tools/screenshot/` AND `src/tools/screenshot/`); delete both `Runtime.evaluate('1+1')` probes; `PageVisionTool` releases handles per action
+  - [ ] `ScreenshotService` + `CoordinateActionService` — **both** trees (`src/extension/tools/screenshot/` AND `src/tools/screenshot/`); delete both `Runtime.evaluate('1+1')` probes; both trees import the **same** singleton registry module
+  - [ ] `PageVisionTool` acquires ONE handle per vision action and releases after the whole screenshot→click sequence — not per service call (§1.6 #3)
   - [ ] Mark `ExtensionBrowserController` `@deprecated` (dormant — do not rewire)
-- [ ] **T04** `src/extension/tools/input/keyDefinitions.ts` — US-layout table per §7.2 (`key → {code, keyCode, text?, location?}`) + unit tests (Enter/Tab/Arrow/letters/digits/modifiers)
+- [ ] **T04** `src/extension/tools/input/keyDefinitions.ts` — US-layout table per §7.2 (`key → {code, keyCode, text?, shiftKey?, shiftKeyCode?, location?}`) + unit tests (Enter/Tab/Arrow/letters/digits/modifiers/**shifted chars**/**keypad**) (§1.6 #4)
 - [ ] **T05** `src/extension/tools/input/InputDispatcher.ts` per §7.2 (§3.4)
-  - [ ] `dispatchKey`: correct `code`, `windowsVirtualKeyCode`, `text` for printables; `rawKeyDown` rule
-  - [ ] `click`: `mouseMoved` → `mousePressed` → `mouseReleased`, `buttons` bitmask, button/clickCount params
+  - [ ] `dispatchKey`: correct `code`, `windowsVirtualKeyCode`, `text` for printables; `rawKeyDown` rule; Shift modifier bit + `shiftKey`/`shiftKeyCode` for capitals/shifted; forward `location` for keypad (§1.6 #4)
+  - [ ] `click`: `mouseMoved` (`button:'none'`,`buttons:0`) → `mousePressed` (button bit set) → `mouseReleased` (button **cleared** from `buttons`); double-click = two press/release pairs; right-click `button:'right'`+`buttons:2` (§1.6 #5)
   - [ ] Replace bespoke dispatch in `DomService.click/keypress` and `CoordinateActionService.*`
-- [ ] **T06** Plumb `ClickOptions` from `DOMTool.executeClick` → `DomService.click` (button, clickCount) (§3.4)
-- [ ] **T07** `DOM.getContentQuads` targeting + viewport-intersection visibility (no scroll offsets); `useContentQuads` ServiceConfig flag with `getBoxModel` fallback; removes `SVG_CLICK_NOT_SUPPORTED` carve-out and the spurious-scroll path (§3.4, §1.5)
-- [ ] **T08** **Vision DPR hotfix**: capture screenshots at CSS-pixel scale (`Page.captureScreenshot` with `clip.scale = 1/devicePixelRatio`), both ScreenshotService trees (§3.3, §1.5)
+- [ ] **T06** Plumb `ClickOptions` from `DOMTool.executeClick` → `DomService.click` — note the type is `clickType:'single'|'double'` (not `clickCount`); map at the boundary (§3.4, §1.6 #5)
+- [ ] **T07** `DOM.getContentQuads` targeting + viewport-intersection visibility (no scroll offsets); **dispatch at the quad∩viewport intersection center, not the whole-quad center** (§1.6 #6); `useContentQuads` ServiceConfig flag with `getBoxModel` fallback; removes `SVG_CLICK_NOT_SUPPORTED` carve-out and the spurious-scroll path (§3.4, §1.5)
+- [ ] **T08** **Vision DPR hotfix**: downscale the captured PNG to `innerWidth × innerHeight` CSS pixels (read `devicePixelRatio` at capture time — **not** `clip.scale`, §1.6 #1), both ScreenshotService trees (§3.3, §1.5)
 
 **Acceptance (§5.1):** no tool-surface changes; DPR-2 vision click lands correctly; keypress Enter submits a real form; concurrent `browser_dom`+`page_vision` don't race attach; one debugger event listener process-wide.
 
@@ -33,30 +34,30 @@ See `design.md` (v2, reviewed) for full technical detail. Section references (§
 - [ ] **T09** `ViewportOverrideService`: `Emulation.setDeviceMetricsOverride({deviceScaleFactor:1, mobile:false})`, default size = tab's current CSS viewport; `clearDeviceMetricsOverride` on release. Applied ONLY in `page_vision` flows + explicit tool use — never on user-bound tabs otherwise (§3.3, §1.5)
 - [ ] **T10** Simplify DPR division in `DomService.buildLayoutMap` when override active; keep fallback (§3.3)
 - [ ] **T11** `browser_viewport` tool (`set WxH` / `reset`) registered in `registerExtensionTools.ts`; reset-before-finishing prompt guidance (§3.3)
-- [ ] **T12** `TabLeaseStore` per §7.4 on `chrome.storage.session`; claim/release wired into `Session.setTabId` (Session.ts:1081), cleanup (Session.ts:995), `abortTasksForTab` (Session.ts:2310); reject cross-session claims + `chrome://` (§3.6, §1.5)
-- [ ] **T13** Per-session `lifecycleQueue` serializing claim/release/cleanup (§3.6)
-- [ ] **T14** Stale-lease GC at service-worker start + session start (§3.6)
-- [ ] **T15** `PageReadiness` per §7.3 (`Page.setLifecycleEventsEnabled`, loaderId-correlated waits) (§3.8)
-- [ ] **T16** `NavigationTool`: `chrome.tabs.update`+poll → `Page.navigate` + `waitFor`; keep poll as no-debugger fallback (§3.8)
+- [ ] **T12** `TabLeaseStore` per §7.4 on `chrome.storage.session`; claim/release wired into **`RepublicAgent.handleTabBinding` (CASES 1/2/3) — not `Session.setTabId`** (§1.6 #7); release at cleanup (Session.ts:995) + `abortTasksForTab` (Session.ts:2310); reject cross-session claims + `chrome://` via an **extracted/shared** blocked-scheme helper; close agent tabs on release **only if unfocused/inactive** (§3.6)
+- [ ] **T13** Per-session `lifecycleQueue` serializing claim/release/cleanup **and the startup GC** (§3.6)
+- [ ] **T14** Stale-lease GC at service-worker start + session start, run through the `lifecycleQueue` to avoid the GC-vs-claim race (§3.6)
+- [ ] **T15** `PageReadiness` per §7.3 (`Page.enable` **then** `Page.setLifecycleEventsEnabled`, loaderId-correlated waits) (§3.8, §1.6 #8)
+- [ ] **T16** `NavigationTool`: `chrome.tabs.update`+poll → `Page.navigate` + `waitFor`; keep poll as no-debugger fallback. Note: this newly attaches a debugger (infobar) to a previously un-debugged tab — weigh the cost (§3.8, §1.6 #8)
 - [ ] **T17** `DomService.waitForPageLoad`: `waitFor('networkAlmostIdle', {timeoutMs: 8000, failOpen: true})` + single content check; heuristic loop only as fallback (`useLifecycleReadiness` config) (§3.8)
-- [ ] **T18** Handle `Page.javascriptDialogOpening` (surface to agent / auto-respond) — fixes `confirm()` deadlock (§3.8)
+- [ ] **T18** Handle `Page.javascriptDialogOpening` via `Page.handleJavaScriptDialog` (requires `Page.enable`); default auto-dismiss (`accept:false`) unless a tool opts in — fixes `confirm()` deadlock (§3.8, §1.6 #8)
 
 **Acceptance (§5.1):** viewport set/reset round-trips; lease invariants (rebind releases+detaches, SW restart leaves no orphans, cross-session bind rejected); navigation completes on `load` event; dialog no longer hangs the turn.
 
 ## PR-3: Downloads + overlay (P1/P2)
 
-- [ ] **T19** `DownloadWatcher` background module; `downloads` permission in `manifest.json`; emit started/completed/interrupted via existing session event path; surface in tool results (§3.9)
-- [ ] **T20** `ensureContentScript(tabId)`: ping (`WORKX_PING`) → `chrome.scripting.executeScript({injectImmediately:true})` → re-ping; dedupe in-flight injections; call from `triggerVisualEffect`; delete dead `ensureVisualEffectsInitialized` (DomService.ts:913-956) (§3.5)
-- [ ] **T21** Overlay self-heal: `MutationObserver` on `documentElement` remounts shadow host; dataset marker detects impostors (§3.5)
+- [ ] **T19** `DownloadWatcher` background module; emit started/completed/interrupted via **`Session.emitEvent`** (not `onProgress`, §1.6 #9); surface in tool results. (`downloads` permission already present — no manifest change.) (§3.9)
+- [ ] **T20** `ensureContentScript(tabId)`: ping (`WORKX_PING`) → `chrome.scripting.executeScript({injectImmediately:true})` → re-ping; dedupe in-flight injections; idempotent re-inject already guarded by `window.__workx_content_script_loaded__`; call from `triggerVisualEffect`; delete dead `ensureVisualEffectsInitialized` (DomService.ts:913-956) (§3.5)
+- [ ] **T21** Overlay self-heal: `MutationObserver` on **`document.body`** (host's actual parent — content-script.ts:126) remounts shadow host when `!host.isConnected`; **guard re-entrancy** (check `isConnected` / disconnect around re-append); dataset marker detects impostors (§3.5)
 - [ ] ~~Cursor arrival handshake~~ — deferred indefinitely (§1.5: no pre-click cursor animation exists to synchronize)
 
 **Acceptance (§5.1):** agent-clicked download reports filename+status; overlay survives `documentElement.replaceChildren()`; effects work on pre-install tabs.
 
-## PR-4: OOPIF (P2)
+## PR-4: OOPIF (P2) — substantial rewrite, not a "natural extension" (§1.6 #10)
 
-- [ ] **T22** Registry target attachment: enumerate iframe targets, attach `{targetId}`, `targetId → tabId` cleanup map (§3.7)
-- [ ] **T23** Read-only first: per-target DOM/a11y/DOMSnapshot grafted under owner `<iframe>` VirtualNode; `FrameRegistry` gains `targetId` (§3.7, §1.5)
-- [ ] **T24** (After T23 proves stable in dogfood) per-target input routing; translate OOPIF-relative coordinates via parent-frame iframe quad (§3.7)
+- [ ] **T22** Add a target-addressed send path to `ChromeDebuggerClient.sendCommand` (currently hard-rejects non-`tabId` targets — prerequisite). Then registry target attachment via `Target.setAutoAttach({flatten:true})` + `attachedToTarget` events (not one-shot `getTargets()`, which races late OOPIFs); `targetId → tabId` cleanup map (§3.7)
+- [ ] **T23** Read-only first: per-target DOM/a11y/DOMSnapshot grafted under owner `<iframe>` VirtualNode; `FrameRegistry` (in **`DomSnapshot.ts`**, not `DOMTool.ts`) gains a real `targetId` column; resolve cross-target `backendNodeId` collisions (ids unique only per target); make every `getBoxModel`/`scrollIntoViewIfNeeded`/`Input.*` site target-aware (§3.7, §1.5)
+- [ ] **T24** (After T23 proves stable in dogfood) input routing: dispatch to the **page session** with translated coordinates = parent iframe content-quad offset + element offset (account for nested scroll / iframe transform / pinch-zoom) — **not** `Input.*` to `{targetId}` (§3.7, §1.6 #10)
 - [ ] **T25** Replace `MAX_IFRAMES=5` count cap with serializer byte budget (§3.7)
 - [ ] **T26** Delete `ExtensionBrowserController` if still unused (§1.5)
 

--- a/.ai_design/improve_webtool_from_codex/tasks.md
+++ b/.ai_design/improve_webtool_from_codex/tasks.md
@@ -1,0 +1,60 @@
+# Tasks — Improve web-operation tools from Codex extension learnings
+
+See `design.md` for full technical detail. Section references (§) point there.
+
+## PR-1: Debugger + input correctness (P0)
+
+- [ ] **T01** Create `src/extension/tools/browser/DebuggerSessionRegistry.ts` (§3.1)
+  - [ ] Per-tab async mutex (`withTabLock`) serializing attach/detach
+  - [ ] Refcounted `acquire(tabId) → DebuggerHandle` / `handle.release()`; detach at refcount 0
+  - [ ] Single global `chrome.debugger.onEvent` / `onDetach` listeners; dispatch by `source.tabId`
+  - [ ] Idempotent attach; tolerate "already attached" only for registry-owned tabs; keep `ALREADY_ATTACHED` DevTools-conflict error
+  - [ ] Per-tab `enabledDomains` set; `ensureDomain(tabId, domain)`
+  - [ ] Force-detach path (clear registry first, ignore detach errors)
+  - [ ] Unit tests: concurrent acquire, release-while-in-flight, onDetach reconciliation
+- [ ] **T02** Add per-command timeout to `ChromeDebuggerClient.sendCommand` (§3.2)
+  - [ ] `timeoutMs` param, default 10s; typed `CdpCommandTimeoutError`
+  - [ ] On timeout: mark tab wedged in registry → force-detach → next acquire re-attaches
+  - [ ] Longer budgets for `Accessibility.getFullAXTree`, `DOMSnapshot.captureSnapshot`
+- [ ] **T03** Port `DomService`, `ScreenshotService`, `CoordinateActionService`, `ExtensionBrowserController` onto the registry; delete both `Runtime.evaluate('1+1')` attach probes (§3.1)
+- [ ] **T04** Create `src/extension/tools/input/keyDefinitions.ts` — US-layout key table (`key → {code, keyCode, text?, location?}`) (§3.4)
+- [ ] **T05** Create `src/extension/tools/input/InputDispatcher.ts` (§3.4)
+  - [ ] `dispatchKey` with correct `code`, `windowsVirtualKeyCode`, `text` for printables
+  - [ ] `click` sequence: `mouseMoved` → `mousePressed` → `mouseReleased`, `buttons` bitmask, clickCount, button param
+  - [ ] Replace bespoke dispatch in `DomService.click/keypress`, `CoordinateActionService.*`
+- [ ] **T06** Plumb `ClickOptions` from `DOMTool.executeClick` into `DomService.click` (button, clickCount) (§3.4)
+- [ ] **T07** Replace `DOM.getBoxModel` targeting with `DOM.getContentQuads` + viewport-intersection visibility check; config-flag fallback to old path; removes `SVG_CLICK_NOT_SUPPORTED` carve-out (§3.4)
+
+## PR-2: Viewport, leases, readiness (P1)
+
+- [ ] **T08** `ViewportOverrideService`: `Emulation.setDeviceMetricsOverride({deviceScaleFactor:1, mobile:false})` at acquire (defaulting to current CSS viewport size), `clearDeviceMetricsOverride` at release (§3.3)
+- [ ] **T09** Simplify DPR handling in `DomService.buildLayoutMap` and `ScreenshotService` once DPR=1 is guaranteed; keep fallback path (§3.3)
+- [ ] **T10** New `browser_viewport` agent tool (`set WxH` / `reset`) with reset-before-finishing prompt guidance (§3.3)
+- [ ] **T11** `TabLeaseStore` on `chrome.storage.session`: claim/release with `origin: agent|user`; reject cross-session claims and `chrome://` (§3.6)
+- [ ] **T12** Per-session `lifecycleQueue` serializing claim/finalize/cleanup (§3.6)
+- [ ] **T13** `finalizeSession(keep?)` turn-end hook: detach all leased-tab debuggers, close unkept agent-origin tabs, release user leases; stale-lease GC at session start (§3.6)
+- [ ] **T14** `PageReadiness` helper on `Page.setLifecycleEventsEnabled`; `waitFor(until: load|DOMContentLoaded|networkAlmostIdle|networkIdle)` (§3.8)
+- [ ] **T15** `NavigationTool`: `chrome.tabs.update`+poll → `Page.navigate` + `waitFor`; keep poll as no-debugger fallback (§3.8)
+- [ ] **T16** `DomService.waitForPageLoad`: lifecycle-event wait + single content check; heuristic loop only as fallback (§3.8)
+- [ ] **T17** Handle `Page.javascriptDialogOpening` (auto-dismiss or surface to agent) (§3.8)
+
+## PR-3: Downloads + overlay (P1/P2)
+
+- [ ] **T18** `DownloadWatcher` background module; `downloads` permission in `manifest.json`; emit started/completed/interrupted to session event bus; surface in tool results (§3.9)
+- [ ] **T19** `ensureContentScript(tabId)`: ping (`WORKX_PING`) → `chrome.scripting.executeScript({injectImmediately:true})` → re-ping; dedupe in-flight injections; call from `triggerVisualEffect`; delete dead `ensureVisualEffectsInitialized` (§3.5)
+- [ ] **T20** Overlay self-heal: `MutationObserver` on `documentElement` remounts shadow host; dataset marker to detect impostors (§3.5)
+- [ ] **T21** (Optional) Cursor arrival handshake: sequence-numbered move → `AGENT_CURSOR_ARRIVED` ack with ~1.5s cap before dispatching click (§3.5)
+
+## PR-4: OOPIF (P2)
+
+- [ ] **T22** Registry target attachment: enumerate iframe targets, attach `{targetId}`, maintain `targetId → tabId` cleanup map (§3.7)
+- [ ] **T23** Snapshot grafting: run DOM/a11y/DOMSnapshot per OOPIF target; graft under owner `<iframe>` VirtualNode; `FrameRegistry` gains `targetId` (§3.7)
+- [ ] **T24** Route actions per-target; translate OOPIF-relative input coordinates via parent-frame iframe quad (§3.7)
+- [ ] **T25** Replace `MAX_IFRAMES=5` count cap with serializer byte budget (§3.7)
+
+## Ride-along hardening (§3.10)
+
+- [ ] **T26** Defer `chrome.runtime.reload()` on pending update until no active session
+- [ ] **T27** Persist `extensionInstanceId` UUID at install; attach to session metadata
+- [ ] **T28** Typed error codes at throw sites; remove string-sniffing mapper in `DOMTool.handleError`
+- [ ] **T29** Shared `withTimeout(promise, ms, fallback?)` utility; replace ad-hoc `setTimeout` races

--- a/.ai_design/improve_webtool_from_codex/tasks.md
+++ b/.ai_design/improve_webtool_from_codex/tasks.md
@@ -1,60 +1,70 @@
 # Tasks — Improve web-operation tools from Codex extension learnings
 
-See `design.md` for full technical detail. Section references (§) point there.
+See `design.md` (v2, reviewed) for full technical detail. Section references (§) point there; interface contracts in §7 are authoritative.
 
 ## PR-1: Debugger + input correctness (P0)
 
-- [ ] **T01** Create `src/extension/tools/browser/DebuggerSessionRegistry.ts` (§3.1)
-  - [ ] Per-tab async mutex (`withTabLock`) serializing attach/detach
-  - [ ] Refcounted `acquire(tabId) → DebuggerHandle` / `handle.release()`; detach at refcount 0
-  - [ ] Single global `chrome.debugger.onEvent` / `onDetach` listeners; dispatch by `source.tabId`
-  - [ ] Idempotent attach; tolerate "already attached" only for registry-owned tabs; keep `ALREADY_ATTACHED` DevTools-conflict error
-  - [ ] Per-tab `enabledDomains` set; `ensureDomain(tabId, domain)`
-  - [ ] Force-detach path (clear registry first, ignore detach errors)
-  - [ ] Unit tests: concurrent acquire, release-while-in-flight, onDetach reconciliation
-- [ ] **T02** Add per-command timeout to `ChromeDebuggerClient.sendCommand` (§3.2)
-  - [ ] `timeoutMs` param, default 10s; typed `CdpCommandTimeoutError`
-  - [ ] On timeout: mark tab wedged in registry → force-detach → next acquire re-attaches
-  - [ ] Longer budgets for `Accessibility.getFullAXTree`, `DOMSnapshot.captureSnapshot`
-- [ ] **T03** Port `DomService`, `ScreenshotService`, `CoordinateActionService`, `ExtensionBrowserController` onto the registry; delete both `Runtime.evaluate('1+1')` attach probes (§3.1)
-- [ ] **T04** Create `src/extension/tools/input/keyDefinitions.ts` — US-layout key table (`key → {code, keyCode, text?, location?}`) (§3.4)
-- [ ] **T05** Create `src/extension/tools/input/InputDispatcher.ts` (§3.4)
-  - [ ] `dispatchKey` with correct `code`, `windowsVirtualKeyCode`, `text` for printables
-  - [ ] `click` sequence: `mouseMoved` → `mousePressed` → `mouseReleased`, `buttons` bitmask, clickCount, button param
-  - [ ] Replace bespoke dispatch in `DomService.click/keypress`, `CoordinateActionService.*`
-- [ ] **T06** Plumb `ClickOptions` from `DOMTool.executeClick` into `DomService.click` (button, clickCount) (§3.4)
-- [ ] **T07** Replace `DOM.getBoxModel` targeting with `DOM.getContentQuads` + viewport-intersection visibility check; config-flag fallback to old path; removes `SVG_CLICK_NOT_SUPPORTED` carve-out (§3.4)
+- [ ] **T01** Create `DebuggerSessionRegistry` per §7.1 — interface in `src/core/tools/browser/`, singleton impl `ChromeDebuggerSessionRegistry` in `src/extension/tools/browser/` (§3.1)
+  - [ ] Per-tab async mutex serializing attach/detach
+  - [ ] Refcounted `acquire(tabId) → DebuggerHandle` / `handle.release()`; detach at refcount 0; `release()` never throws
+  - [ ] ONE global `chrome.debugger.onEvent`/`onDetach` listener pair; dispatch by `source.tabId`
+  - [ ] Idempotent attach; `ALREADY_ATTACHED` thrown only for foreign (DevTools) attachment
+  - [ ] Per-tab `enabledDomains` set; `ensureDomain` sends `.enable` once
+  - [ ] `forceDetach` (clear state first, ignore detach errors)
+  - [ ] Unit tests: concurrent acquire, release-at-zero only, onDetach reconciliation, single-listener assertion
+- [ ] **T02** Per-command timeout in `sendCommand` (default 10s, typed `CdpCommandTimeoutError`); timeout → `forceDetach` → clean re-attach on next acquire; longer budgets for `Accessibility.getFullAXTree` / `DOMSnapshot.captureSnapshot` (§3.2)
+- [ ] **T03** Migrate callers to the registry (§3.1, §1.5):
+  - [ ] `DomService` (`ChromeDebuggerClient` becomes thin adapter over `DebuggerHandle`)
+  - [ ] `ScreenshotService` + `CoordinateActionService` — **both** trees (`src/extension/tools/screenshot/` AND `src/tools/screenshot/`); delete both `Runtime.evaluate('1+1')` probes; `PageVisionTool` releases handles per action
+  - [ ] Mark `ExtensionBrowserController` `@deprecated` (dormant — do not rewire)
+- [ ] **T04** `src/extension/tools/input/keyDefinitions.ts` — US-layout table per §7.2 (`key → {code, keyCode, text?, location?}`) + unit tests (Enter/Tab/Arrow/letters/digits/modifiers)
+- [ ] **T05** `src/extension/tools/input/InputDispatcher.ts` per §7.2 (§3.4)
+  - [ ] `dispatchKey`: correct `code`, `windowsVirtualKeyCode`, `text` for printables; `rawKeyDown` rule
+  - [ ] `click`: `mouseMoved` → `mousePressed` → `mouseReleased`, `buttons` bitmask, button/clickCount params
+  - [ ] Replace bespoke dispatch in `DomService.click/keypress` and `CoordinateActionService.*`
+- [ ] **T06** Plumb `ClickOptions` from `DOMTool.executeClick` → `DomService.click` (button, clickCount) (§3.4)
+- [ ] **T07** `DOM.getContentQuads` targeting + viewport-intersection visibility (no scroll offsets); `useContentQuads` ServiceConfig flag with `getBoxModel` fallback; removes `SVG_CLICK_NOT_SUPPORTED` carve-out and the spurious-scroll path (§3.4, §1.5)
+- [ ] **T08** **Vision DPR hotfix**: capture screenshots at CSS-pixel scale (`Page.captureScreenshot` with `clip.scale = 1/devicePixelRatio`), both ScreenshotService trees (§3.3, §1.5)
+
+**Acceptance (§5.1):** no tool-surface changes; DPR-2 vision click lands correctly; keypress Enter submits a real form; concurrent `browser_dom`+`page_vision` don't race attach; one debugger event listener process-wide.
 
 ## PR-2: Viewport, leases, readiness (P1)
 
-- [ ] **T08** `ViewportOverrideService`: `Emulation.setDeviceMetricsOverride({deviceScaleFactor:1, mobile:false})` at acquire (defaulting to current CSS viewport size), `clearDeviceMetricsOverride` at release (§3.3)
-- [ ] **T09** Simplify DPR handling in `DomService.buildLayoutMap` and `ScreenshotService` once DPR=1 is guaranteed; keep fallback path (§3.3)
-- [ ] **T10** New `browser_viewport` agent tool (`set WxH` / `reset`) with reset-before-finishing prompt guidance (§3.3)
-- [ ] **T11** `TabLeaseStore` on `chrome.storage.session`: claim/release with `origin: agent|user`; reject cross-session claims and `chrome://` (§3.6)
-- [ ] **T12** Per-session `lifecycleQueue` serializing claim/finalize/cleanup (§3.6)
-- [ ] **T13** `finalizeSession(keep?)` turn-end hook: detach all leased-tab debuggers, close unkept agent-origin tabs, release user leases; stale-lease GC at session start (§3.6)
-- [ ] **T14** `PageReadiness` helper on `Page.setLifecycleEventsEnabled`; `waitFor(until: load|DOMContentLoaded|networkAlmostIdle|networkIdle)` (§3.8)
-- [ ] **T15** `NavigationTool`: `chrome.tabs.update`+poll → `Page.navigate` + `waitFor`; keep poll as no-debugger fallback (§3.8)
-- [ ] **T16** `DomService.waitForPageLoad`: lifecycle-event wait + single content check; heuristic loop only as fallback (§3.8)
-- [ ] **T17** Handle `Page.javascriptDialogOpening` (auto-dismiss or surface to agent) (§3.8)
+- [ ] **T09** `ViewportOverrideService`: `Emulation.setDeviceMetricsOverride({deviceScaleFactor:1, mobile:false})`, default size = tab's current CSS viewport; `clearDeviceMetricsOverride` on release. Applied ONLY in `page_vision` flows + explicit tool use — never on user-bound tabs otherwise (§3.3, §1.5)
+- [ ] **T10** Simplify DPR division in `DomService.buildLayoutMap` when override active; keep fallback (§3.3)
+- [ ] **T11** `browser_viewport` tool (`set WxH` / `reset`) registered in `registerExtensionTools.ts`; reset-before-finishing prompt guidance (§3.3)
+- [ ] **T12** `TabLeaseStore` per §7.4 on `chrome.storage.session`; claim/release wired into `Session.setTabId` (Session.ts:1081), cleanup (Session.ts:995), `abortTasksForTab` (Session.ts:2310); reject cross-session claims + `chrome://` (§3.6, §1.5)
+- [ ] **T13** Per-session `lifecycleQueue` serializing claim/release/cleanup (§3.6)
+- [ ] **T14** Stale-lease GC at service-worker start + session start (§3.6)
+- [ ] **T15** `PageReadiness` per §7.3 (`Page.setLifecycleEventsEnabled`, loaderId-correlated waits) (§3.8)
+- [ ] **T16** `NavigationTool`: `chrome.tabs.update`+poll → `Page.navigate` + `waitFor`; keep poll as no-debugger fallback (§3.8)
+- [ ] **T17** `DomService.waitForPageLoad`: `waitFor('networkAlmostIdle', {timeoutMs: 8000, failOpen: true})` + single content check; heuristic loop only as fallback (`useLifecycleReadiness` config) (§3.8)
+- [ ] **T18** Handle `Page.javascriptDialogOpening` (surface to agent / auto-respond) — fixes `confirm()` deadlock (§3.8)
+
+**Acceptance (§5.1):** viewport set/reset round-trips; lease invariants (rebind releases+detaches, SW restart leaves no orphans, cross-session bind rejected); navigation completes on `load` event; dialog no longer hangs the turn.
 
 ## PR-3: Downloads + overlay (P1/P2)
 
-- [ ] **T18** `DownloadWatcher` background module; `downloads` permission in `manifest.json`; emit started/completed/interrupted to session event bus; surface in tool results (§3.9)
-- [ ] **T19** `ensureContentScript(tabId)`: ping (`WORKX_PING`) → `chrome.scripting.executeScript({injectImmediately:true})` → re-ping; dedupe in-flight injections; call from `triggerVisualEffect`; delete dead `ensureVisualEffectsInitialized` (§3.5)
-- [ ] **T20** Overlay self-heal: `MutationObserver` on `documentElement` remounts shadow host; dataset marker to detect impostors (§3.5)
-- [ ] **T21** (Optional) Cursor arrival handshake: sequence-numbered move → `AGENT_CURSOR_ARRIVED` ack with ~1.5s cap before dispatching click (§3.5)
+- [ ] **T19** `DownloadWatcher` background module; `downloads` permission in `manifest.json`; emit started/completed/interrupted via existing session event path; surface in tool results (§3.9)
+- [ ] **T20** `ensureContentScript(tabId)`: ping (`WORKX_PING`) → `chrome.scripting.executeScript({injectImmediately:true})` → re-ping; dedupe in-flight injections; call from `triggerVisualEffect`; delete dead `ensureVisualEffectsInitialized` (DomService.ts:913-956) (§3.5)
+- [ ] **T21** Overlay self-heal: `MutationObserver` on `documentElement` remounts shadow host; dataset marker detects impostors (§3.5)
+- [ ] ~~Cursor arrival handshake~~ — deferred indefinitely (§1.5: no pre-click cursor animation exists to synchronize)
+
+**Acceptance (§5.1):** agent-clicked download reports filename+status; overlay survives `documentElement.replaceChildren()`; effects work on pre-install tabs.
 
 ## PR-4: OOPIF (P2)
 
-- [ ] **T22** Registry target attachment: enumerate iframe targets, attach `{targetId}`, maintain `targetId → tabId` cleanup map (§3.7)
-- [ ] **T23** Snapshot grafting: run DOM/a11y/DOMSnapshot per OOPIF target; graft under owner `<iframe>` VirtualNode; `FrameRegistry` gains `targetId` (§3.7)
-- [ ] **T24** Route actions per-target; translate OOPIF-relative input coordinates via parent-frame iframe quad (§3.7)
+- [ ] **T22** Registry target attachment: enumerate iframe targets, attach `{targetId}`, `targetId → tabId` cleanup map (§3.7)
+- [ ] **T23** Read-only first: per-target DOM/a11y/DOMSnapshot grafted under owner `<iframe>` VirtualNode; `FrameRegistry` gains `targetId` (§3.7, §1.5)
+- [ ] **T24** (After T23 proves stable in dogfood) per-target input routing; translate OOPIF-relative coordinates via parent-frame iframe quad (§3.7)
 - [ ] **T25** Replace `MAX_IFRAMES=5` count cap with serializer byte budget (§3.7)
+- [ ] **T26** Delete `ExtensionBrowserController` if still unused (§1.5)
+
+**Acceptance (§5.1):** cross-origin iframe elements appear in snapshots with frame-scoped node ids; no orphaned debugger state after detach.
 
 ## Ride-along hardening (§3.10)
 
-- [ ] **T26** Defer `chrome.runtime.reload()` on pending update until no active session
-- [ ] **T27** Persist `extensionInstanceId` UUID at install; attach to session metadata
-- [ ] **T28** Typed error codes at throw sites; remove string-sniffing mapper in `DOMTool.handleError`
-- [ ] **T29** Shared `withTimeout(promise, ms, fallback?)` utility; replace ad-hoc `setTimeout` races
+- [ ] **T27** Defer `chrome.runtime.reload()` on pending update until no active session
+- [ ] **T28** Persist `extensionInstanceId` UUID at install; attach to session metadata
+- [ ] **T29** Typed error codes at throw sites; remove string-sniffing mapper in `DOMTool.handleError` (DOMTool.ts:514-541)
+- [ ] **T30** Shared `withTimeout(promise, ms, fallback?)` utility; replace ad-hoc `setTimeout` races


### PR DESCRIPTION
## Summary

Deep technical comparison of how the **OpenAI Codex Chrome extension** (v1.1.5, deobfuscated store build) and **workx** operate browser tabs and page content, distilled into an implementation-ready design doc:

- `.ai_design/improve_webtool_from_codex/design.md` — full analysis with line-level references into both codebases
- `.ai_design/improve_webtool_from_codex/tasks.md` — phased task checklist (4 follow-up PRs, T01–T29)

## Key takeaways

Codex's extension is a thin CDP bridge (intelligence lives in their CLI), so our DOM-serialization/tooling layer has no counterpart there — but their extension is production-hardened exactly where we are weakest:

**P0 correctness gaps found in our stack:**
- Three uncoordinated `chrome.debugger` attach paths (DomService / ScreenshotService / CoordinateActionService) with racy `Runtime.evaluate('1+1')` probes and no detach — proposal: refcounted `DebuggerSessionRegistry` with per-tab locks (their pattern)
- No per-command CDP timeouts — a wedged renderer hangs the agent turn forever (they race every command vs 10s + force-detach)
- Keyboard dispatch sends invalid `code` values (`KeyENTER`) and no `windowsVirtualKeyCode` — many pages ignore our keypresses
- `browser_dom` click drops its documented `button`/options and dispatches without a `mouseMoved` precursor; coordinate-space bug in the in-viewport check on scrolled pages

**Capability gaps:** viewport emulation with `deviceScaleFactor: 1` (kills all DPR math + retina coordinate mismatch), tab leases + turn finalization semantics, lifecycle-event-based page readiness (replacing 100ms polls and 15s SPA heuristics), download tracking, overlay self-healing via MutationObserver, OOPIF target attachment.

## Method

Codex bundle prettified with js-beautify; all claims cross-verified by reading both sources (line refs throughout the doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)