### PR TITLE
chore: update repo references to workx after rename

### DIFF
--- a/.github/workflows/sync-to-private.yml
+++ b/.github/workflows/sync-to-private.yml
@@ -40,7 +40,7 @@ jobs:
 
           echo "Cloning private repository..."
           if ! git clone \
-            https://x-access-token:${{ secrets.OSS_SYNC_TO_PRIVATE }}@github.com/The-AI-Republic/private-pi.git \
+            https://x-access-token:${{ secrets.OSS_SYNC_TO_PRIVATE }}@github.com/The-AI-Republic/private-workx.git \
             private-repo; then
             echo "ERROR: Failed to clone private repository" >&2
             echo "Check that OSS_SYNC_TO_PRIVATE secret is set and valid" >&2

--- a/docs/AGGRESSIVE-OPEN-SOURCE-SYNC-DESIGN.md
+++ b/docs/AGGRESSIVE-OPEN-SOURCE-SYNC-DESIGN.md
@@ -124,7 +124,7 @@ jobs:
 
       - name: Clone public repo
         run: |
-          git clone https://x-access-token:${{ secrets.PRIVATE_SYNC_TO_OSS }}@github.com/The-AI-Republic/browserx.git public-repo
+          git clone https://x-access-token:${{ secrets.PRIVATE_SYNC_TO_OSS }}@github.com/The-AI-Republic/workx.git public-repo
           cd public-repo
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/src/core/queue/README.md
+++ b/src/core/queue/README.md
@@ -25,4 +25,4 @@ for rationale, API, and the explicit non-goals list.
 - Consecutive-prompt batching — requires a `workload` field on submissions.
 - `remove(uuid)` / `popAll(filter)` — no current call site needs them.
 - Persistent audit log — tracked in
-  [#215](https://github.com/The-AI-Republic/browserx/issues/215).
+  [#215](https://github.com/The-AI-Republic/workx/issues/215).

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -74,7 +74,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDUwNEQyMTEzQzc3OTI0MzEKUldReEpIbkhFeUZOVUZBa01rK0s1RVlvYXVFc0EzNExaK2loUFhhbVR3TGszUUwvcFBkRG84V1cK",
       "endpoints": [
-        "https://github.com/The-AI-Republic/browserx/releases/latest/download/latest.json"
+        "https://github.com/The-AI-Republic/workx/releases/latest/download/latest.json"
       ],
       "windows": {
         "installMode": "passive"


### PR DESCRIPTION
Follow-up to the `browserx` → `workx` / `private-browserx` → `private-workx` GitHub repo renames. Updates the in-repo URLs that still pointed at the old repo names.

## Changes
- `tauri/tauri.conf.json` — auto-updater endpoint → `/workx/` releases (was relying on GitHub's redirect)
- `docs/AGGRESSIVE-OPEN-SOURCE-SYNC-DESIGN.md` — clone URL → `/workx`
- `src/core/queue/README.md` — issue #215 link → `/workx`
- `.github/workflows/sync-to-private.yml` — **bug fix:** targeted `The-AI-Republic/private-pi`, which does not exist, so the OSS→private sync was broken. Now targets `private-workx`.

Archival docs under `specs/` and `.ai_design/` still reference `browserx`; left as-is per `docs/NAMING.md` (historical records).

🤖 Generated with [Claude Code](https://claude.com/claude-code)