### PR TITLE
feat(app-server): desktop app-server mode

### DIFF
--- a/.ai_design/app_server_mode/design.md
+++ b/.ai_design/app_server_mode/design.md
@@ -1,0 +1,1407 @@
+# WorkX App-Server Mode Design
+
+Status: Ready for implementation
+Date: 2026-06-02
+
+## Goal
+
+Enable one installed WorkX desktop app to serve both roles:
+
+1. Normal interactive UI app.
+2. Local callable app-server that another process, program, script, or agent can call.
+
+The first production target is local machine automation through a loopback WebSocket endpoint exposed by the desktop runtime sidecar. The design should also keep the headless server path functional and make future Unix socket/named pipe support straightforward.
+
+## Non-goals
+
+- Do not implement A2A server mode as part of this work. `src/core/a2a/A2AServer.ts` remains separate.
+- Do not use the stale desktop WebSocket path in `src/desktop/channels/WebSocketChannel.ts` and `src/desktop/channels/websocket/WebSocketServer.ts`.
+- Do not move runtime ownership from the Node sidecar to Rust/Tauri.
+- Do not build a second agent process just for app-server mode.
+- Do not replace the current `@workx/ws-server` protocol in the MVP.
+
+## Executive Summary
+
+WorkX already has most of the server-mode pieces:
+
+- A headless WebSocket/HTTP server in `src/server/index.ts`.
+- A typed protocol package in `packages/ws-server`.
+- Server handlers for chat, sessions, config, credentials, approvals, tools, logs, and health.
+- A shared runtime bootstrap in `src/server/agent/ServerAgentBootstrap.ts`.
+- A desktop Node sidecar in `src/desktop-runtime`.
+- A channel abstraction that already supports multiple channel types through `ChannelManager`.
+
+The main gap is that the desktop runtime currently registers one channel only: `StdioRuntimeChannel`, which talks to the Tauri UI. App-server mode should add a second runtime channel inside the same Node sidecar. That channel should expose the existing server protocol over a local WebSocket listener and submit work through the same `ChannelManager` and agent runtime.
+
+The most important implementation change is to make `ServerAgentBootstrap` multi-channel capable. Once the bootstrap can register more than one `ChannelAdapter`, the desktop app can keep the UI channel and add an app-server channel without creating a second agent runtime.
+
+Codex's app-server implementation provides the stability lessons WorkX should copy:
+
+- Explicit initialize/connect handshake per connection.
+- Strong local transport security: reject browser `Origin` requests and require auth for non-loopback.
+- Bounded queues and overload errors instead of unbounded task spawning.
+- Slow-consumer protection.
+- Per-connection state and disconnect cleanup.
+- Request serialization by resource, so conflicting mutations do not race.
+- A connection RPC gate so queued requests do not start after a connection closes.
+- Health and readiness endpoints.
+- Tests that verify per-connection isolation and shutdown behavior.
+
+## Current WorkX Architecture
+
+### Headless Server
+
+Current server mode exists as a standalone Node entrypoint:
+
+- `src/server/index.ts`
+- `src/server/config/server-config.ts`
+- `src/server/connection/handshake.ts`
+- `src/server/connection/rate-limiter.ts`
+- `src/server/connection/watchdog.ts`
+- `src/server/limits/resource-limits.ts`
+- `src/server/auth/authorize.ts`
+- `src/server/channels/ServerChannel.ts`
+- `src/server/handlers/*.ts`
+
+The server listens on WebSocket/HTTP and has a default documented port of `18100`. It already serves a `/health` endpoint and performs handshake, method dispatch, scope checks, rate limiting, and connection cleanup.
+
+The protocol lives in:
+
+- `packages/ws-server/src/frames.ts`
+- `packages/ws-server/src/methods.ts`
+- `packages/ws-server/src/errors.ts`
+
+Important protocol facts:
+
+- `PROTOCOL_VERSION = 1`.
+- Server starts with `connect.challenge`.
+- Client sends `connect`.
+- Server replies with `hello-ok` (the wire/schema value is `hello-ok`, not `hello.ok`; see `packages/ws-server/src/frames.ts:203`).
+- Method registry includes:
+  - `chat.send`
+  - `chat.abort`
+  - `chat.history`
+  - `chat.inject`
+  - `sessions.list`
+  - `sessions.get`
+  - `sessions.patch`
+  - `sessions.reset`
+  - `sessions.delete`
+  - `sessions.compact`
+  - `sessions.turns`
+  - `sessions.rewind`
+  - `config.get`
+  - `config.set`
+  - `config.patch`
+  - `health`
+  - `tools.catalog`
+  - `logs.tail`
+  - `credentials.list`
+  - `credentials.set`
+  - `credentials.delete`
+  - `exec.approval.resolve`
+
+This is enough protocol surface to make app-server mode useful immediately.
+
+### Desktop Runtime
+
+The desktop app already runs the agent in a Node sidecar:
+
+- `src/desktop-runtime/index.ts`
+- `src/desktop-runtime/WorkXRuntimeBootstrap.ts`
+- `src/desktop-runtime/channels/StdioRuntimeChannel.ts`
+- `src/desktop-runtime/protocol/stdioCarrier.ts`
+- `src/desktop-runtime/protocol/controlBridge.ts`
+- `src/desktop-runtime/host.ts`
+- `tauri/src/runtime_supervisor.rs`
+
+Rust/Tauri supervises the sidecar process, sends length-prefixed JSON frames over stdio, and relays runtime events to the web UI.
+
+`WorkXRuntimeBootstrap` is a desktop specialization of `ServerAgentBootstrap`. It passes a `StdioRuntimeChannel` into the shared bootstrap.
+
+### Shared Bootstrap Gap
+
+`src/server/agent/ServerAgentBootstrap.ts` currently stores a single channel:
+
+```ts
+private channel: ChannelAdapter | null = null;
+```
+
+During initialization it does:
+
+```ts
+this.channel = this.options.channel ?? new ServerChannel();
+channelManager.registerChannel(this.channel);
+```
+
+Its event dispatcher sends every agent event only to that one channel:
+
+```ts
+channelManager.dispatchEvent(
+  { msg: event.msg, sessionId },
+  this.channel!.channelId
+);
+```
+
+This is the core reason an installed WorkX app cannot yet behave as both UI and app-server through the same runtime. The runtime is structurally single-channel even though `ChannelManager` already supports multiple channels.
+
+### Stale Desktop WebSocket Path
+
+Do not build on these files:
+
+- `src/desktop/channels/WebSocketChannel.ts`
+- `src/desktop/channels/websocket/WebSocketServer.ts`
+
+That path uses old `user_turn`/`assistant_chunk` style events and invokes Tauri commands such as `ws_server_start`, `ws_send`, `ws_server_stop`, and `ws_disconnect` that are not present in the current Rust runtime. It is not aligned with `packages/ws-server` or the desktop sidecar architecture.
+
+## Current Codex App-Server Architecture
+
+Codex app-server lives across these crates:
+
+- `/home/rich/dev/study/codex/codex-rs/app-server`
+- `/home/rich/dev/study/codex/codex-rs/app-server-protocol`
+- `/home/rich/dev/study/codex/codex-rs/app-server-transport`
+- `/home/rich/dev/study/codex/codex-rs/app-server-client`
+- `/home/rich/dev/study/codex/codex-rs/app-server-daemon`
+- `/home/rich/dev/study/codex/codex-rs/app-server-test-client`
+
+Codex uses JSON-RPC 2.0 semantics without the `"jsonrpc": "2.0"` field on the wire. It supports stdio by default, Unix sockets, experimental WebSocket, and off mode.
+
+Key implementation patterns to copy:
+
+### Transport Abstraction
+
+`codex-rs/app-server-transport/src/transport/mod.rs` defines transport events:
+
+- `ConnectionOpened`
+- `ConnectionClosed`
+- `IncomingMessage`
+
+Transport code only accepts bytes/connections and forwards normalized events to the processor. The processor owns protocol behavior.
+
+WorkX should copy the separation:
+
+- WebSocket listener accepts and authenticates connections.
+- Connection registry tracks authenticated clients.
+- Request processor validates frames and dispatches methods.
+- Channel submits work to the agent runtime.
+
+### Bounded Queues
+
+Codex uses bounded channels with `CHANNEL_CAPACITY = 128`.
+
+If inbound request queues are full, Codex returns JSON-RPC error code `-32001` with message `Server overloaded; retry later.`
+
+WorkX should add an equivalent overload path in `packages/ws-server/src/errors.ts` and never let an external caller create an unbounded queue of work.
+
+### Origin Rejection
+
+Codex's WebSocket transport rejects any HTTP request with an `Origin` header. This prevents random browser pages from calling a local app-server through loopback.
+
+WorkX app-server mode should reject `Origin` by default. Browser-origin access should require an explicit allowlist later, not be enabled by accident.
+
+### Auth Policy
+
+Codex refuses unauthenticated non-loopback WebSocket listeners. It also supports capability-token and signed-bearer-token auth modes.
+
+WorkX MVP should:
+
+- Bind only to `127.0.0.1` by default.
+- Require a generated capability token for app-server mode.
+- Keep LAN binding disabled by default.
+- Require explicit config to bind anywhere other than loopback.
+
+### Per-Connection State
+
+Codex tracks initialized state, experimental API state, opt-out notification methods, client info, and outbound writer state per connection.
+
+WorkX already tracks connection metadata in the server path. Desktop app-server mode should use the same concept and avoid global connection flags.
+
+### Slow Consumer Protection
+
+Codex's outbound router disconnects slow connections when the outbound queue is saturated.
+
+WorkX should enforce:
+
+- Maximum WebSocket `bufferedAmount`.
+- Maximum per-connection outbound queue length.
+- Close slow clients with a protocol close code.
+
+### Request Serialization
+
+Codex serializes requests by resource key. Mutating requests against the same thread/process/config resource are exclusive. Non-conflicting reads can run in parallel.
+
+WorkX should introduce the same idea before exposing desktop app-server mode broadly. At minimum:
+
+- Chat mutation requests for the same session are serialized.
+- Config and credential writes are serialized globally.
+- Session mutations for the same session are serialized.
+- Health and read-only queries can run concurrently.
+
+### Connection RPC Gate
+
+Codex has a `ConnectionRpcGate` that prevents queued handlers from starting after a connection closes while allowing in-flight handlers to finish.
+
+WorkX needs this because a local tool may disconnect while a request is queued. The server must not start the queued request later with no active requester.
+
+### In-Process Mode
+
+Codex's `in_process.rs` keeps app-server semantics but removes socket transport. This is important conceptually for WorkX: app-server behavior is an API surface, not just a WebSocket listener.
+
+WorkX desktop app-server should run in-process inside the same Node runtime sidecar. The WebSocket transport is just one caller transport.
+
+## Target Architecture
+
+```text
+                Installed WorkX desktop app
+
+  Web UI <-> Tauri runtime_supervisor <-> Node sidecar process
+                                            |
+                                            v
+                               WorkXRuntimeBootstrap
+                                            |
+                                            v
+                                  ChannelManager
+                                  /            \
+                                 /              \
+                                v                v
+                StdioRuntimeChannel       AppServerChannel
+                channelId:                channelId:
+                desktop-runtime-main      desktop-app-server
+                channelType: tauri        channelType: websocket
+                       |                         ^
+                       v                         |
+                Tauri UI events          WebSocket listener
+                                         ws://127.0.0.1:18101
+                                         /readyz, /healthz, /health
+```
+
+The agent runtime remains single. Only the caller channels multiply.
+
+## Core Decisions
+
+### 1. The Listener Lives In The Node Sidecar
+
+The app-server listener should be started from `src/desktop-runtime/index.ts` after the runtime bootstrap is initialized.
+
+Reasons:
+
+- The Node sidecar already owns the agent runtime.
+- The sidecar already has `ChannelManager`, services, config, sessions, and tools.
+- Rust/Tauri already supervises sidecar lifecycle.
+- Starting a second standalone `src/server/index.ts` process would duplicate the agent runtime and create session/config contention.
+
+### 2. Reuse The Existing Protocol For MVP
+
+Use `packages/ws-server` protocol v1 for the first implementation.
+
+Reasons:
+
+- The protocol already has connect challenge, method registry, scopes, events, and errors.
+- The existing server handlers can be reused.
+- Existing headless server clients stay compatible.
+
+Future API cleanup can introduce a v2 protocol with resource/method names closer to Codex, for example `thread/start` and `turn/start`. That should not block the MVP.
+
+### 3. Add Multi-Channel Runtime Support
+
+`ServerAgentBootstrap` should support more than one registered channel.
+
+Minimal API:
+
+```ts
+export interface ServerAgentBootstrapOptions {
+  profile?: ServerAgentProfile;
+  dataDir?: string;
+  channel?: ChannelAdapter;
+  channels?: ChannelAdapter[];
+}
+
+export class ServerAgentBootstrap {
+  async registerChannel(channel: ChannelAdapter): Promise<void>;
+  async unregisterChannel(channelId: string): Promise<void>;
+}
+```
+
+Implementation guidance:
+
+- Preserve `channel` for backward compatibility.
+- Treat `channel` as the primary channel.
+- Register `channels` during `initialize()`.
+- Allow additional channels to be registered after initialization.
+- Keep `ChannelManager` as the single router.
+
+### 4. Keep App-Server Disabled By Default
+
+Installed app-server mode is powerful. The default desktop app behavior should be no listening socket unless enabled by config or explicit UI setting.
+
+Default config:
+
+```ts
+appServer: {
+  enabled: false,
+  transport: 'websocket',
+  bindHost: '127.0.0.1',
+  port: 18101,
+  requireAuth: true,
+  rejectBrowserOrigins: true,
+  allowLan: false,
+  maxConnections: 16,
+  maxPayloadBytes: 1_048_576,
+  maxBufferedBytes: 4_194_304,
+  requestQueueCapacity: 128,
+}
+```
+
+Port `18101` avoids colliding with the existing headless server default of `18100`.
+
+### 5. Require Capability Token Auth
+
+Even on loopback, a generated token should be required for app-server mode. Loopback alone is not enough when browsers, local malware, or unrelated developer tools can reach local ports.
+
+Token storage:
+
+- Prefer the desktop keychain through the existing runtime control bridge (`controlBridge.keychain.get/set/delete` is available).
+- Fall back to the desktop runtime data directory only if keychain is unavailable. The fallback file must be written with `0600` permissions, and the UI must surface a warning that secure (keychain) storage is unavailable, because a local process that can read this file gains the connection's full scope set.
+- Never print the token in normal logs.
+- Provide an explicit UI/service action to rotate or reveal/copy the token.
+
+Layering constraint: `AppServerAuth` lives in the host-agnostic `src/app-server/connection/` layer, so it must accept an **injected token provider/store** (interface) rather than importing the desktop control bridge directly. `DesktopAppServerManager` constructs the keychain-backed token store and injects it. This keeps `src/app-server/` reusable for the later headless migration.
+
+Capability-token role/scope mapping (Phase 1): the design must specify which role/scopes a capability-token connection receives — this is currently unspecified, and the existing default is dangerous. `resolveScopes(role, requested)` grants the **full role defaults** when the client requests no scopes (`src/server/auth/roles.ts:63-71`), and the `operator` role defaults include `config.write`, `credentials.read`, `credentials.write`, and `admin` (`roles.ts:20-35`). If a capability-token connection is treated as `operator` with no requested scopes, it silently gets full credential and config write access. Phase 1 must therefore either map the capability token to a narrow role or require an explicit reduced scope set by default, with credential/config-write scopes opt-in. Broad per-client scope configuration remains Phase 2.
+
+Handshake:
+
+- Continue using `connect.challenge` and `connect`.
+- A `'token'` auth mode already exists with constant-time verification (`src/server/connection/auth.ts:16` defines `AuthMode = 'none' | 'token' | 'password' | 'trusted-proxy'`; `verifyToken()` at `auth.ts:50-94` does the constant-time compare; the token arrives via `req.params.auth` at `handshake.ts:191`). **Decision needed:** either reuse the existing `'token'` mode for app-server (smaller change, the constant-time-compare task is already satisfied) or add a distinct `'capability-token'` variant if per-capability semantics are wanted. The challenge currently advertises a single mode (`authModes: [config.server.auth.mode]`, `handshake.ts:101`); the app-server transport must source its mode from `IAppServerConfig`, not `config.server.auth`.
+- Bind the authenticated identity to connection state.
+
+### 6. Reject Browser Origins
+
+For desktop app-server mode:
+
+- Reject any HTTP/WebSocket upgrade request with an `Origin` header by default.
+- Return `403`.
+- Do not accept browser-origin local calls unless an explicit allowlist is added later.
+
+This is a direct Codex lesson and should be part of Phase 1, not deferred.
+
+### 7. Do Not Crash The App On App-Server Failure
+
+If app-server mode fails to start because the port is already in use, auth config is invalid, or TLS/keychain setup fails:
+
+- The desktop UI and agent runtime should continue running.
+- Runtime status should report `appServer.status = 'error'`.
+- The error should be visible in settings/logs.
+- A restart action should retry the listener.
+
+## New Module Layout
+
+Create a reusable app-server layer instead of copying all of `src/server/index.ts` into desktop runtime.
+
+Recommended layout:
+
+```text
+src/app-server/
+  AppServerManager.ts
+  AppServerChannel.ts
+  AppServerRequestProcessor.ts
+  AppServerConnectionRegistry.ts
+  appServerConfig.ts
+  connection/
+    AppServerAuth.ts
+    ConnectionRpcGate.ts
+    ConnectionWatchdog.ts
+    rateLimiter.ts
+  transport/
+    AppServerWebSocketTransport.ts
+    httpHealth.ts
+  queue/
+    RequestQueue.ts
+    requestSerialization.ts
+  status/
+    AppServerStatus.ts
+```
+
+Responsibility boundary between the two managers (define this explicitly to avoid duplicated logic):
+
+- `AppServerManager` (in `src/app-server/`) is **host-agnostic**. It owns the transport, request processor, connection registry, request scheduler, and status controller. It accepts its config and an `AppServerAuthProvider` as injected dependencies and knows nothing about the desktop control bridge, keychain, or Tauri.
+- `DesktopAppServerManager` (in `src/desktop-runtime/`) does **only desktop wiring**: read `IAgentConfig.appServer`, obtain/rotate the capability token via the control-bridge keychain, build the desktop `AppServerAuth`, construct an `AppServerManager` with those deps, register the `AppServerChannel` on the bootstrap, and publish status to runtime services.
+
+The same `AppServerManager` is what a later headless migration reuses.
+
+Desktop integration:
+
+```text
+src/desktop-runtime/app-server/
+  DesktopAppServerManager.ts
+```
+
+Headless integration can be migrated later:
+
+```text
+src/server/index.ts
+  imports reusable app-server transport/processor modules
+```
+
+Do not make the first implementation depend on headless refactor completion. The desktop app-server can use the new reusable layer first, then headless server can be migrated to the same layer in a later cleanup.
+
+## Config Design
+
+Add config types in `src/config/types.ts`:
+
+```ts
+export type AppServerTransport = 'websocket';
+
+export interface IAppServerConfig {
+  enabled: boolean;
+  transport: AppServerTransport;
+  bindHost: string;
+  port: number;
+  requireAuth: boolean;
+  rejectBrowserOrigins: boolean;
+  allowLan: boolean;
+  maxConnections: number;
+  maxPayloadBytes: number;
+  maxBufferedBytes: number;
+  requestQueueCapacity: number;
+}
+
+export interface IAgentConfig {
+  // existing fields
+  appServer?: IAppServerConfig;
+}
+```
+
+Add defaults in `src/config/defaults.ts`.
+
+Add validation in `src/config/configSchema.ts`. This file uses Zod plus per-field `llm_access` metadata organized by `SECTIONS`. The new `appServer` fields must be added as a new section with `llm_access` set to **no LLM write access** (the agent must not be able to enable its own server or change its bind/auth settings); read access can also be withheld to avoid exposing the token surface. Validation rules:
+
+- `enabled`: boolean.
+- `transport`: only `'websocket'` for MVP.
+- `bindHost`: default `127.0.0.1`.
+- `port`: integer `0..65535`; `0` allowed only if UI can show assigned port.
+- `requireAuth`: boolean. There is no development-override field in `IAppServerConfig`; either add an explicit `devAllowNoAuth?: boolean` field guarded by a dev build flag, or drop the "unless development override" caveat. Do not silently treat `false` as valid in production.
+- `rejectBrowserOrigins`: boolean; default true.
+- `allowLan`: boolean; if false, reject non-loopback bind hosts.
+- `maxConnections`: integer `1..256`.
+- `maxPayloadBytes`: integer `1024..67108864`.
+- `maxBufferedBytes`: integer `65536..67108864`.
+- `requestQueueCapacity`: integer `1..4096`.
+
+Desktop app-server must not use `src/server/config/server-config.ts`. That file is for the standalone server environment variables and `.workx-server/config.json`.
+
+## Runtime Status And Services
+
+Expose app-server status through runtime services so the UI can render status and control it.
+
+Extend `src/core/services/runtime-services.ts`:
+
+```ts
+runtime.getStateSnapshot -> {
+  // existing fields
+  appServer: {
+    enabled: boolean;
+    status: 'disabled' | 'starting' | 'ready' | 'error' | 'stopping';
+    url?: string;
+    bindHost?: string;
+    port?: number;
+    authMode?: 'capability-token';
+    connections: number;
+    lastError?: string;
+  };
+}
+```
+
+Add service handlers:
+
+```text
+appServer.getStatus
+appServer.setConfig
+appServer.restart
+appServer.stop
+appServer.rotateToken
+```
+
+These services are for UI control only. External WebSocket clients should use protocol methods from `packages/ws-server`.
+
+## Bootstrap Implementation
+
+### Step 1: Make Bootstrap Multi-Channel
+
+Modify `src/server/agent/ServerAgentBootstrap.ts`:
+
+```ts
+private channels = new Map<string, ChannelAdapter>();
+private primaryChannelId: string | null = null;
+```
+
+During initialize:
+
+```ts
+const initialChannels = [
+  ...(this.options.channel ? [this.options.channel] : []),
+  ...(this.options.channels ?? []),
+];
+
+const channels = initialChannels.length > 0
+  ? initialChannels
+  : [new ServerChannel()];
+
+for (const channel of channels) {
+  await this.registerChannel(channel);
+}
+this.primaryChannelId = channels[0]?.channelId ?? null;
+```
+
+Add:
+
+```ts
+async registerChannel(channel: ChannelAdapter): Promise<void> {
+  if (!this.initializedChannelManager) {
+    // store for initialize or throw depending on implementation choice
+  }
+  this.channelManager.registerChannel(channel);
+  this.channels.set(channel.channelId, channel);
+}
+```
+
+Also add `unregisterChannel` if `ChannelManager` does not already support it. If unregister support is absent, implement it in `src/core/channels/ChannelManager.ts`.
+
+### Step 2: Event Dispatch
+
+Current code dispatches only to `this.channel!.channelId`. Replace that with multi-channel dispatch.
+
+A naive `broadcastEvent` is **not** safe for Phase 1. Verified current behavior makes this a correctness/security gap, not a cosmetic one:
+
+- `channelManager.broadcastEvent(...)` sends to every registered channel (`ChannelManager.ts:119`).
+- `StdioRuntimeChannel.sendEvent` forwards every event unfiltered to the Tauri UI; it does not inspect `sessionId` (`StdioRuntimeChannel.ts:43-45`).
+- `ServerChannel.sendEvent` filters by **scope only**, never by session (`ServerChannel.ts:105-106`; `authorize.ts:75-93` ignores `sessionId`). `ChannelEvent` carries only `{ msg, sessionId? }` (`core/channels/types.ts:17-22`).
+
+So a plain broadcast leaks every external session's events into the desktop UI, and leaks one app-server client's session events to every other connected client. Phase 1 integration test #9 ("streams events only to authorized/subscribed clients") cannot pass under a plain broadcast.
+
+**Therefore session→channel ownership routing and per-connection session-subscription filtering are Phase 1, not Phase 2.** Minimum required in Phase 1:
+
+- Record the owning channel for each session when it is created (the existing per-session `eventDispatcherFactory(sessionId)` already runs in the owning context — route on that instead of broadcasting to all channels).
+- `AppServerChannel.sendEvent()` filters by authenticated connection, event scope, and session subscription/ownership before sending.
+- The UI `StdioRuntimeChannel` must not receive events for sessions owned by app-server connections (and vice versa) beyond global runtime-status events.
+
+The Phase 2 work is then only the richer router below and run-level (`runId`) ownership refinement, not basic session isolation.
+
+Preferred Phase 2 router (refinement on top of the Phase 1 ownership map):
+
+```ts
+interface ChannelEventRouter {
+  registerSessionOwner(sessionKey: string, channelId: string): void;
+  dispatchAgentEvent(event: AgentEvent, sessionId: string): Promise<void>;
+}
+```
+
+Routing rule:
+
+- Send to the originating channel.
+- Send to UI channel only if UI is observing that session or global runtime status should update.
+- Send to app-server connections only if subscribed and authorized.
+
+## AppServerChannel
+
+Create `src/app-server/AppServerChannel.ts`.
+
+It should implement `ChannelAdapter` and be a cleaned-up desktop-compatible version of `src/server/channels/ServerChannel.ts`.
+
+Required behavior:
+
+- `channelId = 'desktop-app-server'` by default.
+- `channelType = 'websocket'`.
+- Accept an injected connection registry.
+- Accept an injected request processor.
+- Send events to authenticated connections only.
+- Apply event scope filtering.
+- Apply session/run subscription filtering.
+- Track active requests by connection and session.
+- On connection close, cancel/mark queued requests for that connection.
+
+Do not hardcode `server-main`.
+
+Current handler issue:
+
+`src/server/handlers/chat.ts` builds context with:
+
+```ts
+channelId: 'server-main',
+channelType: 'server',
+sessionId: ctx.sessionKey,
+```
+
+Change method context so handlers can use the caller channel. This must be an **additive** change to the existing `MethodContext` in `packages/ws-server/src/methods.ts` — do not drop the current fields. The existing interface today is:
+
+```ts
+export interface MethodContext {
+  connectionId: string;
+  requestId: string;
+  role: string;
+  scopes: string[];
+  userId?: string;
+  sessionKey?: string;
+  sendEvent: (event: string, payload?: unknown) => void;
+}
+```
+
+Add only the two new fields, preserving the rest:
+
+```ts
+export interface MethodContext {
+  // ...all existing fields above...
+  channelId: string;
+  channelType: ChannelType;
+}
+```
+
+The dispatcher must populate `channelId`/`channelType` for **every** caller. For the headless server path these must default to `'server-main'`/`'server'` so existing headless behavior is preserved (otherwise the `chat.ts` change below is a headless regression).
+
+Then `chat.send` should use:
+
+```ts
+channelId: ctx.channelId,
+channelType: ctx.channelType,
+sessionId: ctx.sessionKey,
+```
+
+This is required for desktop app-server events to route through the right channel.
+
+## WebSocket Transport
+
+Create `src/app-server/transport/AppServerWebSocketTransport.ts`.
+
+It should contain reusable logic currently concentrated in `src/server/index.ts`:
+
+- HTTP server creation.
+- WebSocket upgrade handling.
+- `/readyz` endpoint.
+- `/healthz` endpoint.
+- `/health` endpoint for existing compatibility.
+- Origin rejection.
+- Payload limit.
+- Connection count limit.
+- Handshake timeout.
+- Rate limiter attachment.
+- Watchdog/heartbeat.
+- Slow consumer checks.
+- Graceful stop.
+
+Recommended public API:
+
+```ts
+export interface AppServerWebSocketTransportOptions {
+  host: string;
+  port: number;
+  maxConnections: number;
+  maxPayloadBytes: number;
+  maxBufferedBytes: number;
+  rejectBrowserOrigins: boolean;
+  auth: AppServerAuthProvider;
+  processor: AppServerRequestProcessor;
+  status: AppServerStatusController;
+}
+
+export class AppServerWebSocketTransport {
+  start(): Promise<AppServerListenInfo>;
+  stop(reason?: string): Promise<void>;
+}
+```
+
+If `port = 0`, return the assigned port in `AppServerListenInfo`.
+
+## Handshake And Auth
+
+Use the existing challenge/connect flow from `src/server/connection/handshake.ts`, but make it reusable for desktop app-server.
+
+MVP auth mode:
+
+```text
+capability-token
+```
+
+Token requirements:
+
+- Generated automatically on first enable.
+- Stored in keychain if available.
+- Scoped to the local desktop app installation.
+- Rotatable through `appServer.rotateToken`.
+- Accepted only during `connect`.
+- Compared using constant-time comparison.
+
+Connection state after connect:
+
+```ts
+interface AppServerConnectionState {
+  connectionId: string;
+  authenticated: boolean;
+  role: Role;
+  scopes: Scope[];
+  sessionKey: string;
+  clientInfo?: ClientInfo;
+  subscriptions: Set<string>;
+  requestIds: Set<string | number>;
+  createdAt: number;
+  lastSeenAt: number;
+}
+```
+
+Pre-connect method frames should be rejected with `UNAUTHORIZED` or `INVALID_REQUEST`, matching existing protocol semantics.
+
+## Backpressure And Overload
+
+Add an overload error in `packages/ws-server/src/errors.ts`:
+
+```ts
+export const ErrorCode = {
+  // existing
+  OVERLOADED: 'OVERLOADED',
+} as const;
+```
+
+Recommended response body:
+
+```json
+{
+  "code": "OVERLOADED",
+  "message": "Server overloaded; retry later.",
+  "retryable": true,
+  "retryAfterMs": 250
+}
+```
+
+Use bounded request scheduling:
+
+```ts
+interface ScheduledRequest {
+  connectionId: string;
+  requestId: RequestId;
+  method: string;
+  params: unknown;
+  context: MethodContext;
+}
+
+class RequestQueue {
+  enqueue(request: ScheduledRequest): EnqueueResult;
+  shutdown(reason: string): Promise<void>;
+}
+```
+
+Rules:
+
+- If queue length >= `requestQueueCapacity`, reject immediately with `OVERLOADED`.
+- Do not start queued work if the connection closes before execution.
+- Do not allow one connection to fill the entire queue if per-connection caps are enabled.
+- Health checks should bypass or use a small separate queue so readiness remains observable.
+
+Slow outbound client rules:
+
+- If `ws.bufferedAmount > maxBufferedBytes`, close the connection.
+- If per-connection outbound queue is full, close the connection.
+- Emit a close reason such as `SLOW_CONSUMER`.
+
+## Request Serialization
+
+Add `src/app-server/queue/requestSerialization.ts`.
+
+Serialization keys:
+
+```ts
+type RequestSerializationKey =
+  | { kind: 'global'; resource: 'config' | 'credentials' | 'tools' }
+  | { kind: 'session'; sessionKey: string }
+  | { kind: 'approval'; approvalId: string }
+  | { kind: 'connection-local'; connectionId: string }
+  | { kind: 'none' };
+```
+
+Access modes:
+
+```ts
+type RequestAccessMode = 'read' | 'write';
+```
+
+Initial mapping:
+
+| Method | Key | Mode |
+| --- | --- | --- |
+| `health` | none | read |
+| `tools.catalog` | global:tools | read |
+| `config.get` | global:config | read |
+| `config.set` | global:config | write |
+| `config.patch` | global:config | write |
+| `credentials.list` | global:credentials | read |
+| `credentials.set` | global:credentials | write |
+| `credentials.delete` | global:credentials | write |
+| `sessions.list` | none | read |
+| `sessions.get` | session | read |
+| `sessions.turns` | session | read |
+| `sessions.patch` | session | write |
+| `sessions.reset` | session | write |
+| `sessions.delete` | session | write |
+| `sessions.compact` | session | write |
+| `sessions.rewind` | session | write |
+| `chat.history` | session | read |
+| `chat.send` | session | write |
+| `chat.abort` | session | write |
+| `chat.inject` | session | write |
+| `exec.approval.resolve` | approval | write |
+| `logs.tail` | connection-local | read |
+
+Behavior:
+
+- Writes for the same key are exclusive.
+- Reads for the same key can run together.
+- Reads do not overtake earlier writes.
+- Requests for different keys can run concurrently.
+
+This prevents two external callers from racing session mutation and chat generation on the same session.
+
+## Connection RPC Gate
+
+Add `src/app-server/connection/ConnectionRpcGate.ts`.
+
+Behavior:
+
+- Each accepted connection has a gate.
+- Before a queued request starts, it must call `gate.tryEnter()`.
+- If the connection is closed, `tryEnter()` fails and the request is dropped/rejected.
+- In-flight requests release their gate permit on completion.
+- On close, no new requests can enter.
+
+This copies the Codex pattern and prevents disconnected clients from starting delayed work.
+
+## Request Processing
+
+Create `src/app-server/AppServerRequestProcessor.ts`.
+
+Responsibilities:
+
+- Parse and validate frames using `packages/ws-server`.
+- Enforce connected/authenticated state.
+- Enforce method scopes via existing `authorize.ts` logic.
+- Deduplicate request IDs if the protocol requires it.
+- Enqueue through `RequestQueue`.
+- Dispatch to existing server handlers.
+- Send response frames.
+- Track active requests by connection.
+- Clean up on disconnect.
+
+Do not let WebSocket transport call handlers directly. Transport should only create connection events and forward validated wire frames.
+
+## Handler Reuse
+
+Reuse current handlers where possible:
+
+- `src/server/handlers/chat.ts`
+- `src/server/handlers/sessions.ts`
+- `src/server/handlers/config.ts`
+- `src/server/handlers/credentials.ts`
+- `src/server/handlers/exec.ts`
+- `src/server/handlers/health.ts`
+- `src/server/handlers/logs.ts`
+- `src/server/handlers/tools.ts`
+
+Required changes:
+
+- Add `channelId` and `channelType` to `MethodContext`.
+- Remove hardcoded `server-main` assumptions.
+- Make config handlers use desktop `AgentConfig` services in desktop app-server mode, not `.workx-server/config.json`.
+- Keep credential writes requiring loopback or TLS. Desktop app-server loopback with token is acceptable for MVP.
+
+Recommended dependency shape:
+
+```ts
+interface AppServerHandlerDeps {
+  channelManager: ChannelManager;
+  configStore: AgentConfigStore;
+  credentialStore: CredentialStore;
+  logs: LogsTailSource;
+  appServerMode: 'desktop' | 'headless';
+}
+```
+
+## Desktop Integration
+
+Create `src/desktop-runtime/app-server/DesktopAppServerManager.ts`.
+
+Responsibilities:
+
+- Read `appServer` config after `WorkXRuntimeBootstrap.initialize()`.
+- Ensure capability token exists if enabled.
+- Create `AppServerConnectionRegistry`.
+- Create `AppServerChannel`.
+- Register the channel with `ServerAgentBootstrap.registerChannel()`.
+- Start `AppServerWebSocketTransport`.
+- Publish status to runtime services.
+- Watch config changes and restart listener when host/port/auth settings change.
+- Stop transport on sidecar shutdown.
+
+Modify `src/desktop-runtime/index.ts`:
+
+```ts
+const bootstrap = new WorkXRuntimeBootstrap({ channel, host });
+await bootstrap.initialize();
+
+const appServerManager = new DesktopAppServerManager({
+  bootstrap,
+  host,
+  controlBridge,
+});
+await appServerManager.startFromConfig();
+
+// On shutdown:
+await appServerManager.stop('runtime shutdown');
+await bootstrap.shutdown();
+```
+
+If app-server startup fails, catch it, update status, log it, and keep the runtime alive.
+
+## UI Integration
+
+Minimal UI controls should be in an advanced/developer settings area:
+
+- Toggle app-server mode.
+- Show status: disabled, starting, ready, error, stopping.
+- Show endpoint: `ws://127.0.0.1:18101`.
+- Rotate token.
+- Reveal/copy token through explicit action.
+- Restart server.
+- Show last error.
+
+The UI should call runtime services, not talk to the WebSocket server itself.
+
+Do not expose token in passive UI by default.
+
+## External Client Contract
+
+MVP external client flow:
+
+1. Connect to `ws://127.0.0.1:18101`.
+2. Receive `connect.challenge`.
+3. Send `connect` with protocol version, client info, requested scopes, and capability token.
+4. Receive `hello-ok`.
+5. Send request frames, for example `chat.send`.
+6. Receive response frame and event frames.
+7. Send `chat.abort` to interrupt an active turn.
+
+Example conceptual request:
+
+```json
+{
+  "type": "request",
+  "id": "req-1",
+  "method": "chat.send",
+  "params": {
+    "message": "Summarize this repo",
+    "sessionKey": "external-tool-session"
+  }
+}
+```
+
+`chat.send` should return enough identifiers for stable automation:
+
+```json
+{
+  "status": "started",
+  "sessionKey": "external-tool-session",
+  "runId": "run_...",
+  "accepted": true
+}
+```
+
+Note: `runId`/`accepted` are not returned today, but the underlying id already exists — this is a low-effort surface, not net-new generation. `RepublicAgent.submitOperation()` already mints a per-turn submission id (`src/core/RepublicAgent.ts:688`) and returns it synchronously on the `chat.send` path. `chat-stream.ts` already exposes that id as `runId` on `TaskStarted` and delta events (`chat-stream.ts:129,166`). So Phase 1 work is: (a) capture the returned id in `chat.send` and add it to the response as `runId` (keep `status` for headless compatibility, Decision #2); (b) propagate `runId` from the existing per-turn id onto the `ChannelEvent` envelope (`core/channels/types.ts:17-22` carries only `{ msg, sessionId? }` today) so all event types — not just deltas — carry it. Reuse the existing submission id; do not invent a second identifier.
+
+Events should include:
+
+- `sessionKey`
+- `runId` when applicable (net-new envelope field; see above)
+- event type
+- monotonically increasing sequence number where possible
+
+## Security Requirements
+
+Phase 1 must include:
+
+- Default disabled.
+- Loopback bind only.
+- Capability token required.
+- Browser `Origin` rejected.
+- Max payload enforced.
+- Max connection count enforced.
+- Rate limiting enabled.
+- Credential writes allowed only for loopback/TLS and authenticated clients.
+- Token not logged.
+- App-server failure does not crash UI runtime.
+
+Phase 2 should include:
+
+- Per-client scope configuration.
+- Token rotation invalidates active sessions unless explicitly deferred.
+- Optional signed bearer token support.
+- Optional Unix socket/named pipe local transport.
+- Per-method audit logs for credential/config mutations.
+
+## Health And Readiness
+
+Support:
+
+- `GET /readyz`
+- `GET /healthz`
+- `GET /health`
+
+Behavior:
+
+- `/readyz` returns 200 when listener is accepting connections and runtime is initialized.
+- `/healthz` returns health JSON including app-server status, runtime profile, connection count, and uptime.
+- `/health` remains as compatibility alias for existing server clients.
+
+Example:
+
+```json
+{
+  "status": "ready",
+  "profile": "desktop-runtime",
+  "connections": 2,
+  "uptimeMs": 123456
+}
+```
+
+Do not include secrets.
+
+## Testing Strategy
+
+### Unit Tests
+
+Add tests for:
+
+- `AppServerAuth` token validation and constant-time compare path.
+- Origin rejection decision.
+- Request scheduler overload behavior.
+- Request serialization ordering.
+- Connection RPC gate close behavior.
+- Slow consumer threshold behavior.
+- Method context includes `channelId` and `channelType`.
+- `chat.send` no longer hardcodes `server-main`.
+
+### Integration Tests
+
+Add desktop-runtime integration tests that start:
+
+- `WorkXRuntimeBootstrap`.
+- `StdioRuntimeChannel`.
+- `DesktopAppServerManager`.
+- WebSocket test client.
+
+Required cases:
+
+1. App-server disabled by default: no listener started.
+2. Enabled app-server starts on loopback and `/readyz` returns 200.
+3. `/health`, `/healthz`, and protocol `health` work.
+4. WebSocket request with `Origin` is rejected.
+5. Invalid token cannot connect.
+6. Valid token can connect.
+7. Request before `connect` is rejected.
+8. Two clients can use the same request ID without cross-talk.
+9. `chat.send` from external client streams events only to authorized/subscribed clients.
+10. UI `StdioRuntimeChannel` continues receiving runtime events while app-server client is connected.
+11. Disconnect before queued request starts prevents handler execution.
+12. Queue saturation returns `OVERLOADED`.
+13. Slow consumer is disconnected.
+14. Port already in use sets app-server status error and keeps UI runtime alive.
+15. Config toggle starts and stops listener without restarting the desktop app.
+16. Shutdown stops the listener before sidecar exit.
+
+### Regression Tests For Headless Server
+
+If shared server modules are refactored, run and add tests for:
+
+- Existing headless handshake.
+- Existing `/health`.
+- Existing method registry.
+- Existing scope authorization.
+- Existing logs tail behavior.
+
+## Implementation Phases
+
+### Phase 1: Desktop MVP
+
+Deliver a working installed-app callable mode.
+
+Tasks:
+
+- Add `IAppServerConfig` defaults and schema.
+- Add runtime app-server status services.
+- Make `ServerAgentBootstrap` support additional channels.
+- Add `AppServerChannel`.
+- Add `DesktopAppServerManager`.
+- Add WebSocket transport with `/readyz`, `/healthz`, `/health`.
+- Add capability token auth.
+- Reject `Origin`.
+- Add max payload and max connection limits.
+- Fix `chat.send`/method context to use caller channel (additive `MethodContext` change; headless defaults to `server-main`/`server`).
+- Plumb a `runId` into the `chat.send` response and onto the `ChannelEvent` envelope (net-new; keep `status` for headless compatibility).
+- Add session→channel ownership routing and per-connection session-subscription filtering so external sessions do not leak into the UI and clients do not see each other's events.
+- Map the capability-token connection to a narrow role/scope set by default (no implicit credential/config-write).
+- Add minimal integration tests, including multi-client event isolation and shutdown-before-exit.
+
+Exit criteria:
+
+- User can enable app-server mode in config/UI.
+- External local process can call the running app through WebSocket.
+- UI remains functional while external client is connected.
+- Invalid browser-origin and invalid-token calls are rejected.
+- App-server startup failure does not crash the app.
+
+### Phase 2: Stability Hardening
+
+Tasks:
+
+- Add bounded `RequestQueue`.
+- Add `OVERLOADED` error.
+- Add `ConnectionRpcGate`.
+- Add request serialization.
+- Add slow-consumer outbound protection.
+- Add per-client session/event subscription filtering.
+- Add config-driven restart on app-server settings change.
+- Add broad integration tests for queue, disconnect, overload, and shutdown.
+
+Exit criteria:
+
+- Saturated app-server returns retryable overload instead of growing memory.
+- Disconnected clients cannot start queued work.
+- Conflicting session/config/credential mutations are serialized.
+- Slow clients cannot stall the runtime.
+
+### Phase 3: API Maturity
+
+Tasks:
+
+- Generate TypeScript client types from `packages/ws-server`.
+- Add a `workx-app-server-test-client`.
+- Add external client examples.
+- Add stable event sequence numbers.
+- Add v2 API planning for thread/turn naming.
+- Add opt-out notification support similar to Codex.
+
+Exit criteria:
+
+- External callers have documented, typed, tested client contract.
+- API changes can be validated by generated schema diffs.
+
+### Phase 4: Local Socket Transport
+
+Tasks:
+
+- Add Unix socket on macOS/Linux.
+- Add named pipe on Windows.
+- Add startup lock/stale socket cleanup.
+- Add file permissions checks.
+- Make token optional for OS-permission-protected local socket if security review accepts it.
+
+Exit criteria:
+
+- Local automation can avoid TCP ports.
+- Socket lifecycle is robust across app crashes/restarts.
+
+## Exact File Change Checklist
+
+### Config
+
+- `src/config/types.ts`: add `IAppServerConfig`; add optional `appServer` field.
+- `src/config/defaults.ts`: add default app-server config.
+- `src/config/configSchema.ts`: validate app-server config.
+
+### Protocol
+
+- `packages/ws-server/src/errors.ts`: add `OVERLOADED`.
+- `packages/ws-server/src/methods.ts`: add `channelId` and `channelType` to `MethodContext`.
+- `packages/ws-server/src/frames.ts`: add optional client capabilities if needed for event opt-out.
+
+### Runtime Bootstrap
+
+- `src/server/agent/ServerAgentBootstrap.ts`: support multiple channels and runtime registration.
+- `src/core/channels/ChannelManager.ts`: add unregister support if missing.
+- `src/core/channels/types.ts`: ensure `ChannelType` includes the app-server channel type that handlers use.
+
+### App-Server Modules
+
+- `src/app-server/AppServerManager.ts`: lifecycle coordinator.
+- `src/app-server/AppServerChannel.ts`: channel adapter.
+- `src/app-server/AppServerRequestProcessor.ts`: method frame dispatch.
+- `src/app-server/AppServerConnectionRegistry.ts`: connection state.
+- `src/app-server/appServerConfig.ts`: normalize/validate runtime app-server config.
+- `src/app-server/transport/AppServerWebSocketTransport.ts`: listener and health endpoints.
+- `src/app-server/transport/httpHealth.ts`: health response helpers.
+- `src/app-server/connection/AppServerAuth.ts`: token auth provider.
+- `src/app-server/connection/ConnectionRpcGate.ts`: disconnect gate.
+- `src/app-server/connection/ConnectionWatchdog.ts`: heartbeat/slow unauth cleanup.
+- `src/app-server/connection/rateLimiter.ts`: reusable rate limiter or wrapper.
+- `src/app-server/queue/RequestQueue.ts`: bounded request queue.
+- `src/app-server/queue/requestSerialization.ts`: resource serialization.
+- `src/app-server/status/AppServerStatus.ts`: status controller.
+
+### Desktop Runtime
+
+- `src/desktop-runtime/index.ts`: start/stop `DesktopAppServerManager`.
+- `src/desktop-runtime/app-server/DesktopAppServerManager.ts`: desktop integration.
+- `src/desktop-runtime/WorkXRuntimeBootstrap.ts`: expose register/unregister channel through inherited bootstrap.
+
+### Handlers
+
+- `src/server/handlers/chat.ts`: remove hardcoded `server-main`; use method context channel fields.
+- `src/server/handlers/config.ts`: support desktop config backend.
+- `src/server/handlers/credentials.ts`: confirm loopback/token/TLS checks for desktop mode.
+- `src/server/handlers/logs.ts`: ensure subscriptions are per connection and cleaned up on disconnect.
+
+### Services And UI
+
+- `src/core/services/runtime-services.ts`: include app-server status.
+- `src/core/services/agent-services.ts` or new service file: add `appServer.*` service handlers.
+- `src/webfront/stores/runtimeStatusStore.ts`: consume app-server status. Note this store currently only listens to Tauri `runtime:*` events (`runtimeStatusStore.ts:55`); app-server status is not a `runtime:*` event today, so specify the delivery mechanism — either emit a new Tauri event for app-server status changes or have the UI poll `runtime.getStateSnapshot` / `appServer.getStatus`.
+- Settings UI file to be identified during implementation: add advanced controls.
+
+### Tests
+
+- Add unit tests under the repo's existing test layout for app-server modules.
+- Add desktop-runtime integration tests for callable mode.
+- Add regression tests for headless server if modules are shared.
+
+## Migration Notes
+
+### Headless Server
+
+Do not break `src/server/index.ts` in Phase 1. The headless server can continue using its current code while desktop app-server mode uses new reusable modules.
+
+After Phase 1, migrate shared pieces from `src/server/index.ts` into `src/app-server`:
+
+- HTTP health.
+- WebSocket transport.
+- Handshake.
+- Rate limiting.
+- Watchdog.
+- Resource limits.
+- Request processing.
+
+This reduces duplication while avoiding a risky all-at-once refactor.
+
+### Existing Desktop WebSocket Files
+
+Leave these untouched during Phase 1 unless tests require cleanup:
+
+- `src/desktop/channels/WebSocketChannel.ts`
+- `src/desktop/channels/websocket/WebSocketServer.ts`
+
+After app-server mode ships, mark them deprecated or remove them in a separate cleanup PR.
+
+### Server Config Split
+
+Keep these separate:
+
+- Headless server config: `src/server/config/server-config.ts`.
+- Desktop app-server config: `IAgentConfig.appServer`.
+
+Do not write `.workx-server/config.json` from desktop app-server settings.
+
+## Risks And Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| External clients receive UI-only events or other clients' events | AppServerChannel must filter by scope, session, and subscription. Add tests with two clients. |
+| UI sees external sessions unexpectedly | Start with UI receiving global runtime events; add session ownership router in Phase 2 if needed. |
+| App-server port conflict crashes desktop app | Catch startup failures and publish app-server error status only. |
+| Local browser page calls app-server | Reject all `Origin` headers by default and require token. |
+| Unbounded memory under many requests | Bounded RequestQueue and overload responses. |
+| Slow WebSocket client stalls event delivery | Per-connection outbound caps and slow-consumer disconnect. |
+| Concurrent mutation corrupts session/config state | Request serialization by resource key. |
+| Disconnect leaves queued work that later starts | ConnectionRpcGate. |
+| Token leaks in logs/UI | Never log token; reveal only through explicit UI action. |
+| Shared handler refactor breaks headless server | Add headless regression tests and migrate in phases. |
+
+## Acceptance Criteria
+
+The feature is complete when:
+
+- WorkX desktop can run UI and app-server mode in the same installed app process tree.
+- App-server is disabled by default.
+- When enabled, the desktop sidecar listens on loopback WebSocket.
+- External local process can authenticate and call `chat.send`.
+- External local process can call `chat.abort`.
+- External local process can query health.
+- UI remains usable while external calls run.
+- Browser-origin WebSocket upgrades are rejected.
+- Invalid tokens are rejected.
+- Port conflicts do not kill the app.
+- Request queue overload returns a retryable overload error.
+- Disconnect cleanup prevents queued requests from starting.
+- Tests cover multi-client isolation, auth, origin rejection, overload, disconnect, and shutdown.
+
+## Source Research References
+
+WorkX:
+
+- `README.md`
+- `package.json`
+- `packages/ws-server/src/frames.ts`
+- `packages/ws-server/src/methods.ts`
+- `packages/ws-server/src/errors.ts`
+- `src/server/index.ts`
+- `src/server/agent/ServerAgentBootstrap.ts`
+- `src/server/channels/ServerChannel.ts`
+- `src/server/connection/handshake.ts`
+- `src/server/connection/rate-limiter.ts`
+- `src/server/connection/watchdog.ts`
+- `src/server/limits/resource-limits.ts`
+- `src/server/auth/authorize.ts`
+- `src/server/handlers/chat.ts`
+- `src/server/handlers/config.ts`
+- `src/server/handlers/credentials.ts`
+- `src/server/handlers/exec.ts`
+- `src/server/handlers/health.ts`
+- `src/server/handlers/logs.ts`
+- `src/server/handlers/sessions.ts`
+- `src/server/handlers/tools.ts`
+- `src/core/channels/ChannelManager.ts`
+- `src/core/channels/types.ts`
+- `src/core/services/runtime-services.ts`
+- `src/core/services/agent-services.ts`
+- `src/desktop-runtime/index.ts`
+- `src/desktop-runtime/WorkXRuntimeBootstrap.ts`
+- `src/desktop-runtime/channels/StdioRuntimeChannel.ts`
+- `src/desktop-runtime/protocol/frames.ts`
+- `src/desktop-runtime/protocol/stdioCarrier.ts`
+- `src/desktop-runtime/protocol/controlBridge.ts`
+- `src/desktop-runtime/host.ts`
+- `tauri/src/runtime_supervisor.rs`
+- `src/desktop/channels/WebSocketChannel.ts`
+- `src/desktop/channels/websocket/WebSocketServer.ts`
+- `.ai_design/server_mode/server_mode_design.md`
+- `.ai_design/agent_improvements/43_apple_pi_runtime_decoupling_DONE/design.md`
+- `.ai_design/message_routing_v2/design.md`
+
+Codex:
+
+- `/home/rich/dev/study/codex/AGENTS.md`
+- `/home/rich/dev/study/codex/codex-rs/app-server/README.md`
+- `/home/rich/dev/study/codex/codex-rs/app-server/src/main.rs`
+- `/home/rich/dev/study/codex/codex-rs/app-server/src/lib.rs`
+- `/home/rich/dev/study/codex/codex-rs/app-server/src/transport.rs`
+- `/home/rich/dev/study/codex/codex-rs/app-server/src/message_processor.rs`
+- `/home/rich/dev/study/codex/codex-rs/app-server/src/connection_rpc_gate.rs`
+- `/home/rich/dev/study/codex/codex-rs/app-server/src/request_serialization.rs`
+- `/home/rich/dev/study/codex/codex-rs/app-server/src/in_process.rs`
+- `/home/rich/dev/study/codex/codex-rs/app-server-transport/src/transport/mod.rs`
+- `/home/rich/dev/study/codex/codex-rs/app-server-transport/src/transport/websocket.rs`
+- `/home/rich/dev/study/codex/codex-rs/app-server-transport/src/transport/auth.rs`
+- `/home/rich/dev/study/codex/codex-rs/app-server-transport/src/transport/unix_socket.rs`
+- `/home/rich/dev/study/codex/codex-rs/app-server-client/src/lib.rs`
+- `/home/rich/dev/study/codex/codex-rs/app-server-protocol/src/protocol/common.rs`
+- `/home/rich/dev/study/codex/codex-rs/app-server-daemon/README.md`
+- `/home/rich/dev/study/codex/codex-rs/app-server-test-client/README.md`
+- `/home/rich/dev/study/codex/codex-rs/app-server/tests/suite/v2/connection_handling_websocket.rs`
+- `/home/rich/dev/study/codex/codex-rs/app-server/tests/suite/v2/connection_handling_websocket_unix.rs`
+- `/home/rich/dev/study/codex/codex-rs/app-server/tests/suite/v2/initialize.rs`
+- `/home/rich/dev/study/codex/codex-rs/app-server/tests/suite/v2/thread_resume.rs`
+- `/home/rich/dev/study/codex/codex-rs/app-server/tests/suite/v2/turn_interrupt.rs`

--- a/.ai_design/app_server_mode/tasks.md
+++ b/.ai_design/app_server_mode/tasks.md
@@ -1,0 +1,207 @@
+# WorkX App-Server Mode Implementation Tasks
+
+Status: Ready for implementation
+Date: 2026-06-02
+
+This checklist implements the design in `design.md`.
+
+## Phase 1: Desktop MVP
+
+### Config
+
+- [ ] Add `IAppServerConfig` to `src/config/types.ts`.
+- [ ] Add `appServer?: IAppServerConfig` to `IAgentConfig`.
+- [ ] Add default app-server config in `src/config/defaults.ts`.
+- [ ] Add validation in `src/config/configSchema.ts`.
+- [ ] Ensure desktop app-server does not use `src/server/config/server-config.ts`.
+
+### Runtime Bootstrap
+
+- [ ] Update `src/server/agent/ServerAgentBootstrap.ts` to track multiple channels.
+- [ ] Preserve existing `channel` option behavior.
+- [ ] Add `channels?: ChannelAdapter[]` option.
+- [ ] Add `registerChannel(channel)` public method.
+- [ ] Add `unregisterChannel(channelId)` public method or implement unregister in `ChannelManager`.
+- [ ] Replace single-channel event dispatch with multi-channel dispatch.
+- [ ] Add tests that initialize bootstrap with stdio and app-server channels.
+
+### Protocol Context
+
+- [ ] Add `channelId` to `MethodContext` in `packages/ws-server/src/methods.ts` (additive — keep existing `requestId`, `userId`, `sendEvent`, optional `sessionKey`).
+- [ ] Add `channelType` to `MethodContext`.
+- [ ] Update method dispatch to populate both fields; headless dispatch defaults to `server-main`/`server`.
+- [ ] Update `src/server/handlers/chat.ts` to stop hardcoding `server-main`.
+- [ ] Confirm all handlers compile with the expanded context.
+- [ ] Add a `runId` to the `chat.send` response and onto the `ChannelEvent` envelope (keep `status` for headless compatibility).
+
+### Event Routing (Phase 1)
+
+- [ ] Record the owning channel per session at session creation.
+- [ ] Replace plain `broadcastEvent` with session→channel ownership routing.
+- [ ] Filter `AppServerChannel` events by authenticated connection, scope, and session subscription/ownership.
+- [ ] Verify external sessions do not leak into the UI `StdioRuntimeChannel` (and vice versa) beyond global runtime status.
+
+### App-Server Core Modules
+
+- [ ] Add `src/app-server/AppServerManager.ts`.
+- [ ] Add `src/app-server/AppServerChannel.ts`.
+- [ ] Add `src/app-server/AppServerRequestProcessor.ts`.
+- [ ] Add `src/app-server/AppServerConnectionRegistry.ts`.
+- [ ] Add `src/app-server/appServerConfig.ts`.
+- [ ] Add `src/app-server/status/AppServerStatus.ts`.
+
+### WebSocket Transport
+
+- [ ] Add `src/app-server/transport/AppServerWebSocketTransport.ts`.
+- [ ] Add `src/app-server/transport/httpHealth.ts`.
+- [ ] Implement `/readyz`.
+- [ ] Implement `/healthz`.
+- [ ] Keep `/health` compatibility alias.
+- [ ] Enforce max connections.
+- [ ] Enforce max payload bytes.
+- [ ] Reject WebSocket upgrades with `Origin` header by default.
+- [ ] Start only on loopback unless `allowLan` is true.
+- [ ] Return actual port when configured port is `0`.
+
+### Connection Lifecycle
+
+- [ ] Add `src/app-server/connection/rateLimiter.ts` (reusable rate limiter or wrapper) and attach it in the transport.
+- [ ] Add `src/app-server/connection/ConnectionWatchdog.ts` for handshake timeout, heartbeat, and slow-unauthenticated cleanup.
+
+### Auth
+
+- [ ] Add `src/app-server/connection/AppServerAuth.ts`.
+- [ ] Generate capability token on first enable.
+- [ ] Accept an injected token store in `AppServerAuth`; keep `src/app-server/` free of desktop control-bridge imports.
+- [ ] Store token in keychain through desktop runtime control bridge when available (wired in `DesktopAppServerManager`).
+- [ ] Add file fallback only if keychain is unavailable; write with `0600` perms and surface a UI warning.
+- [ ] Map the capability-token connection to a narrow role/scope set by default (no implicit credential/config-write).
+- [ ] Compare tokens with constant-time comparison.
+- [ ] Reject pre-connect method frames.
+- [ ] Never log token values.
+
+### Desktop Runtime Integration
+
+- [ ] Add `src/desktop-runtime/app-server/DesktopAppServerManager.ts`.
+- [ ] Start manager after `WorkXRuntimeBootstrap.initialize()` in `src/desktop-runtime/index.ts`.
+- [ ] Register `AppServerChannel` with bootstrap.
+- [ ] Stop manager before bootstrap shutdown.
+- [ ] Catch app-server startup errors and keep sidecar running.
+- [ ] Publish app-server status changes.
+
+### Handlers
+
+- [ ] Make `src/server/handlers/config.ts` use the desktop `AgentConfig` services in desktop app-server mode (not `.workx-server/config.json`).
+- [ ] Confirm `src/server/handlers/credentials.ts` loopback/token/TLS checks hold for desktop app-server mode.
+- [ ] Ensure `src/server/handlers/logs.ts` subscriptions are per connection and cleaned up on disconnect.
+
+### Runtime Services
+
+- [ ] Extend `runtime.getStateSnapshot` with app-server status.
+- [ ] Add `appServer.getStatus`.
+- [ ] Add `appServer.setConfig`.
+- [ ] Add `appServer.restart`.
+- [ ] Add `appServer.stop`.
+- [ ] Add `appServer.rotateToken`.
+
+### UI Integration
+
+- [ ] Consume app-server status in `src/webfront/stores/runtimeStatusStore.ts` via the chosen delivery mechanism (new Tauri event or poll `appServer.getStatus`).
+- [ ] Add advanced/developer settings controls: toggle app-server, show status, show endpoint.
+- [ ] Add rotate-token and explicit reveal/copy-token actions (no passive token display).
+- [ ] Add restart action and last-error display.
+- [ ] UI calls runtime services only, never the WebSocket server directly.
+
+### MVP Tests
+
+- [ ] App-server disabled by default.
+- [ ] Enabled app-server starts on `127.0.0.1`.
+- [ ] `/readyz` returns 200 after runtime initializes.
+- [ ] `/health`, `/healthz`, and protocol `health` work.
+- [ ] Origin header is rejected.
+- [ ] Invalid token is rejected.
+- [ ] Valid token completes connect handshake.
+- [ ] Request before connect is rejected.
+- [ ] UI channel still receives runtime events while app-server client is connected.
+- [ ] External session events do not leak into the UI channel; two app-server clients do not see each other's session events.
+- [ ] Shutdown stops the listener before sidecar exit.
+- [ ] Port conflict sets app-server error status without crashing runtime.
+
+## Phase 2: Stability Hardening
+
+### Backpressure
+
+- [ ] Add `OVERLOADED` to `packages/ws-server/src/errors.ts`.
+- [ ] Add `src/app-server/queue/RequestQueue.ts`.
+- [ ] Enforce global request queue capacity.
+- [ ] Enforce optional per-connection queue capacity.
+- [ ] Return retryable overload response when saturated.
+- [ ] Let health/readiness remain observable under load.
+
+### Disconnect Safety
+
+- [ ] Add `src/app-server/connection/ConnectionRpcGate.ts`.
+- [ ] Gate queued request startup on active connection state.
+- [ ] Prevent queued requests from starting after disconnect.
+- [ ] Clean up active request tracking on connection close.
+
+### Request Serialization
+
+- [ ] Add `src/app-server/queue/requestSerialization.ts`.
+- [ ] Serialize `chat.send`, `chat.abort`, and session mutations by session key.
+- [ ] Serialize config writes globally.
+- [ ] Serialize credential writes globally.
+- [ ] Allow read-only requests to run concurrently where safe.
+- [ ] Add ordering tests.
+
+### Slow Consumer Protection
+
+- [ ] Add per-connection outbound queue cap.
+- [ ] Close clients whose `bufferedAmount` exceeds `maxBufferedBytes`.
+- [ ] Emit/log `SLOW_CONSUMER` close reason without leaking secrets.
+- [ ] Add integration test with blocked client reads.
+
+### Event Filtering (refinement — basic session isolation lands in Phase 1)
+
+- [ ] Add run-level (`runId`) ownership filtering on top of the Phase 1 session ownership map.
+- [ ] Add the richer `ChannelEventRouter` abstraction.
+- [ ] Add same request ID on two clients test.
+
+### Config Restart
+
+- [ ] Watch app-server config changes.
+- [ ] Restart listener when host, port, auth, or limits change.
+- [ ] Stop listener when `enabled` changes to false.
+- [ ] Keep existing connections behavior explicit during restart.
+
+## Phase 3: API Maturity
+
+- [ ] Generate TypeScript protocol/client types from `packages/ws-server`.
+- [ ] Add an app-server test client package or script.
+- [ ] Add external client examples for `chat.send`, `chat.abort`, and `health`.
+- [ ] Add stable event sequence numbers.
+- [ ] Add event opt-out capability in connect handshake.
+- [ ] Document v1 external API.
+- [ ] Plan v2 API with resource/method names such as `thread/start` and `turn/start`.
+
+## Phase 4: Local Socket Transport
+
+- [ ] Add Unix socket transport for macOS/Linux.
+- [ ] Add Windows named pipe transport.
+- [ ] Add startup lock.
+- [ ] Remove stale socket files only after verifying they are not in use.
+- [ ] Enforce socket file permissions.
+- [ ] Add socket transport tests.
+
+## Release Checklist
+
+- [ ] Default install has no listening app-server socket.
+- [ ] Enabling app-server requires explicit user action or config.
+- [ ] Endpoint is loopback by default.
+- [ ] Capability token auth is required.
+- [ ] Browser-origin WebSocket upgrade is rejected.
+- [ ] App-server errors do not crash UI runtime.
+- [ ] Request overload is bounded and retryable.
+- [ ] Disconnect cleanup is tested.
+- [ ] Multi-client event isolation is tested.
+- [ ] Headless server regression tests pass if shared modules were changed.

--- a/packages/ws-server/src/errors.ts
+++ b/packages/ws-server/src/errors.ts
@@ -18,6 +18,8 @@ export enum ErrorCode {
   AGENT_TIMEOUT = 'AGENT_TIMEOUT',
   UNAVAILABLE = 'UNAVAILABLE',
   DISCONNECTED = 'DISCONNECTED',
+  /** Inbound request queue is saturated; the caller should retry later. */
+  OVERLOADED = 'OVERLOADED',
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -88,5 +90,14 @@ export function unavailable(message?: string, details?: unknown): ErrorShape {
     message: message ?? 'Service temporarily unavailable',
     details,
     retryable: true,
+  };
+}
+
+export function overloaded(retryAfterMs = 250, message?: string): ErrorShape {
+  return {
+    code: ErrorCode.OVERLOADED,
+    message: message ?? 'Server overloaded; retry later.',
+    retryable: true,
+    retryAfterMs,
   };
 }

--- a/packages/ws-server/src/methods.ts
+++ b/packages/ws-server/src/methods.ts
@@ -96,6 +96,20 @@ export const BROADCAST_EVENTS = new Set([
   'connect.hello-ok',
 ]);
 
+/**
+ * Build the wire-event list a connection may receive given its scopes: always
+ * the broadcast events, plus every scoped event the connection is entitled to.
+ * Shared by the headless-server handshake and the desktop app-server so the two
+ * advertise an identical event set from the same source of truth.
+ */
+export function buildAvailableEvents(scopes: string[]): string[] {
+  const events = new Set<string>(BROADCAST_EVENTS);
+  for (const [eventName, requiredScope] of Object.entries(EVENT_SCOPE_MAP)) {
+    if (scopes.includes(requiredScope)) events.add(eventName);
+  }
+  return Array.from(events);
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // Handler function type
 // ─────────────────────────────────────────────────────────────────────────

--- a/packages/ws-server/src/methods.ts
+++ b/packages/ws-server/src/methods.ts
@@ -112,6 +112,14 @@ export interface MethodContext {
   scopes: string[];
   userId?: string;
   sessionKey?: string;
+  /**
+   * Caller channel identity. Populated by the dispatcher so handlers route
+   * submissions/events through the originating channel instead of a hardcoded
+   * one. Optional for backward compatibility: the headless server omits these
+   * and handlers fall back to the `server-main`/`server` defaults.
+   */
+  channelId?: string;
+  channelType?: string;
   /** Send an event frame back to this connection */
   sendEvent: (event: string, payload?: unknown) => void;
 }

--- a/src/app-server/AppServerChannel.ts
+++ b/src/app-server/AppServerChannel.ts
@@ -1,0 +1,175 @@
+/**
+ * App-Server Channel Adapter
+ *
+ * ChannelAdapter for the desktop app-server. Receives agent events for sessions
+ * owned by app-server connections (routed by ServerAgentBootstrap's session
+ * ownership map) and fans them out to the right connections, filtered by:
+ *   - authenticated connection,
+ *   - event scope (EVENT_SCOPE_MAP / BROADCAST_EVENTS),
+ *   - session ownership / subscription.
+ *
+ * Submissions flow through the shared chat handlers (not this channel's
+ * onSubmission), so onSubmission is a no-op sink here.
+ *
+ * @module app-server/AppServerChannel
+ */
+
+import type { ChannelAdapter } from '@/core/channels/ChannelAdapter';
+import type {
+  ChannelType,
+  ChannelCapabilities,
+  ChannelEvent,
+  SubmissionHandler,
+  ConnectionState,
+} from '@/core/channels/types';
+import type { EventMsg } from '@/core/protocol/events';
+import { makeEvent, EVENT_SCOPE_MAP, BROADCAST_EVENTS } from '@workx/ws-server';
+import { redactEventMsgSecrets } from '@/server/security/eventRedaction';
+import type { AppServerConnectionRegistry } from './AppServerConnectionRegistry';
+
+export const APP_SERVER_CHANNEL_ID = 'desktop-app-server';
+
+export class AppServerChannel implements ChannelAdapter {
+  readonly channelId: string;
+  readonly channelType: ChannelType = 'websocket';
+
+  private submissionHandler: SubmissionHandler | null = null;
+  private connectionState: ConnectionState = 'disconnected';
+  private eventSeq = 0;
+
+  constructor(
+    private readonly registry: AppServerConnectionRegistry,
+    channelId: string = APP_SERVER_CHANNEL_ID,
+  ) {
+    this.channelId = channelId;
+  }
+
+  async initialize(): Promise<void> {
+    this.connectionState = 'connected';
+  }
+
+  async shutdown(): Promise<void> {
+    this.submissionHandler = null;
+    this.connectionState = 'disconnected';
+  }
+
+  onSubmission(handler: SubmissionHandler): void {
+    this.submissionHandler = handler;
+  }
+
+  /**
+   * Fan an agent event out to eligible connections.
+   */
+  async sendEvent(event: ChannelEvent, targetClientId?: string): Promise<void> {
+    const msg = redactEventMsgSecrets(event.msg);
+    const eventName = eventMsgToName(msg);
+    const runId = extractRunId(msg);
+    const seq = ++this.eventSeq;
+
+    const basePayload: Record<string, unknown> = { ...(msg as Record<string, unknown>) };
+    if (event.sessionId) basePayload.sessionId = event.sessionId;
+    if (runId) basePayload.runId = runId;
+    const frame = JSON.stringify(makeEvent(eventName, basePayload, seq));
+
+    for (const conn of this.registry.all()) {
+      if (!conn.authenticated) continue;
+      if (targetClientId && conn.connectionId !== targetClientId) continue;
+      if (!isScopeEligible(eventName, conn.scopes)) continue;
+      if (!isSessionEligible(event.sessionId, conn)) continue;
+
+      try {
+        conn.socket.send(frame);
+      } catch (err) {
+        console.error(`[AppServerChannel] send to ${conn.connectionId} failed:`, err);
+      }
+    }
+  }
+
+  supportsStreaming(): boolean {
+    return true;
+  }
+  supportsApprovals(): boolean {
+    return true;
+  }
+  supportsMedia(): boolean {
+    return false;
+  }
+  supportsServices(): boolean {
+    return true;
+  }
+  getCapabilities(): ChannelCapabilities {
+    return {
+      streaming: this.supportsStreaming(),
+      approvals: this.supportsApprovals(),
+      media: this.supportsMedia(),
+      services: this.supportsServices(),
+    };
+  }
+  getConnectionState(): ConnectionState {
+    return this.connectionState;
+  }
+  async close(): Promise<void> {
+    return this.shutdown();
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Filtering helpers (exported for unit tests)
+// ─────────────────────────────────────────────────────────────────────────
+
+export function isScopeEligible(eventName: string, scopes: string[]): boolean {
+  if (BROADCAST_EVENTS.has(eventName)) return true;
+  const required = EVENT_SCOPE_MAP[eventName];
+  if (!required) return true; // unscoped events are visible to authenticated connections
+  return scopes.includes(required);
+}
+
+export function isSessionEligible(
+  sessionId: string | undefined,
+  conn: { sessionKey?: string; subscriptions: Set<string> },
+): boolean {
+  // Events without a session (global/runtime) reach all connections.
+  if (!sessionId) return true;
+  if (conn.sessionKey === sessionId) return true;
+  return conn.subscriptions.has(sessionId);
+}
+
+export function extractRunId(msg: EventMsg): string | undefined {
+  const data = (msg as { data?: { submission_id?: string; turn_id?: string } }).data;
+  return data?.submission_id ?? data?.turn_id;
+}
+
+export function eventMsgToName(event: EventMsg): string {
+  if (
+    event.type === 'AgentMessageDelta' ||
+    event.type === 'AgentMessage' ||
+    event.type === 'AgentReasoning' ||
+    event.type === 'AgentReasoningDelta'
+  ) {
+    return 'chat';
+  }
+  if (
+    event.type === 'ToolExecutionStart' ||
+    event.type === 'ToolExecutionEnd' ||
+    event.type === 'ToolExecutionProgress' ||
+    event.type === 'McpToolCallBegin' ||
+    event.type === 'McpToolCallEnd' ||
+    event.type === 'ExecCommandBegin' ||
+    event.type === 'ExecCommandEnd' ||
+    event.type === 'TurnStarted' ||
+    event.type === 'TurnComplete' ||
+    event.type === 'TaskStarted' ||
+    event.type === 'TaskComplete'
+  ) {
+    return 'agent';
+  }
+  if (event.type === 'ExecApprovalRequest' || event.type === 'ApplyPatchApprovalRequest') {
+    return 'exec.approval.requested';
+  }
+  if (event.type === 'Error' || event.type === 'StreamError') {
+    return 'health';
+  }
+  if (event.type === 'ServiceResponse') return 'service.response';
+  if (event.type === 'StateUpdate') return 'state.update';
+  return event.type;
+}

--- a/src/app-server/AppServerChannel.ts
+++ b/src/app-server/AppServerChannel.ts
@@ -25,6 +25,7 @@ import type {
 import type { EventMsg } from '@/core/protocol/events';
 import { makeEvent, EVENT_SCOPE_MAP, BROADCAST_EVENTS } from '@workx/ws-server';
 import { redactEventMsgSecrets } from '@/server/security/eventRedaction';
+import { eventMsgToName } from '@/server/channels/eventWireName';
 import type { AppServerConnectionRegistry } from './AppServerConnectionRegistry';
 
 export const APP_SERVER_CHANNEL_ID = 'desktop-app-server';
@@ -137,39 +138,4 @@ export function isSessionEligible(
 export function extractRunId(msg: EventMsg): string | undefined {
   const data = (msg as { data?: { submission_id?: string; turn_id?: string } }).data;
   return data?.submission_id ?? data?.turn_id;
-}
-
-export function eventMsgToName(event: EventMsg): string {
-  if (
-    event.type === 'AgentMessageDelta' ||
-    event.type === 'AgentMessage' ||
-    event.type === 'AgentReasoning' ||
-    event.type === 'AgentReasoningDelta'
-  ) {
-    return 'chat';
-  }
-  if (
-    event.type === 'ToolExecutionStart' ||
-    event.type === 'ToolExecutionEnd' ||
-    event.type === 'ToolExecutionProgress' ||
-    event.type === 'McpToolCallBegin' ||
-    event.type === 'McpToolCallEnd' ||
-    event.type === 'ExecCommandBegin' ||
-    event.type === 'ExecCommandEnd' ||
-    event.type === 'TurnStarted' ||
-    event.type === 'TurnComplete' ||
-    event.type === 'TaskStarted' ||
-    event.type === 'TaskComplete'
-  ) {
-    return 'agent';
-  }
-  if (event.type === 'ExecApprovalRequest' || event.type === 'ApplyPatchApprovalRequest') {
-    return 'exec.approval.requested';
-  }
-  if (event.type === 'Error' || event.type === 'StreamError') {
-    return 'health';
-  }
-  if (event.type === 'ServiceResponse') return 'service.response';
-  if (event.type === 'StateUpdate') return 'state.update';
-  return event.type;
 }

--- a/src/app-server/AppServerConnectionRegistry.ts
+++ b/src/app-server/AppServerConnectionRegistry.ts
@@ -31,7 +31,6 @@ export interface AppServerConnectionState {
   subscriptions: Set<string>;
   /** In-flight request ids (for dedupe + cleanup). */
   requestIds: Set<string>;
-  isLoopback: boolean;
   createdAt: number;
   lastSeenAt: number;
   gate: ConnectionRpcGate;
@@ -43,7 +42,6 @@ export class AppServerConnectionRegistry {
   add(params: {
     connectionId: string;
     socket: ConnectionSocket;
-    isLoopback: boolean;
     now: number;
   }): AppServerConnectionState {
     const state: AppServerConnectionState = {
@@ -54,7 +52,6 @@ export class AppServerConnectionRegistry {
       scopes: [],
       subscriptions: new Set(),
       requestIds: new Set(),
-      isLoopback: params.isLoopback,
       createdAt: params.now,
       lastSeenAt: params.now,
       gate: new ConnectionRpcGate(),

--- a/src/app-server/AppServerConnectionRegistry.ts
+++ b/src/app-server/AppServerConnectionRegistry.ts
@@ -1,0 +1,96 @@
+/**
+ * App-Server Connection Registry
+ *
+ * Instance-scoped per-connection state for the app-server. Tracks
+ * authentication, scopes, the dedicated session, event subscriptions, and the
+ * RPC gate used to abandon queued work after disconnect.
+ *
+ * @module app-server/AppServerConnectionRegistry
+ */
+
+import { ConnectionRpcGate } from './connection/ConnectionRpcGate';
+
+/** Transport-level handle for sending bytes to a single connection. */
+export interface ConnectionSocket {
+  send(data: string): void;
+  close(code: number, reason: string): void;
+  /** Current outbound buffer size in bytes (for slow-consumer detection). */
+  bufferedAmount(): number;
+}
+
+export interface AppServerConnectionState {
+  connectionId: string;
+  socket: ConnectionSocket;
+  authenticated: boolean;
+  role: string;
+  scopes: string[];
+  /** Dedicated agent session for this connection. */
+  sessionKey?: string;
+  clientInfo?: { id: string; mode: string };
+  /** Sessions this connection is subscribed to (defaults to its own session). */
+  subscriptions: Set<string>;
+  /** In-flight request ids (for dedupe + cleanup). */
+  requestIds: Set<string>;
+  isLoopback: boolean;
+  createdAt: number;
+  lastSeenAt: number;
+  gate: ConnectionRpcGate;
+}
+
+export class AppServerConnectionRegistry {
+  private connections = new Map<string, AppServerConnectionState>();
+
+  add(params: {
+    connectionId: string;
+    socket: ConnectionSocket;
+    isLoopback: boolean;
+    now: number;
+  }): AppServerConnectionState {
+    const state: AppServerConnectionState = {
+      connectionId: params.connectionId,
+      socket: params.socket,
+      authenticated: false,
+      role: 'channel',
+      scopes: [],
+      subscriptions: new Set(),
+      requestIds: new Set(),
+      isLoopback: params.isLoopback,
+      createdAt: params.now,
+      lastSeenAt: params.now,
+      gate: new ConnectionRpcGate(),
+    };
+    this.connections.set(params.connectionId, state);
+    return state;
+  }
+
+  get(connectionId: string): AppServerConnectionState | undefined {
+    return this.connections.get(connectionId);
+  }
+
+  all(): AppServerConnectionState[] {
+    return Array.from(this.connections.values());
+  }
+
+  count(): number {
+    return this.connections.size;
+  }
+
+  touch(connectionId: string, now: number): void {
+    const conn = this.connections.get(connectionId);
+    if (conn) conn.lastSeenAt = now;
+  }
+
+  remove(connectionId: string): AppServerConnectionState | undefined {
+    const conn = this.connections.get(connectionId);
+    if (conn) {
+      conn.gate.close();
+      this.connections.delete(connectionId);
+    }
+    return conn;
+  }
+
+  clear(): void {
+    for (const conn of this.connections.values()) conn.gate.close();
+    this.connections.clear();
+  }
+}

--- a/src/app-server/AppServerManager.ts
+++ b/src/app-server/AppServerManager.ts
@@ -131,7 +131,7 @@ export class AppServerManager {
     this.queue = null;
     this.watchdog = null;
     this.listenInfo = null;
-    this.status.set({ status: this.config.enabled ? 'disabled' : 'disabled', connections: 0, url: undefined });
+    this.status.set({ status: 'disabled', connections: 0, url: undefined });
   }
 
   /** Rotate the capability token. Existing connections remain until they close. */

--- a/src/app-server/AppServerManager.ts
+++ b/src/app-server/AppServerManager.ts
@@ -1,0 +1,150 @@
+/**
+ * App-Server Manager (host-agnostic)
+ *
+ * Owns the transport, request processor, connection registry, request queue, and
+ * status controller. Knows nothing about the desktop control bridge or
+ * keychain — those are injected (auth + sessionFactory) by the host
+ * integration (DesktopAppServerManager). The same manager can back a future
+ * headless migration.
+ *
+ * @module app-server/AppServerManager
+ */
+
+import type { ChannelAdapter } from '@/core/channels/ChannelAdapter';
+import { normalizeAppServerConfig, type IAppServerConfig } from './appServerConfig';
+import { AppServerConnectionRegistry } from './AppServerConnectionRegistry';
+import { AppServerChannel, APP_SERVER_CHANNEL_ID } from './AppServerChannel';
+import { AppServerRequestProcessor } from './AppServerRequestProcessor';
+import { AppServerWebSocketTransport, type AppServerListenInfo } from './transport/AppServerWebSocketTransport';
+import { AppServerAuth } from './connection/AppServerAuth';
+import { AppServerRateLimiter } from './connection/rateLimiter';
+import { ConnectionWatchdog } from './connection/ConnectionWatchdog';
+import { RequestQueue } from './queue/RequestQueue';
+import { AppServerStatusController, type AppServerStatusSnapshot } from './status/AppServerStatus';
+
+export interface AppServerManagerDeps {
+  config: Partial<IAppServerConfig> | undefined;
+  auth: AppServerAuth;
+  /** Create a dedicated agent session per connection. */
+  sessionFactory: () => Promise<string>;
+  /** Tear down a connection's dedicated session on disconnect. */
+  sessionDisposer?: (sessionKey: string) => Promise<void>;
+  /** Runtime profile, for health responses. */
+  profile?: string;
+  channelId?: string;
+  handshakeTimeoutMs?: number;
+  allowedScopes?: string[];
+}
+
+export class AppServerManager {
+  readonly status = new AppServerStatusController();
+  private readonly registry = new AppServerConnectionRegistry();
+  private readonly channel: AppServerChannel;
+  private readonly config: IAppServerConfig;
+  private transport: AppServerWebSocketTransport | null = null;
+  private queue: RequestQueue | null = null;
+  private watchdog: ConnectionWatchdog | null = null;
+  private listenInfo: AppServerListenInfo | null = null;
+
+  constructor(private readonly deps: AppServerManagerDeps) {
+    this.config = normalizeAppServerConfig(deps.config);
+    this.channel = new AppServerChannel(this.registry, deps.channelId ?? APP_SERVER_CHANNEL_ID);
+  }
+
+  /** The channel adapter to register with the agent bootstrap. */
+  getChannel(): ChannelAdapter {
+    return this.channel;
+  }
+
+  getStatus(): AppServerStatusSnapshot {
+    return this.status.getSnapshot();
+  }
+
+  isEnabled(): boolean {
+    return this.config.enabled;
+  }
+
+  /** Start the listener. Throws on bind failure (caller decides recovery). */
+  async start(): Promise<void> {
+    if (!this.config.enabled) {
+      this.status.set({ enabled: false, status: 'disabled' });
+      return;
+    }
+
+    this.status.set({
+      enabled: true,
+      status: 'starting',
+      authMode: this.config.requireAuth ? 'capability-token' : 'none',
+      bindHost: this.config.bindHost,
+      lastError: undefined,
+    });
+
+    await this.deps.auth.ensureToken();
+
+    this.queue = new RequestQueue({ capacity: this.config.requestQueueCapacity });
+    this.watchdog = new ConnectionWatchdog({ handshakeTimeoutMs: this.deps.handshakeTimeoutMs ?? 10_000 });
+    const rateLimiter = new AppServerRateLimiter({ windowMs: 1000, max: 50 });
+
+    const processor = new AppServerRequestProcessor({
+      channelId: this.channel.channelId,
+      channelType: 'websocket',
+      registry: this.registry,
+      auth: this.deps.auth,
+      queue: this.queue,
+      rateLimiter,
+      watchdog: this.watchdog,
+      status: this.status,
+      sessionFactory: this.deps.sessionFactory,
+      sessionDisposer: this.deps.sessionDisposer,
+      allowedScopes: this.deps.allowedScopes,
+    });
+
+    this.transport = new AppServerWebSocketTransport({
+      host: this.config.bindHost,
+      port: this.config.port,
+      socketPath: this.config.transport === 'unix-socket' ? this.config.socketPath : undefined,
+      maxConnections: this.config.maxConnections,
+      maxPayloadBytes: this.config.maxPayloadBytes,
+      maxBufferedBytes: this.config.maxBufferedBytes,
+      rejectBrowserOrigins: this.config.rejectBrowserOrigins,
+      processor,
+      status: this.status,
+      profile: this.deps.profile ?? 'desktop-runtime',
+    });
+
+    this.listenInfo = await this.transport.start();
+    this.status.set({
+      status: 'ready',
+      url: this.listenInfo.url,
+      port: this.listenInfo.port,
+      socketPath: this.listenInfo.socketPath,
+    });
+  }
+
+  async stop(reason = 'stop'): Promise<void> {
+    this.status.set({ status: 'stopping' });
+    await this.transport?.stop(reason);
+    await this.queue?.shutdown(reason);
+    this.watchdog?.stopAll();
+    this.registry.clear();
+    this.transport = null;
+    this.queue = null;
+    this.watchdog = null;
+    this.listenInfo = null;
+    this.status.set({ status: this.config.enabled ? 'disabled' : 'disabled', connections: 0, url: undefined });
+  }
+
+  /** Rotate the capability token. Existing connections remain until they close. */
+  async rotateToken(): Promise<string> {
+    return this.deps.auth.rotateToken();
+  }
+
+  async revealToken(): Promise<string | null> {
+    return this.deps.auth.revealToken();
+  }
+
+  /** Record a fatal startup/runtime error in status (UI surfaces it). */
+  markError(message: string): void {
+    this.status.set({ status: 'error', lastError: message });
+  }
+}

--- a/src/app-server/AppServerRequestProcessor.ts
+++ b/src/app-server/AppServerRequestProcessor.ts
@@ -1,0 +1,351 @@
+/**
+ * App-Server Request Processor
+ *
+ * Owns protocol behavior: handshake, auth, scope enforcement, request
+ * queueing/serialization, and method dispatch to the shared handlers. The
+ * transport only forwards raw connection events here.
+ *
+ * @module app-server/AppServerRequestProcessor
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  ConnectRequestSchema,
+  RequestFrameSchema,
+  PROTOCOL_VERSION,
+  negotiateProtocolVersion,
+  resolveClientInfo,
+  makeResponse,
+  makeErrorResponse,
+  makeEvent,
+  getMethodHandler,
+  getRegisteredMethods,
+  METHOD_REGISTRY,
+  EVENT_SCOPE_MAP,
+  BROADCAST_EVENTS,
+  invalidRequest,
+  unauthorized,
+  WS_CLOSE,
+  type MethodContext,
+  type ChallengePayload,
+  type HelloOkPayload,
+  type ErrorShape,
+} from '@workx/ws-server';
+import type { AppServerConnectionRegistry, ConnectionSocket } from './AppServerConnectionRegistry';
+import type { AppServerAuth } from './connection/AppServerAuth';
+import type { RequestQueue } from './queue/RequestQueue';
+import { resolveSerialization } from './queue/requestSerialization';
+import type { AppServerRateLimiter } from './connection/rateLimiter';
+import type { ConnectionWatchdog } from './connection/ConnectionWatchdog';
+import type { AppServerStatusController } from './status/AppServerStatus';
+
+/**
+ * Default scope set for a capability-token connection. Intentionally narrow:
+ * no `credentials.*` and no `config.write` unless explicitly requested AND
+ * allowed by config. `admin` only enables health/tools.catalog/logs.tail.
+ */
+export const DEFAULT_APP_SERVER_SCOPES = [
+  'chat',
+  'sessions.read',
+  'sessions.write',
+  'config.read',
+  'operator.approvals',
+  'admin',
+];
+
+const SERVER_VERSION = '1.0.0';
+
+export interface AppServerRequestProcessorDeps {
+  channelId: string;
+  channelType: string;
+  registry: AppServerConnectionRegistry;
+  auth: AppServerAuth;
+  queue: RequestQueue;
+  rateLimiter: AppServerRateLimiter;
+  watchdog: ConnectionWatchdog;
+  status: AppServerStatusController;
+  /** Create a dedicated agent session for a connection; returns its id. */
+  sessionFactory: () => Promise<string>;
+  /** Tear down a connection's dedicated session on disconnect (prevents leaks). */
+  sessionDisposer?: (sessionKey: string) => Promise<void>;
+  /** Allowed scopes a connection may be granted (intersected with requested). */
+  allowedScopes?: string[];
+  now?: () => number;
+}
+
+export class AppServerRequestProcessor {
+  private readonly now: () => number;
+
+  constructor(private readonly deps: AppServerRequestProcessorDeps) {
+    this.now = deps.now ?? (() => Date.now());
+  }
+
+  /** Called when the transport accepts a new connection. */
+  onOpen(connectionId: string, socket: ConnectionSocket, isLoopback: boolean): void {
+    this.deps.registry.add({ connectionId, socket, isLoopback, now: this.now() });
+    this.deps.status.setConnections(this.deps.registry.count());
+
+    const challenge: ChallengePayload = {
+      nonce: randomUUID(),
+      protocolVersion: PROTOCOL_VERSION,
+      serverVersion: SERVER_VERSION,
+      authModes: this.deps.auth.authModes(),
+    };
+    socket.send(JSON.stringify(makeEvent('connect.challenge', challenge)));
+
+    this.deps.watchdog.armHandshakeTimeout(connectionId, () => {
+      const conn = this.deps.registry.get(connectionId);
+      if (conn && !conn.authenticated) {
+        conn.socket.close(WS_CLOSE.POLICY_VIOLATION, 'Handshake timeout');
+        this.onClose(connectionId);
+      }
+    });
+  }
+
+  /** Called when the transport receives a frame. `raw` is the JSON string. */
+  async onMessage(connectionId: string, raw: string): Promise<void> {
+    const conn = this.deps.registry.get(connectionId);
+    if (!conn) return;
+    this.deps.registry.touch(connectionId, this.now());
+
+    let frame: unknown;
+    try {
+      frame = JSON.parse(raw);
+    } catch {
+      conn.socket.send(JSON.stringify(makeErrorResponse(randomUUID(), invalidRequest('Invalid JSON'))));
+      return;
+    }
+
+    if (!conn.authenticated) {
+      await this.handleConnect(connectionId, frame);
+      return;
+    }
+
+    const parsed = RequestFrameSchema.safeParse(frame);
+    if (!parsed.success) {
+      conn.socket.send(
+        JSON.stringify(
+          makeErrorResponse(
+            (frame as { id?: string })?.id ?? randomUUID(),
+            invalidRequest('Invalid request frame', parsed.error.issues),
+          ),
+        ),
+      );
+      return;
+    }
+
+    const req = parsed.data;
+
+    // Dedupe per connection.
+    if (conn.requestIds.has(req.id)) {
+      conn.socket.send(JSON.stringify(makeErrorResponse(req.id, invalidRequest('Duplicate request'))));
+      return;
+    }
+
+    // Rate limit.
+    const rl = this.deps.rateLimiter.check(connectionId, this.now());
+    if (rl) {
+      conn.socket.send(JSON.stringify(makeErrorResponse(req.id, rl)));
+      return;
+    }
+
+    // Authorize scope.
+    const spec = METHOD_REGISTRY[req.method];
+    if (!spec) {
+      conn.socket.send(JSON.stringify(makeErrorResponse(req.id, invalidRequest(`Unknown method: ${req.method}`))));
+      return;
+    }
+    if (!conn.scopes.includes(spec.scope)) {
+      conn.socket.send(JSON.stringify(makeErrorResponse(req.id, unauthorized(`Missing scope: ${spec.scope}`))));
+      return;
+    }
+
+    const handler = getMethodHandler(req.method);
+    if (!handler) {
+      conn.socket.send(JSON.stringify(makeErrorResponse(req.id, invalidRequest(`No handler: ${req.method}`))));
+      return;
+    }
+
+    // Health/readiness bypass the queue so they stay observable under load.
+    if (req.method === 'health') {
+      await this.runHandler(connectionId, req.id, req.method, req.params, handler);
+      return;
+    }
+
+    const serialization = resolveSerialization(req.method, {
+      sessionKey: conn.sessionKey,
+      connectionId,
+      approvalId: req.params?.approvalId as string | undefined,
+    });
+
+    conn.requestIds.add(req.id);
+    const result = this.deps.queue.enqueue({
+      connectionId,
+      requestId: req.id,
+      serialKey: serialization.key,
+      mode: serialization.mode,
+      gate: conn.gate,
+      run: () => this.runHandler(connectionId, req.id, req.method, req.params, handler),
+    });
+
+    if (!result.accepted && result.error) {
+      conn.requestIds.delete(req.id);
+      conn.socket.send(JSON.stringify(makeErrorResponse(req.id, result.error)));
+    }
+  }
+
+  /** Called when the transport reports the connection closed. */
+  onClose(connectionId: string): void {
+    const conn = this.deps.registry.get(connectionId);
+    if (!conn) return;
+    const sessionKey = conn.sessionKey;
+    this.deps.watchdog.clearHandshakeTimeout(connectionId);
+    this.deps.rateLimiter.clear(connectionId);
+    this.deps.registry.remove(connectionId);
+    this.deps.status.setConnections(this.deps.registry.count());
+
+    // Dispose the connection's dedicated session so sessions don't accumulate
+    // for the life of the runtime. Fire-and-forget — onClose is a sync sink.
+    if (sessionKey && this.deps.sessionDisposer) {
+      void this.deps.sessionDisposer(sessionKey).catch((err) => {
+        console.error(`[AppServerRequestProcessor] session dispose failed for ${sessionKey}:`, err);
+      });
+    }
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Internals
+  // ───────────────────────────────────────────────────────────────────────
+
+  private async runHandler(
+    connectionId: string,
+    requestId: string,
+    method: string,
+    params: Record<string, unknown> | undefined,
+    handler: ReturnType<typeof getMethodHandler>,
+  ): Promise<void> {
+    const conn = this.deps.registry.get(connectionId);
+    if (!conn || !handler) return;
+
+    const ctx: MethodContext = {
+      connectionId,
+      requestId,
+      role: conn.role,
+      scopes: conn.scopes,
+      sessionKey: (params?.sessionKey as string) ?? conn.sessionKey,
+      channelId: this.deps.channelId,
+      channelType: this.deps.channelType,
+      sendEvent: (event: string, payload?: unknown) => {
+        conn.socket.send(JSON.stringify(makeEvent(event, payload)));
+      },
+    };
+
+    try {
+      const out = await handler(params, ctx);
+      conn.socket.send(JSON.stringify(makeResponse(requestId, out)));
+    } catch (err) {
+      const shape = isErrorShape(err)
+        ? err
+        : ({
+            code: 'UNAVAILABLE',
+            message: err instanceof Error ? err.message : 'Internal error',
+            retryable: true,
+          } as ErrorShape);
+      conn.socket.send(JSON.stringify(makeErrorResponse(requestId, shape)));
+    } finally {
+      conn.requestIds.delete(requestId);
+    }
+  }
+
+  private async handleConnect(connectionId: string, frame: unknown): Promise<void> {
+    const conn = this.deps.registry.get(connectionId);
+    if (!conn) return;
+
+    const parsed = ConnectRequestSchema.safeParse(frame);
+    if (!parsed.success) {
+      const reqId = (frame as { id?: string })?.id ?? randomUUID();
+      conn.socket.send(
+        JSON.stringify(makeErrorResponse(reqId, invalidRequest('Invalid connect request', parsed.error.issues))),
+      );
+      return;
+    }
+    const req = parsed.data;
+
+    const negotiated = negotiateProtocolVersion(req.params);
+    if (negotiated === null) {
+      conn.socket.send(
+        JSON.stringify(makeErrorResponse(req.id, invalidRequest(`Protocol mismatch (server ${PROTOCOL_VERSION})`))),
+      );
+      conn.socket.close(WS_CLOSE.PROTOCOL_MISMATCH, 'Protocol mismatch');
+      return;
+    }
+
+    const clientInfo = resolveClientInfo(req.params);
+    if (!clientInfo) {
+      conn.socket.send(JSON.stringify(makeErrorResponse(req.id, invalidRequest('Client identification required'))));
+      return;
+    }
+
+    if (!this.deps.auth.verify(req.params.auth?.token)) {
+      conn.socket.send(JSON.stringify(makeErrorResponse(req.id, unauthorized('Invalid capability token'))));
+      conn.socket.close(WS_CLOSE.POLICY_VIOLATION, 'Invalid token');
+      this.onClose(connectionId);
+      return;
+    }
+
+    // Resolve scopes: allowed ∩ requested (or all allowed if none requested).
+    const allowed = this.deps.allowedScopes ?? DEFAULT_APP_SERVER_SCOPES;
+    const requested = req.params.scopes;
+    const scopes =
+      requested && requested.length > 0 ? requested.filter((s) => allowed.includes(s)) : [...allowed];
+
+    // Create a dedicated session for this connection.
+    let sessionKey: string;
+    try {
+      sessionKey = await this.deps.sessionFactory();
+    } catch (err) {
+      conn.socket.send(
+        JSON.stringify(
+          makeErrorResponse(req.id, {
+            code: 'UNAVAILABLE',
+            message: `Failed to create session: ${err instanceof Error ? err.message : String(err)}`,
+            retryable: true,
+          }),
+        ),
+      );
+      return;
+    }
+
+    conn.authenticated = true;
+    conn.role = clientInfo.mode;
+    conn.scopes = scopes;
+    conn.sessionKey = sessionKey;
+    conn.clientInfo = { id: clientInfo.id, mode: clientInfo.mode };
+    conn.subscriptions.add(sessionKey);
+    this.deps.watchdog.clearHandshakeTimeout(connectionId);
+
+    const helloOk: HelloOkPayload = {
+      type: 'hello-ok',
+      protocol: negotiated,
+      server: { version: SERVER_VERSION, connId: connectionId },
+      features: { methods: getRegisteredMethods(), events: buildAvailableEvents(scopes) },
+      snapshot: { sessions: [], health: { status: this.deps.status.getSnapshot().status } },
+      auth: { role: clientInfo.mode, scopes, issuedAtMs: this.now() },
+      policy: { maxPayload: 0, maxBufferedBytes: 0, tickIntervalMs: 30_000 },
+      sessionKey,
+    };
+    conn.socket.send(JSON.stringify(makeResponse(req.id, helloOk)));
+  }
+}
+
+function buildAvailableEvents(scopes: string[]): string[] {
+  const events = new Set<string>(BROADCAST_EVENTS);
+  for (const [name, scope] of Object.entries(EVENT_SCOPE_MAP)) {
+    if (scopes.includes(scope)) events.add(name);
+  }
+  return Array.from(events);
+}
+
+function isErrorShape(err: unknown): err is ErrorShape {
+  return typeof err === 'object' && err !== null && 'code' in err && 'message' in err;
+}

--- a/src/app-server/AppServerRequestProcessor.ts
+++ b/src/app-server/AppServerRequestProcessor.ts
@@ -20,9 +20,8 @@ import {
   makeEvent,
   getMethodHandler,
   getRegisteredMethods,
+  buildAvailableEvents,
   METHOD_REGISTRY,
-  EVENT_SCOPE_MAP,
-  BROADCAST_EVENTS,
   invalidRequest,
   unauthorized,
   WS_CLOSE,
@@ -81,8 +80,8 @@ export class AppServerRequestProcessor {
   }
 
   /** Called when the transport accepts a new connection. */
-  onOpen(connectionId: string, socket: ConnectionSocket, isLoopback: boolean): void {
-    this.deps.registry.add({ connectionId, socket, isLoopback, now: this.now() });
+  onOpen(connectionId: string, socket: ConnectionSocket): void {
+    this.deps.registry.add({ connectionId, socket, now: this.now() });
     this.deps.status.setConnections(this.deps.registry.count());
 
     const challenge: ChallengePayload = {
@@ -142,13 +141,6 @@ export class AppServerRequestProcessor {
       return;
     }
 
-    // Rate limit.
-    const rl = this.deps.rateLimiter.check(connectionId, this.now());
-    if (rl) {
-      conn.socket.send(JSON.stringify(makeErrorResponse(req.id, rl)));
-      return;
-    }
-
     // Authorize scope.
     const spec = METHOD_REGISTRY[req.method];
     if (!spec) {
@@ -166,9 +158,18 @@ export class AppServerRequestProcessor {
       return;
     }
 
-    // Health/readiness bypass the queue so they stay observable under load.
+    // Health/readiness bypass BOTH the rate limiter and the queue so they stay
+    // observable under load — a throttled liveness probe reads as an unhealthy
+    // server and can trigger a needless restart of a healthy sidecar.
     if (req.method === 'health') {
       await this.runHandler(connectionId, req.id, req.method, req.params, handler);
+      return;
+    }
+
+    // Rate limit (after the health bypass).
+    const rl = this.deps.rateLimiter.check(connectionId, this.now());
+    if (rl) {
+      conn.socket.send(JSON.stringify(makeErrorResponse(req.id, rl)));
       return;
     }
 
@@ -336,14 +337,6 @@ export class AppServerRequestProcessor {
     };
     conn.socket.send(JSON.stringify(makeResponse(req.id, helloOk)));
   }
-}
-
-function buildAvailableEvents(scopes: string[]): string[] {
-  const events = new Set<string>(BROADCAST_EVENTS);
-  for (const [name, scope] of Object.entries(EVENT_SCOPE_MAP)) {
-    if (scopes.includes(scope)) events.add(name);
-  }
-  return Array.from(events);
 }
 
 function isErrorShape(err: unknown): err is ErrorShape {

--- a/src/app-server/__tests__/AppServerAuth.test.ts
+++ b/src/app-server/__tests__/AppServerAuth.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { AppServerAuth, InMemoryTokenStore } from '../connection/AppServerAuth';
+
+describe('AppServerAuth', () => {
+  it('generates and persists a token on ensureToken', async () => {
+    const store = new InMemoryTokenStore();
+    const auth = new AppServerAuth({ requireAuth: true, store });
+    const token = await auth.ensureToken();
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    expect(await store.getToken()).toBe(token);
+  });
+
+  it('returns the same token on repeated ensureToken', async () => {
+    const auth = new AppServerAuth({ requireAuth: true, store: new InMemoryTokenStore() });
+    const a = await auth.ensureToken();
+    const b = await auth.ensureToken();
+    expect(a).toBe(b);
+  });
+
+  it('verifies the correct token and rejects wrong ones', async () => {
+    const auth = new AppServerAuth({ requireAuth: true, store: new InMemoryTokenStore() });
+    const token = await auth.ensureToken();
+    expect(auth.verify(token)).toBe(true);
+    expect(auth.verify('wrong')).toBe(false);
+    expect(auth.verify(undefined)).toBe(false);
+    expect(auth.verify(token + 'x')).toBe(false);
+  });
+
+  it('rotates the token, invalidating the old one', async () => {
+    const auth = new AppServerAuth({ requireAuth: true, store: new InMemoryTokenStore() });
+    const old = await auth.ensureToken();
+    const next = await auth.rotateToken();
+    expect(next).not.toBe(old);
+    expect(auth.verify(old)).toBe(false);
+    expect(auth.verify(next)).toBe(true);
+  });
+
+  it('advertises capability-token mode when auth required', () => {
+    const auth = new AppServerAuth({ requireAuth: true, store: new InMemoryTokenStore() });
+    expect(auth.authModes()).toEqual(['capability-token']);
+  });
+
+  it('accepts any token when auth is disabled', async () => {
+    const auth = new AppServerAuth({ requireAuth: false, store: new InMemoryTokenStore() });
+    await auth.ensureToken();
+    expect(auth.verify(undefined)).toBe(true);
+    expect(auth.authModes()).toEqual(['none']);
+  });
+});

--- a/src/app-server/__tests__/AppServerChannel.test.ts
+++ b/src/app-server/__tests__/AppServerChannel.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { AppServerChannel } from '../AppServerChannel';
+import { AppServerConnectionRegistry } from '../AppServerConnectionRegistry';
+import type { EventMsg } from '@/core/protocol/events';
+
+function fakeSocket() {
+  const sent: string[] = [];
+  return {
+    sent,
+    socket: { send: (d: string) => sent.push(d), close: () => {}, bufferedAmount: () => 0 },
+  };
+}
+
+function addAuthedConn(
+  reg: AppServerConnectionRegistry,
+  id: string,
+  sessionKey: string,
+  scopes: string[],
+) {
+  const f = fakeSocket();
+  const conn = reg.add({ connectionId: id, socket: f.socket, isLoopback: true, now: 0 });
+  conn.authenticated = true;
+  conn.sessionKey = sessionKey;
+  conn.subscriptions.add(sessionKey);
+  conn.scopes = scopes;
+  return f;
+}
+
+describe('AppServerChannel.sendEvent', () => {
+  it('delivers a session event only to the owning connection (multi-client isolation)', async () => {
+    const reg = new AppServerConnectionRegistry();
+    const a = addAuthedConn(reg, 'connA', 'sessA', ['chat']);
+    const b = addAuthedConn(reg, 'connB', 'sessB', ['chat']);
+    const channel = new AppServerChannel(reg);
+
+    await channel.sendEvent({
+      msg: { type: 'AgentMessageDelta', data: { delta: 'hi' } } as unknown as EventMsg,
+      sessionId: 'sessA',
+    });
+
+    expect(a.sent).toHaveLength(1);
+    expect(b.sent).toHaveLength(0);
+    const frame = JSON.parse(a.sent[0]);
+    expect(frame.type).toBe('event');
+    expect(frame.event).toBe('chat');
+    expect(frame.payload.sessionId).toBe('sessA');
+  });
+
+  it('does not deliver scoped events to connections lacking the scope', async () => {
+    const reg = new AppServerConnectionRegistry();
+    const a = addAuthedConn(reg, 'connA', 'sessA', ['sessions.read']); // no 'chat'
+    const channel = new AppServerChannel(reg);
+    await channel.sendEvent({
+      msg: { type: 'AgentMessageDelta', data: {} } as unknown as EventMsg,
+      sessionId: 'sessA',
+    });
+    expect(a.sent).toHaveLength(0);
+  });
+
+  it('skips unauthenticated connections', async () => {
+    const reg = new AppServerConnectionRegistry();
+    const f = fakeSocket();
+    reg.add({ connectionId: 'c', socket: f.socket, isLoopback: true, now: 0 }); // not authenticated
+    const channel = new AppServerChannel(reg);
+    await channel.sendEvent({ msg: { type: 'AgentMessageDelta', data: {} } as unknown as EventMsg, sessionId: 'x' });
+    expect(f.sent).toHaveLength(0);
+  });
+
+  it('includes runId derived from the event payload', async () => {
+    const reg = new AppServerConnectionRegistry();
+    const a = addAuthedConn(reg, 'connA', 'sessA', ['chat', 'admin']);
+    const channel = new AppServerChannel(reg);
+    await channel.sendEvent({
+      msg: { type: 'TaskStarted', data: { submission_id: 'sub_42' } } as unknown as EventMsg,
+      sessionId: 'sessA',
+    });
+    const frame = JSON.parse(a.sent[0]);
+    expect(frame.payload.runId).toBe('sub_42');
+    expect(frame.seq).toBe(1);
+  });
+
+  it('reports websocket channel type and default id', () => {
+    const channel = new AppServerChannel(new AppServerConnectionRegistry());
+    expect(channel.channelType).toBe('websocket');
+    expect(channel.channelId).toBe('desktop-app-server');
+  });
+});

--- a/src/app-server/__tests__/AppServerChannel.test.ts
+++ b/src/app-server/__tests__/AppServerChannel.test.ts
@@ -18,7 +18,7 @@ function addAuthedConn(
   scopes: string[],
 ) {
   const f = fakeSocket();
-  const conn = reg.add({ connectionId: id, socket: f.socket, isLoopback: true, now: 0 });
+  const conn = reg.add({ connectionId: id, socket: f.socket, now: 0 });
   conn.authenticated = true;
   conn.sessionKey = sessionKey;
   conn.subscriptions.add(sessionKey);
@@ -60,7 +60,7 @@ describe('AppServerChannel.sendEvent', () => {
   it('skips unauthenticated connections', async () => {
     const reg = new AppServerConnectionRegistry();
     const f = fakeSocket();
-    reg.add({ connectionId: 'c', socket: f.socket, isLoopback: true, now: 0 }); // not authenticated
+    reg.add({ connectionId: 'c', socket: f.socket, now: 0 }); // not authenticated
     const channel = new AppServerChannel(reg);
     await channel.sendEvent({ msg: { type: 'AgentMessageDelta', data: {} } as unknown as EventMsg, sessionId: 'x' });
     expect(f.sent).toHaveLength(0);

--- a/src/app-server/__tests__/AppServerRequestProcessor.test.ts
+++ b/src/app-server/__tests__/AppServerRequestProcessor.test.ts
@@ -73,7 +73,7 @@ async function makeHarness(opts?: { capacity?: number; requireAuth?: boolean }):
       const sent: unknown[] = [];
       const close = vi.fn();
       sockets.set(id, { sent, close });
-      processor.onOpen(id, { send: (d) => sent.push(d), close, bufferedAmount: () => 0 }, true);
+      processor.onOpen(id, { send: (d) => sent.push(d), close, bufferedAmount: () => 0 });
     },
     send: (id, frame) => processor.onMessage(id, JSON.stringify(frame)),
     frames: (id) => (sockets.get(id)!.sent as string[]).map((s) => JSON.parse(s)),

--- a/src/app-server/__tests__/AppServerRequestProcessor.test.ts
+++ b/src/app-server/__tests__/AppServerRequestProcessor.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { registerMethodHandler } from '@workx/ws-server';
+import { AppServerRequestProcessor } from '../AppServerRequestProcessor';
+import { AppServerConnectionRegistry } from '../AppServerConnectionRegistry';
+import { AppServerAuth, InMemoryTokenStore } from '../connection/AppServerAuth';
+import { RequestQueue } from '../queue/RequestQueue';
+import { AppServerRateLimiter } from '../connection/rateLimiter';
+import { ConnectionWatchdog } from '../connection/ConnectionWatchdog';
+import { AppServerStatusController } from '../status/AppServerStatus';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+let blockHealthList: ReturnType<typeof deferred> | null = null;
+
+beforeAll(() => {
+  registerMethodHandler('health', async () => ({ status: 'ok' }));
+  registerMethodHandler('sessions.list', async () => {
+    if (blockHealthList) await blockHealthList.promise;
+    return { sessions: [] };
+  });
+});
+
+interface Harness {
+  processor: AppServerRequestProcessor;
+  auth: AppServerAuth;
+  token: string;
+  sockets: Map<string, { sent: unknown[]; close: ReturnType<typeof vi.fn> }>;
+  disposed: string[];
+  open: (id: string) => void;
+  send: (id: string, frame: unknown) => Promise<void>;
+  frames: (id: string) => any[];
+  last: (id: string) => any;
+}
+
+async function makeHarness(opts?: { capacity?: number; requireAuth?: boolean }): Promise<Harness> {
+  const registry = new AppServerConnectionRegistry();
+  const store = new InMemoryTokenStore();
+  const auth = new AppServerAuth({ requireAuth: opts?.requireAuth ?? true, store });
+  const token = await auth.ensureToken();
+  const status = new AppServerStatusController();
+  let sessionCounter = 0;
+  const disposed: string[] = [];
+
+  const sockets = new Map<string, { sent: unknown[]; close: ReturnType<typeof vi.fn> }>();
+
+  const processor = new AppServerRequestProcessor({
+    channelId: 'desktop-app-server',
+    channelType: 'websocket',
+    registry,
+    auth,
+    queue: new RequestQueue({ capacity: opts?.capacity ?? 128 }),
+    rateLimiter: new AppServerRateLimiter({ windowMs: 1000, max: 1000 }),
+    watchdog: new ConnectionWatchdog({ handshakeTimeoutMs: 10_000 }),
+    status,
+    sessionFactory: async () => `sess_${++sessionCounter}`,
+    sessionDisposer: async (key) => {
+      disposed.push(key);
+    },
+  });
+
+  return {
+    processor,
+    auth,
+    token,
+    sockets,
+    disposed,
+    open: (id: string) => {
+      const sent: unknown[] = [];
+      const close = vi.fn();
+      sockets.set(id, { sent, close });
+      processor.onOpen(id, { send: (d) => sent.push(d), close, bufferedAmount: () => 0 }, true);
+    },
+    send: (id, frame) => processor.onMessage(id, JSON.stringify(frame)),
+    frames: (id) => (sockets.get(id)!.sent as string[]).map((s) => JSON.parse(s)),
+    last: (id) => {
+      const arr = sockets.get(id)!.sent as string[];
+      return JSON.parse(arr[arr.length - 1]);
+    },
+  };
+}
+
+function connectFrame(token?: string) {
+  return {
+    type: 'req',
+    id: randomUUID(),
+    method: 'connect',
+    params: {
+      protocolVersion: 1,
+      clientId: 'test-client',
+      clientMode: 'operator',
+      auth: token ? { token } : undefined,
+    },
+  };
+}
+
+describe('AppServerRequestProcessor', () => {
+  it('sends a connect.challenge on open', async () => {
+    const h = await makeHarness();
+    h.open('c1');
+    const f = h.frames('c1');
+    expect(f[0].type).toBe('event');
+    expect(f[0].event).toBe('connect.challenge');
+    expect(f[0].payload.authModes).toEqual(['capability-token']);
+  });
+
+  it('rejects a method request before connect', async () => {
+    const h = await makeHarness();
+    h.open('c1');
+    await h.send('c1', { type: 'req', id: randomUUID(), method: 'health' });
+    const last = h.last('c1');
+    expect(last.ok).toBe(false);
+    expect(last.error.code).toBe('INVALID_REQUEST');
+  });
+
+  it('rejects an invalid capability token and closes', async () => {
+    const h = await makeHarness();
+    h.open('c1');
+    await h.send('c1', connectFrame('bogus-token'));
+    const last = h.last('c1');
+    expect(last.ok).toBe(false);
+    expect(last.error.code).toBe('UNAUTHORIZED');
+    expect(h.sockets.get('c1')!.close).toHaveBeenCalled();
+  });
+
+  it('completes the handshake with a valid token and assigns a session', async () => {
+    const h = await makeHarness();
+    h.open('c1');
+    await h.send('c1', connectFrame(h.token));
+    const last = h.last('c1');
+    expect(last.ok).toBe(true);
+    expect(last.payload.type).toBe('hello-ok');
+    expect(last.payload.sessionKey).toBe('sess_1');
+    // Narrow default scopes: no credential/config write.
+    expect(last.payload.auth.scopes).not.toContain('credentials.write');
+    expect(last.payload.auth.scopes).not.toContain('config.write');
+    expect(last.payload.auth.scopes).toContain('chat');
+  });
+
+  it('gives each connection its own session (isolation)', async () => {
+    const h = await makeHarness();
+    h.open('a');
+    h.open('b');
+    await h.send('a', connectFrame(h.token));
+    await h.send('b', connectFrame(h.token));
+    expect(h.last('a').payload.sessionKey).toBe('sess_1');
+    expect(h.last('b').payload.sessionKey).toBe('sess_2');
+  });
+
+  it('dispatches an authorized method and returns its result', async () => {
+    const h = await makeHarness();
+    h.open('c1');
+    await h.send('c1', connectFrame(h.token));
+    const reqId = randomUUID();
+    await h.send('c1', { type: 'req', id: reqId, method: 'health' });
+    const res = h.frames('c1').find((f) => f.id === reqId);
+    expect(res.ok).toBe(true);
+    expect(res.payload.status).toBe('ok');
+  });
+
+  it('rejects a duplicate request id while the first is in flight', async () => {
+    const h = await makeHarness();
+    h.open('c1');
+    await h.send('c1', connectFrame(h.token));
+    const id = randomUUID();
+    blockHealthList = deferred();
+    try {
+      // First in-flight (blocked) request occupies the id.
+      void h.send('c1', { type: 'req', id, method: 'sessions.list' });
+      // Second with the same id while the first is still running.
+      await h.send('c1', { type: 'req', id, method: 'sessions.list' });
+      const dup = h.frames('c1').filter((f) => f.id === id && f.ok === false);
+      expect(dup.some((f) => f.error.message === 'Duplicate request')).toBe(true);
+    } finally {
+      blockHealthList.resolve();
+      blockHealthList = null;
+    }
+  });
+
+  it('returns OVERLOADED when the scheduler is saturated', async () => {
+    const h = await makeHarness({ capacity: 1 });
+    h.open('c1');
+    await h.send('c1', connectFrame(h.token));
+    blockHealthList = deferred();
+    try {
+      await h.send('c1', { type: 'req', id: randomUUID(), method: 'sessions.list' }); // occupies capacity
+      const overflowId = randomUUID();
+      await h.send('c1', { type: 'req', id: overflowId, method: 'sessions.list' });
+      const res = h.frames('c1').find((f) => f.id === overflowId);
+      expect(res.ok).toBe(false);
+      expect(res.error.code).toBe('OVERLOADED');
+    } finally {
+      blockHealthList.resolve();
+      blockHealthList = null;
+    }
+  });
+
+  it('drops connection state on close', async () => {
+    const h = await makeHarness();
+    h.open('c1');
+    await h.send('c1', connectFrame(h.token));
+    h.processor.onClose('c1');
+    // A subsequent message for the closed connection is a no-op (no throw).
+    await expect(h.send('c1', { type: 'req', id: randomUUID(), method: 'health' })).resolves.toBeUndefined();
+  });
+
+  it('disposes the connection session on close (no session leak)', async () => {
+    const h = await makeHarness();
+    h.open('c1');
+    await h.send('c1', connectFrame(h.token));
+    expect(h.last('c1').payload.sessionKey).toBe('sess_1');
+    h.processor.onClose('c1');
+    await Promise.resolve(); // let the fire-and-forget disposer settle
+    expect(h.disposed).toEqual(['sess_1']);
+  });
+
+  it('does not dispose a session for a connection that never authenticated', async () => {
+    const h = await makeHarness();
+    h.open('c1');
+    h.processor.onClose('c1'); // closed before any successful connect
+    await Promise.resolve();
+    expect(h.disposed).toEqual([]);
+  });
+});

--- a/src/app-server/__tests__/RequestQueue.test.ts
+++ b/src/app-server/__tests__/RequestQueue.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { RequestQueue } from '../queue/RequestQueue';
+import { ConnectionRpcGate } from '../connection/ConnectionRpcGate';
+
+function deferred<T = void>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+describe('RequestQueue', () => {
+  it('returns OVERLOADED when the queue is at capacity', async () => {
+    const queue = new RequestQueue({ capacity: 1 });
+    const block = deferred();
+
+    const first = queue.enqueue({
+      connectionId: 'c1',
+      requestId: 'r1',
+      serialKey: 'none',
+      mode: 'read',
+      run: () => block.promise,
+    });
+    expect(first.accepted).toBe(true);
+
+    const second = queue.enqueue({
+      connectionId: 'c1',
+      requestId: 'r2',
+      serialKey: 'none',
+      mode: 'read',
+      run: async () => {},
+    });
+    expect(second.accepted).toBe(false);
+    expect(second.error?.code).toBe('OVERLOADED');
+    expect(second.error?.retryable).toBe(true);
+
+    block.resolve();
+    await first.done;
+  });
+
+  it('frees capacity after a request completes', async () => {
+    const queue = new RequestQueue({ capacity: 1 });
+    const r1 = queue.enqueue({ connectionId: 'c', requestId: '1', serialKey: 'none', mode: 'read', run: async () => {} });
+    await r1.done;
+    const r2 = queue.enqueue({ connectionId: 'c', requestId: '2', serialKey: 'none', mode: 'read', run: async () => {} });
+    expect(r2.accepted).toBe(true);
+    await r2.done;
+  });
+
+  it('serializes writes on the same key in order', async () => {
+    const queue = new RequestQueue({ capacity: 10 });
+    const order: string[] = [];
+    const mk = (id: string) =>
+      queue.enqueue({
+        connectionId: 'c',
+        requestId: id,
+        serialKey: 'session:s1',
+        mode: 'write',
+        run: async () => {
+          order.push(`start:${id}`);
+          await new Promise((r) => setTimeout(r, 5));
+          order.push(`end:${id}`);
+        },
+      });
+    const a = mk('a');
+    const b = mk('b');
+    await Promise.all([a.done, b.done]);
+    // b cannot start until a finished.
+    expect(order).toEqual(['start:a', 'end:a', 'start:b', 'end:b']);
+  });
+
+  it('never overlaps same-key writes, even when later writes arrive mid-flight', async () => {
+    // Regression: the per-key lock entry must not be dropped while a same-key
+    // request is still queued, or a replacement lock would let a later write
+    // run concurrently. Stagger arrivals so some land while earlier writes are
+    // in flight and others land just as the queue drains.
+    const queue = new RequestQueue({ capacity: 50 });
+    let active = 0;
+    let maxActive = 0;
+    let ran = 0;
+    const mk = (id: string) =>
+      queue.enqueue({
+        connectionId: 'c',
+        requestId: id,
+        serialKey: 'session:s1',
+        mode: 'write',
+        run: async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((r) => setTimeout(r, 1));
+          ran += 1;
+          active -= 1;
+        },
+      });
+
+    const pending: Array<Promise<void> | undefined> = [];
+    for (let i = 0; i < 8; i++) {
+      pending.push(mk(`w${i}`).done);
+      // Yield between some enqueues so arrivals interleave with completions.
+      if (i % 2 === 0) await Promise.resolve();
+    }
+    await Promise.all(pending);
+
+    expect(maxActive).toBe(1); // strict mutual exclusion held throughout
+    expect(ran).toBe(8);
+  });
+
+  it('runs reads on the same key concurrently', async () => {
+    const queue = new RequestQueue({ capacity: 10 });
+    let active = 0;
+    let maxActive = 0;
+    const mk = (id: string) =>
+      queue.enqueue({
+        connectionId: 'c',
+        requestId: id,
+        serialKey: 'session:s1',
+        mode: 'read',
+        run: async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((r) => setTimeout(r, 5));
+          active -= 1;
+        },
+      });
+    await Promise.all([mk('a').done, mk('b').done]);
+    expect(maxActive).toBeGreaterThan(1);
+  });
+
+  it('does not run work whose connection gate is closed', async () => {
+    const queue = new RequestQueue({ capacity: 10 });
+    const gate = new ConnectionRpcGate();
+    gate.close();
+    let ran = false;
+    const res = queue.enqueue({
+      connectionId: 'c',
+      requestId: '1',
+      serialKey: 'session:s1',
+      mode: 'write',
+      gate,
+      run: async () => {
+        ran = true;
+      },
+    });
+    await res.done;
+    expect(ran).toBe(false);
+  });
+});

--- a/src/app-server/__tests__/appServerConfig.test.ts
+++ b/src/app-server/__tests__/appServerConfig.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  normalizeAppServerConfig,
+  isLoopbackHost,
+  AppServerConfigError,
+  APP_SERVER_DEFAULTS,
+} from '../appServerConfig';
+import { getDefaultAgentConfig } from '@/config/defaults';
+
+describe('appServerConfig', () => {
+  afterEach(() => {
+    delete process.env.WORKX_APP_SERVER_DEV_ALLOW_NO_AUTH;
+  });
+
+  it('applies defaults for an empty config', () => {
+    const cfg = normalizeAppServerConfig(undefined);
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.bindHost).toBe('127.0.0.1');
+    expect(cfg.port).toBe(18101);
+    expect(cfg.requireAuth).toBe(true);
+    expect(cfg.rejectBrowserOrigins).toBe(true);
+  });
+
+  it('matches the exported defaults', () => {
+    expect(APP_SERVER_DEFAULTS.port).toBe(18101);
+    expect(APP_SERVER_DEFAULTS.maxConnections).toBe(16);
+  });
+
+  it('identifies loopback hosts', () => {
+    expect(isLoopbackHost('127.0.0.1')).toBe(true);
+    expect(isLoopbackHost('::1')).toBe(true);
+    expect(isLoopbackHost('localhost')).toBe(true);
+    expect(isLoopbackHost('0.0.0.0')).toBe(false);
+    expect(isLoopbackHost('192.168.1.5')).toBe(false);
+  });
+
+  it('rejects a non-loopback bind when allowLan is false', () => {
+    expect(() =>
+      normalizeAppServerConfig({ enabled: true, bindHost: '0.0.0.0', allowLan: false }),
+    ).toThrow(AppServerConfigError);
+  });
+
+  it('permits a non-loopback bind when allowLan is true', () => {
+    const cfg = normalizeAppServerConfig({ enabled: true, bindHost: '0.0.0.0', allowLan: true });
+    expect(cfg.bindHost).toBe('0.0.0.0');
+  });
+
+  it('rejects requireAuth=false without the dev override', () => {
+    expect(() => normalizeAppServerConfig({ requireAuth: false })).toThrow(AppServerConfigError);
+  });
+
+  it('permits requireAuth=false with the dev override env', () => {
+    process.env.WORKX_APP_SERVER_DEV_ALLOW_NO_AUTH = '1';
+    const cfg = normalizeAppServerConfig({ requireAuth: false });
+    expect(cfg.requireAuth).toBe(false);
+  });
+
+  it('clamps out-of-range numeric fields by throwing', () => {
+    expect(() => normalizeAppServerConfig({ port: 70000 })).toThrow(AppServerConfigError);
+    expect(() => normalizeAppServerConfig({ maxConnections: 0 })).toThrow(AppServerConfigError);
+    expect(() => normalizeAppServerConfig({ requestQueueCapacity: 99999 })).toThrow(AppServerConfigError);
+    expect(() => normalizeAppServerConfig({ maxPayloadBytes: 10 })).toThrow(AppServerConfigError);
+  });
+
+  it('rejects an unknown transport', () => {
+    expect(() =>
+      normalizeAppServerConfig({ transport: 'carrier-pigeon' as unknown as 'websocket' }),
+    ).toThrow(AppServerConfigError);
+  });
+
+  it('allows port 0 (OS-assigned)', () => {
+    const cfg = normalizeAppServerConfig({ port: 0 });
+    expect(cfg.port).toBe(0);
+  });
+
+  it('is disabled by default in the shipped agent config', () => {
+    const cfg = getDefaultAgentConfig();
+    expect(cfg.appServer?.enabled).toBe(false);
+    expect(cfg.appServer?.bindHost).toBe('127.0.0.1');
+    expect(cfg.appServer?.requireAuth).toBe(true);
+  });
+});

--- a/src/app-server/__tests__/transport.integration.test.ts
+++ b/src/app-server/__tests__/transport.integration.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { get as httpGet } from 'node:http';
+import { WebSocket } from 'ws';
+import { registerMethodHandler } from '@workx/ws-server';
+import { AppServerManager } from '../AppServerManager';
+import { AppServerAuth, InMemoryTokenStore } from '../connection/AppServerAuth';
+
+let manager: AppServerManager;
+let auth: AppServerAuth;
+let token: string;
+let port: number;
+
+beforeAll(async () => {
+  registerMethodHandler('health', async () => ({ status: 'ok' }));
+
+  auth = new AppServerAuth({ requireAuth: true, store: new InMemoryTokenStore() });
+  let n = 0;
+  manager = new AppServerManager({
+    config: { enabled: true, bindHost: '127.0.0.1', port: 0 },
+    auth,
+    sessionFactory: async () => `sess_${++n}`,
+    profile: 'test',
+  });
+  await manager.start();
+  token = (await auth.revealToken())!;
+  port = manager.getStatus().port!;
+});
+
+afterAll(async () => {
+  await manager.stop('test');
+});
+
+function httpStatus(path: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    httpGet({ host: '127.0.0.1', port, path }, (res) => {
+      let body = '';
+      res.on('data', (c) => (body += c));
+      res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
+    }).on('error', reject);
+  });
+}
+
+/** Connect, perform the handshake, return the hello-ok payload + socket. */
+function connect(opts: { token?: string; origin?: string } = {}): Promise<{ ws: WebSocket; hello: any }> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`, opts.origin ? { origin: opts.origin } : undefined);
+    const timer = setTimeout(() => reject(new Error('handshake timeout')), 4000);
+
+    ws.on('unexpected-response', (_req, res) => {
+      clearTimeout(timer);
+      reject(new Error(`unexpected-response ${res.statusCode}`));
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    ws.on('message', (data) => {
+      const frame = JSON.parse(data.toString());
+      if (frame.type === 'event' && frame.event === 'connect.challenge') {
+        ws.send(
+          JSON.stringify({
+            type: 'req',
+            id: crypto.randomUUID(),
+            method: 'connect',
+            params: {
+              protocolVersion: 1,
+              clientId: 'itest',
+              clientMode: 'operator',
+              auth: opts.token ? { token: opts.token } : undefined,
+            },
+          }),
+        );
+        return;
+      }
+      if (frame.type === 'res') {
+        clearTimeout(timer);
+        if (frame.ok) resolve({ ws, hello: frame.payload });
+        else {
+          ws.close();
+          reject(new Error(frame.error?.code ?? 'connect failed'));
+        }
+      }
+    });
+  });
+}
+
+describe('AppServerWebSocketTransport (integration)', () => {
+  it('serves /readyz with 200 when ready', async () => {
+    const r = await httpStatus('/readyz');
+    expect(r.status).toBe(200);
+  });
+
+  it('serves /healthz JSON with connection count and no secrets', async () => {
+    const r = await httpStatus('/healthz');
+    expect(r.status).toBe(200);
+    const body = JSON.parse(r.body);
+    expect(body.status).toBe('ready');
+    expect(typeof body.connections).toBe('number');
+    expect(r.body).not.toMatch(/token/i);
+  });
+
+  it('keeps the /health compatibility alias', async () => {
+    const r = await httpStatus('/health');
+    expect(r.status).toBe(200);
+  });
+
+  it('rejects a WebSocket upgrade carrying an Origin header', async () => {
+    await expect(connect({ token, origin: 'http://evil.example' })).rejects.toThrow(/403|unexpected-response/);
+  });
+
+  it('rejects an invalid capability token', async () => {
+    await expect(connect({ token: 'wrong-token' })).rejects.toThrow(/UNAUTHORIZED/);
+  });
+
+  it('completes the handshake with a valid token and runs a method', async () => {
+    const { ws, hello } = await connect({ token });
+    expect(hello.type).toBe('hello-ok');
+    expect(hello.sessionKey).toMatch(/^sess_/);
+
+    const reqId = crypto.randomUUID();
+    const result = await new Promise<any>((resolve) => {
+      ws.on('message', (data) => {
+        const f = JSON.parse(data.toString());
+        if (f.type === 'res' && f.id === reqId) resolve(f);
+      });
+      ws.send(JSON.stringify({ type: 'req', id: reqId, method: 'health' }));
+    });
+    expect(result.ok).toBe(true);
+    expect(result.payload.status).toBe('ok');
+    ws.close();
+  });
+});

--- a/src/app-server/__tests__/units.test.ts
+++ b/src/app-server/__tests__/units.test.ts
@@ -10,8 +10,8 @@ import {
   isScopeEligible,
   isSessionEligible,
   extractRunId,
-  eventMsgToName,
 } from '../AppServerChannel';
+import { eventMsgToName } from '@/server/channels/eventWireName';
 import type { EventMsg } from '@/core/protocol/events';
 import type { AppServerStatusSnapshot } from '../status/AppServerStatus';
 
@@ -99,7 +99,7 @@ describe('AppServerConnectionRegistry', () => {
 
   it('adds, gets, counts, and removes connections', () => {
     const reg = new AppServerConnectionRegistry();
-    reg.add({ connectionId: 'c1', socket, isLoopback: true, now: 1 });
+    reg.add({ connectionId: 'c1', socket, now: 1 });
     expect(reg.count()).toBe(1);
     expect(reg.get('c1')?.connectionId).toBe('c1');
     const removed = reg.remove('c1');

--- a/src/app-server/__tests__/units.test.ts
+++ b/src/app-server/__tests__/units.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ConnectionRpcGate } from '../connection/ConnectionRpcGate';
+import { resolveSerialization, serializationKeyString } from '../queue/requestSerialization';
+import { AppServerRateLimiter } from '../connection/rateLimiter';
+import { handleHealthRequest, buildHealthBody } from '../transport/httpHealth';
+import { AppServerConnectionRegistry } from '../AppServerConnectionRegistry';
+import { ConnectionWatchdog } from '../connection/ConnectionWatchdog';
+import { AppServerStatusController } from '../status/AppServerStatus';
+import {
+  isScopeEligible,
+  isSessionEligible,
+  extractRunId,
+  eventMsgToName,
+} from '../AppServerChannel';
+import type { EventMsg } from '@/core/protocol/events';
+import type { AppServerStatusSnapshot } from '../status/AppServerStatus';
+
+describe('ConnectionRpcGate', () => {
+  it('allows entry until closed', () => {
+    const g = new ConnectionRpcGate();
+    expect(g.tryEnter()).toBe(true);
+    expect(g.activeRequests).toBe(1);
+    g.release();
+    expect(g.activeRequests).toBe(0);
+    g.close();
+    expect(g.tryEnter()).toBe(false);
+    expect(g.isClosed).toBe(true);
+  });
+});
+
+describe('requestSerialization', () => {
+  it('maps writes and reads to keys/modes', () => {
+    expect(resolveSerialization('health', { connectionId: 'c' })).toEqual({ key: 'none', mode: 'read' });
+    expect(resolveSerialization('config.set', { connectionId: 'c' }).mode).toBe('write');
+    expect(resolveSerialization('config.get', { connectionId: 'c' }).mode).toBe('read');
+    expect(resolveSerialization('credentials.set', { connectionId: 'c' }).key).toBe('global:credentials');
+    expect(resolveSerialization('chat.send', { connectionId: 'c', sessionKey: 's1' })).toEqual({
+      key: 'session:s1',
+      mode: 'write',
+    });
+    expect(resolveSerialization('logs.tail', { connectionId: 'c9' }).key).toBe('conn:c9');
+  });
+
+  it('stringifies the connection-local key kind', () => {
+    expect(serializationKeyString({ kind: 'connection-local', connectionId: 'x' })).toBe('conn:x');
+  });
+});
+
+describe('AppServerRateLimiter', () => {
+  it('limits requests within a window', () => {
+    const rl = new AppServerRateLimiter({ windowMs: 1000, max: 2 });
+    expect(rl.check('c', 0)).toBeNull();
+    expect(rl.check('c', 1)).toBeNull();
+    const err = rl.check('c', 2);
+    expect(err?.code).toBe('RATE_LIMITED');
+  });
+
+  it('resets after the window passes', () => {
+    const rl = new AppServerRateLimiter({ windowMs: 1000, max: 1 });
+    expect(rl.check('c', 0)).toBeNull();
+    expect(rl.check('c', 500)?.code).toBe('RATE_LIMITED');
+    expect(rl.check('c', 1500)).toBeNull();
+  });
+});
+
+describe('httpHealth', () => {
+  const status: AppServerStatusSnapshot = { enabled: true, status: 'ready', connections: 2 };
+  const ctx = { status, profile: 'desktop-runtime', startedAtMs: 0, now: 1000 };
+
+  it('returns 200 for /readyz when ready', () => {
+    expect(handleHealthRequest('GET', '/readyz', ctx)?.statusCode).toBe(200);
+  });
+
+  it('returns 503 for /readyz when not ready', () => {
+    const r = handleHealthRequest('GET', '/readyz', { ...ctx, status: { ...status, status: 'starting' } });
+    expect(r?.statusCode).toBe(503);
+  });
+
+  it('serves /healthz and /health JSON', () => {
+    const hz = handleHealthRequest('GET', '/healthz', ctx);
+    expect(hz?.statusCode).toBe(200);
+    expect(JSON.parse(hz!.body).connections).toBe(2);
+    expect(handleHealthRequest('GET', '/health', ctx)?.statusCode).toBe(200);
+  });
+
+  it('ignores non-health paths and non-GET', () => {
+    expect(handleHealthRequest('GET', '/other', ctx)).toBeNull();
+    expect(handleHealthRequest('POST', '/healthz', ctx)).toBeNull();
+  });
+
+  it('never leaks secrets in the health body', () => {
+    const body = buildHealthBody(ctx);
+    expect(JSON.stringify(body)).not.toMatch(/token/i);
+  });
+});
+
+describe('AppServerConnectionRegistry', () => {
+  const socket = { send: () => {}, close: () => {}, bufferedAmount: () => 0 };
+
+  it('adds, gets, counts, and removes connections', () => {
+    const reg = new AppServerConnectionRegistry();
+    reg.add({ connectionId: 'c1', socket, isLoopback: true, now: 1 });
+    expect(reg.count()).toBe(1);
+    expect(reg.get('c1')?.connectionId).toBe('c1');
+    const removed = reg.remove('c1');
+    expect(removed?.gate.isClosed).toBe(true);
+    expect(reg.count()).toBe(0);
+  });
+});
+
+describe('ConnectionWatchdog', () => {
+  it('fires the handshake timeout when not cleared', () => {
+    vi.useFakeTimers();
+    const wd = new ConnectionWatchdog({ handshakeTimeoutMs: 100 });
+    const onTimeout = vi.fn();
+    wd.armHandshakeTimeout('c', onTimeout);
+    vi.advanceTimersByTime(150);
+    expect(onTimeout).toHaveBeenCalledOnce();
+    vi.useRealTimers();
+  });
+
+  it('does not fire when cleared in time', () => {
+    vi.useFakeTimers();
+    const wd = new ConnectionWatchdog({ handshakeTimeoutMs: 100 });
+    const onTimeout = vi.fn();
+    wd.armHandshakeTimeout('c', onTimeout);
+    wd.clearHandshakeTimeout('c');
+    vi.advanceTimersByTime(150);
+    expect(onTimeout).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});
+
+describe('AppServerStatusController', () => {
+  it('merges updates and notifies listeners', () => {
+    const ctrl = new AppServerStatusController();
+    const seen: string[] = [];
+    ctrl.onChange((s) => seen.push(s.status));
+    ctrl.set({ status: 'starting' });
+    ctrl.set({ status: 'ready', url: 'ws://127.0.0.1:1' });
+    expect(ctrl.getSnapshot().status).toBe('ready');
+    expect(ctrl.getSnapshot().url).toBe('ws://127.0.0.1:1');
+    expect(seen).toEqual(['starting', 'ready']);
+  });
+
+  it('only emits on connection change', () => {
+    const ctrl = new AppServerStatusController();
+    const cb = vi.fn();
+    ctrl.onChange(cb);
+    ctrl.setConnections(0); // no change from default 0
+    expect(cb).not.toHaveBeenCalled();
+    ctrl.setConnections(1);
+    expect(cb).toHaveBeenCalledOnce();
+  });
+});
+
+describe('AppServerChannel filtering helpers', () => {
+  it('isScopeEligible respects EVENT_SCOPE_MAP and broadcasts', () => {
+    expect(isScopeEligible('tick', [])).toBe(true); // broadcast
+    expect(isScopeEligible('chat', ['chat'])).toBe(true);
+    expect(isScopeEligible('chat', ['sessions.read'])).toBe(false);
+    expect(isScopeEligible('unknown.event', [])).toBe(true); // unscoped
+  });
+
+  it('isSessionEligible matches owner session or subscriptions', () => {
+    const conn = { sessionKey: 's1', subscriptions: new Set(['s2']) };
+    expect(isSessionEligible(undefined, conn)).toBe(true); // global event
+    expect(isSessionEligible('s1', conn)).toBe(true);
+    expect(isSessionEligible('s2', conn)).toBe(true);
+    expect(isSessionEligible('s3', conn)).toBe(false);
+  });
+
+  it('extractRunId pulls submission_id/turn_id from event data', () => {
+    expect(extractRunId({ type: 'TaskStarted', data: { submission_id: 'sub_1' } } as unknown as EventMsg)).toBe('sub_1');
+    expect(extractRunId({ type: 'TurnStarted', data: { turn_id: 't9' } } as unknown as EventMsg)).toBe('t9');
+    expect(extractRunId({ type: 'AgentMessage', data: {} } as unknown as EventMsg)).toBeUndefined();
+  });
+
+  it('eventMsgToName maps event types to wire names', () => {
+    expect(eventMsgToName({ type: 'AgentMessageDelta' } as unknown as EventMsg)).toBe('chat');
+    expect(eventMsgToName({ type: 'TaskStarted' } as unknown as EventMsg)).toBe('agent');
+    expect(eventMsgToName({ type: 'ExecApprovalRequest' } as unknown as EventMsg)).toBe('exec.approval.requested');
+    expect(eventMsgToName({ type: 'Error' } as unknown as EventMsg)).toBe('health');
+  });
+});

--- a/src/app-server/appServerConfig.ts
+++ b/src/app-server/appServerConfig.ts
@@ -1,0 +1,85 @@
+/**
+ * App-Server Config Normalization
+ *
+ * Host-agnostic normalization/validation of {@link IAppServerConfig}. The
+ * desktop integration reads `IAgentConfig.appServer` and passes it through
+ * here; the agent-facing config schema intentionally does NOT expose these
+ * fields (no LLM write access).
+ *
+ * @module app-server/appServerConfig
+ */
+
+import type { IAppServerConfig, AppServerTransport } from '@/config/types';
+import { DEFAULT_APP_SERVER_CONFIG } from '@/config/defaults';
+
+export type { IAppServerConfig, AppServerTransport };
+
+/** Resolved defaults for app-server config. */
+export const APP_SERVER_DEFAULTS: IAppServerConfig = { ...DEFAULT_APP_SERVER_CONFIG };
+
+/** Env override that permits `requireAuth: false` (development only). */
+const DEV_ALLOW_NO_AUTH_ENV = 'WORKX_APP_SERVER_DEV_ALLOW_NO_AUTH';
+
+export class AppServerConfigError extends Error {}
+
+function clampInt(value: number, min: number, max: number, label: string): number {
+  if (!Number.isInteger(value)) {
+    throw new AppServerConfigError(`appServer.${label} must be an integer`);
+  }
+  if (value < min || value > max) {
+    throw new AppServerConfigError(`appServer.${label} must be in [${min}, ${max}]`);
+  }
+  return value;
+}
+
+/** True when a host is a loopback address. */
+export function isLoopbackHost(host: string): boolean {
+  return (
+    host === '127.0.0.1' ||
+    host === '::1' ||
+    host === 'localhost' ||
+    host === '::ffff:127.0.0.1'
+  );
+}
+
+/**
+ * Normalize a partial app-server config, applying defaults and validating
+ * bounds. Throws {@link AppServerConfigError} on invalid input.
+ */
+export function normalizeAppServerConfig(raw?: Partial<IAppServerConfig>): IAppServerConfig {
+  const merged: IAppServerConfig = { ...APP_SERVER_DEFAULTS, ...(raw ?? {}) };
+
+  if (merged.transport !== 'websocket' && merged.transport !== 'unix-socket') {
+    throw new AppServerConfigError(`appServer.transport must be 'websocket' or 'unix-socket'`);
+  }
+
+  if (typeof merged.bindHost !== 'string' || merged.bindHost.length === 0) {
+    merged.bindHost = APP_SERVER_DEFAULTS.bindHost;
+  }
+
+  merged.port = clampInt(merged.port, 0, 65535, 'port');
+  merged.maxConnections = clampInt(merged.maxConnections, 1, 256, 'maxConnections');
+  merged.maxPayloadBytes = clampInt(merged.maxPayloadBytes, 1024, 67_108_864, 'maxPayloadBytes');
+  merged.maxBufferedBytes = clampInt(merged.maxBufferedBytes, 65_536, 67_108_864, 'maxBufferedBytes');
+  merged.requestQueueCapacity = clampInt(merged.requestQueueCapacity, 1, 4096, 'requestQueueCapacity');
+
+  // Auth must be required unless an explicit development override is set.
+  if (!merged.requireAuth && process.env[DEV_ALLOW_NO_AUTH_ENV] !== '1') {
+    throw new AppServerConfigError(
+      `appServer.requireAuth must be true (set ${DEV_ALLOW_NO_AUTH_ENV}=1 to override in development)`,
+    );
+  }
+
+  // Non-loopback bind requires allowLan.
+  if (
+    merged.transport === 'websocket' &&
+    !merged.allowLan &&
+    !isLoopbackHost(merged.bindHost)
+  ) {
+    throw new AppServerConfigError(
+      `appServer.bindHost '${merged.bindHost}' is not loopback and allowLan is false`,
+    );
+  }
+
+  return merged;
+}

--- a/src/app-server/connection/AppServerAuth.ts
+++ b/src/app-server/connection/AppServerAuth.ts
@@ -1,0 +1,97 @@
+/**
+ * App-Server Capability-Token Auth
+ *
+ * Host-agnostic auth provider. The token is stored through an injected
+ * {@link CapabilityTokenStore} so this module stays free of desktop
+ * control-bridge / keychain imports (the desktop integration injects a
+ * keychain-backed store; tests/headless inject an in-memory store).
+ *
+ * @module app-server/connection/AppServerAuth
+ */
+
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+
+/** Persistence seam for the capability token. */
+export interface CapabilityTokenStore {
+  getToken(): Promise<string | null>;
+  setToken(token: string): Promise<void>;
+  clear(): Promise<void>;
+}
+
+/** In-memory token store (headless/tests). Not persisted across restarts. */
+export class InMemoryTokenStore implements CapabilityTokenStore {
+  private token: string | null = null;
+  async getToken(): Promise<string | null> {
+    return this.token;
+  }
+  async setToken(token: string): Promise<void> {
+    this.token = token;
+  }
+  async clear(): Promise<void> {
+    this.token = null;
+  }
+}
+
+export interface AppServerAuthOptions {
+  requireAuth: boolean;
+  store: CapabilityTokenStore;
+}
+
+export class AppServerAuth {
+  private cached: string | null = null;
+
+  constructor(private readonly opts: AppServerAuthOptions) {}
+
+  get requireAuth(): boolean {
+    return this.opts.requireAuth;
+  }
+
+  /** Auth modes advertised in the connect challenge. */
+  authModes(): string[] {
+    return this.opts.requireAuth ? ['capability-token'] : ['none'];
+  }
+
+  /** Generate a new random capability token. */
+  private static generate(): string {
+    return randomBytes(32).toString('hex');
+  }
+
+  /** Ensure a token exists, generating and persisting one if absent. */
+  async ensureToken(): Promise<string> {
+    if (!this.opts.requireAuth) return '';
+    let token = await this.opts.store.getToken();
+    if (!token) {
+      token = AppServerAuth.generate();
+      await this.opts.store.setToken(token);
+    }
+    this.cached = token;
+    return token;
+  }
+
+  /** Rotate the token, invalidating the previous value. */
+  async rotateToken(): Promise<string> {
+    const token = AppServerAuth.generate();
+    await this.opts.store.setToken(token);
+    this.cached = token;
+    return token;
+  }
+
+  /** Reveal the current token (explicit UI action only). */
+  async revealToken(): Promise<string | null> {
+    return this.opts.store.getToken();
+  }
+
+  /**
+   * Verify a presented token using constant-time comparison.
+   * When auth is disabled, always returns true.
+   */
+  verify(presented: string | undefined): boolean {
+    if (!this.opts.requireAuth) return true;
+    const expected = this.cached;
+    if (!expected || !presented) return false;
+    const a = Buffer.from(presented);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+  }
+}

--- a/src/app-server/connection/ConnectionRpcGate.ts
+++ b/src/app-server/connection/ConnectionRpcGate.ts
@@ -1,0 +1,43 @@
+/**
+ * Connection RPC Gate
+ *
+ * Prevents queued requests from starting after a connection has closed, while
+ * letting in-flight requests finish. Copies the Codex `ConnectionRpcGate`
+ * pattern.
+ *
+ * @module app-server/connection/ConnectionRpcGate
+ */
+
+export class ConnectionRpcGate {
+  private closed = false;
+  private inFlight = 0;
+
+  /**
+   * Attempt to enter the gate before starting a queued request. Returns false
+   * if the connection has closed — the caller must drop/reject the request.
+   * On success the caller MUST call {@link release} when the request completes.
+   */
+  tryEnter(): boolean {
+    if (this.closed) return false;
+    this.inFlight += 1;
+    return true;
+  }
+
+  /** Release a permit acquired via {@link tryEnter}. */
+  release(): void {
+    if (this.inFlight > 0) this.inFlight -= 1;
+  }
+
+  /** Mark the connection closed; no new requests may enter. */
+  close(): void {
+    this.closed = true;
+  }
+
+  get isClosed(): boolean {
+    return this.closed;
+  }
+
+  get activeRequests(): number {
+    return this.inFlight;
+  }
+}

--- a/src/app-server/connection/ConnectionWatchdog.ts
+++ b/src/app-server/connection/ConnectionWatchdog.ts
@@ -1,0 +1,48 @@
+/**
+ * Connection Watchdog
+ *
+ * Handshake-timeout and slow-unauthenticated cleanup for app-server
+ * connections. Each accepted connection is armed with a handshake deadline;
+ * connections that do not authenticate in time are closed.
+ *
+ * @module app-server/connection/ConnectionWatchdog
+ */
+
+export interface ConnectionWatchdogOptions {
+  /** Time a connection has to complete the connect handshake. */
+  handshakeTimeoutMs: number;
+}
+
+export class ConnectionWatchdog {
+  private timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  constructor(
+    private readonly opts: ConnectionWatchdogOptions = { handshakeTimeoutMs: 10_000 },
+  ) {}
+
+  /** Arm a handshake deadline; onTimeout fires if not cleared in time. */
+  armHandshakeTimeout(connectionId: string, onTimeout: () => void): void {
+    this.clearHandshakeTimeout(connectionId);
+    const timer = setTimeout(() => {
+      this.timers.delete(connectionId);
+      onTimeout();
+    }, this.opts.handshakeTimeoutMs);
+    (timer as { unref?: () => void }).unref?.();
+    this.timers.set(connectionId, timer);
+  }
+
+  /** Clear the handshake deadline (called once authenticated). */
+  clearHandshakeTimeout(connectionId: string): void {
+    const timer = this.timers.get(connectionId);
+    if (timer) {
+      clearTimeout(timer);
+      this.timers.delete(connectionId);
+    }
+  }
+
+  /** Stop all timers (shutdown). */
+  stopAll(): void {
+    for (const timer of this.timers.values()) clearTimeout(timer);
+    this.timers.clear();
+  }
+}

--- a/src/app-server/connection/rateLimiter.ts
+++ b/src/app-server/connection/rateLimiter.ts
@@ -1,0 +1,48 @@
+/**
+ * App-Server Rate Limiter
+ *
+ * Simple per-connection sliding-window limiter. Instance-scoped (unlike the
+ * module-global headless limiter) so each app-server instance is independent.
+ *
+ * @module app-server/connection/rateLimiter
+ */
+
+import { rateLimited, type ErrorShape } from '@workx/ws-server';
+
+export interface RateLimiterOptions {
+  /** Window length in milliseconds. */
+  windowMs: number;
+  /** Max requests per connection per window. */
+  max: number;
+}
+
+export class AppServerRateLimiter {
+  private hits = new Map<string, number[]>();
+
+  constructor(private readonly opts: RateLimiterOptions = { windowMs: 1000, max: 50 }) {}
+
+  /**
+   * Record a request and return a RATE_LIMITED error if the connection has
+   * exceeded its window budget, or null if allowed.
+   */
+  check(connectionId: string, now: number): ErrorShape | null {
+    const windowStart = now - this.opts.windowMs;
+    const arr = (this.hits.get(connectionId) ?? []).filter((t) => t > windowStart);
+    if (arr.length >= this.opts.max) {
+      const retryAfterMs = Math.max(1, arr[0] + this.opts.windowMs - now);
+      this.hits.set(connectionId, arr);
+      return rateLimited(retryAfterMs);
+    }
+    arr.push(now);
+    this.hits.set(connectionId, arr);
+    return null;
+  }
+
+  clear(connectionId: string): void {
+    this.hits.delete(connectionId);
+  }
+
+  clearAll(): void {
+    this.hits.clear();
+  }
+}

--- a/src/app-server/queue/RequestQueue.ts
+++ b/src/app-server/queue/RequestQueue.ts
@@ -1,0 +1,156 @@
+/**
+ * Bounded Request Queue
+ *
+ * Enforces a global inbound-queue capacity (returning OVERLOADED when full) and
+ * serializes conflicting requests by resource key (writes exclusive, reads
+ * shared). A per-connection RPC gate prevents queued work from starting after
+ * the connection closes.
+ *
+ * @module app-server/queue/RequestQueue
+ */
+
+import { overloaded, type ErrorShape } from '@workx/ws-server';
+import type { ConnectionRpcGate } from '../connection/ConnectionRpcGate';
+import type { RequestAccessMode } from './requestSerialization';
+
+export interface QueuedRequest {
+  connectionId: string;
+  requestId: string;
+  /** Serialization key (from resolveSerialization). */
+  serialKey: string;
+  mode: RequestAccessMode;
+  /** RPC gate for the owning connection. */
+  gate?: ConnectionRpcGate;
+  /** The work to run. Rejections are surfaced to the caller of run(). */
+  run: () => Promise<void>;
+}
+
+export interface RequestQueueOptions {
+  capacity: number;
+}
+
+/**
+ * Read/write lock per serialization key. Writes are exclusive; reads run
+ * concurrently but never overtake a pending write, and a write waits for
+ * in-flight reads to drain.
+ */
+class RWLock {
+  private writeTail: Promise<void> = Promise.resolve();
+  private activeReads = new Set<Promise<unknown>>();
+
+  /**
+   * Number of requests currently referencing this lock — in-flight OR queued.
+   * The owning map entry must only be removed when this hits zero, otherwise a
+   * still-queued request and a freshly-created replacement lock for the same
+   * key could run concurrently and break serialization.
+   */
+  refs = 0;
+
+  async runWrite<T>(fn: () => Promise<T>): Promise<T> {
+    const prior = this.writeTail;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    this.writeTail = prior.then(() => gate);
+    await prior;
+    // Wait for any in-flight reads issued before this write to finish.
+    await Promise.allSettled([...this.activeReads]);
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+
+  async runRead<T>(fn: () => Promise<T>): Promise<T> {
+    // Reads wait for pending writes, then run concurrently with each other.
+    await this.writeTail;
+    const p = fn();
+    this.activeReads.add(p);
+    try {
+      return await p;
+    } finally {
+      this.activeReads.delete(p);
+    }
+  }
+}
+
+export class RequestQueue {
+  private size = 0;
+  private locks = new Map<string, RWLock>();
+  private shuttingDown = false;
+
+  constructor(private readonly opts: RequestQueueOptions) {}
+
+  get inFlight(): number {
+    return this.size;
+  }
+
+  /**
+   * Enqueue a request. Returns immediately with an OVERLOADED error if the
+   * queue is at capacity. Otherwise schedules the work and returns a promise
+   * that resolves once the work has been attempted.
+   *
+   * Health/readiness checks should bypass the scheduler entirely.
+   */
+  enqueue(req: QueuedRequest): { accepted: boolean; error?: ErrorShape; done?: Promise<void> } {
+    if (this.shuttingDown) {
+      return { accepted: false, error: overloaded(500, 'Server shutting down') };
+    }
+    if (this.size >= this.opts.capacity) {
+      return { accepted: false, error: overloaded() };
+    }
+
+    this.size += 1;
+    const done = this.dispatch(req).finally(() => {
+      this.size -= 1;
+    });
+    return { accepted: true, done };
+  }
+
+  private async dispatch(req: QueuedRequest): Promise<void> {
+    const guarded = async (): Promise<void> => {
+      // Drop work whose connection closed while queued.
+      if (req.gate && !req.gate.tryEnter()) return;
+      try {
+        await req.run();
+      } finally {
+        req.gate?.release();
+      }
+    };
+
+    if (req.serialKey === 'none') {
+      await guarded();
+      return;
+    }
+
+    let lock = this.locks.get(req.serialKey);
+    if (!lock) {
+      lock = new RWLock();
+      this.locks.set(req.serialKey, lock);
+    }
+
+    // Reference the lock for the whole queued+running lifetime so a concurrent
+    // same-key request always shares THIS lock. Only drop the map entry once no
+    // request references it — deleting earlier (e.g. while a write is still
+    // queued) would let a replacement lock run concurrently and break
+    // serialization.
+    lock.refs += 1;
+    try {
+      if (req.mode === 'write') {
+        await lock.runWrite(guarded);
+      } else {
+        await lock.runRead(guarded);
+      }
+    } finally {
+      lock.refs -= 1;
+      if (lock.refs === 0 && this.locks.get(req.serialKey) === lock) {
+        this.locks.delete(req.serialKey);
+      }
+    }
+  }
+
+  async shutdown(_reason: string): Promise<void> {
+    this.shuttingDown = true;
+    this.locks.clear();
+  }
+}

--- a/src/app-server/queue/requestSerialization.ts
+++ b/src/app-server/queue/requestSerialization.ts
@@ -1,0 +1,104 @@
+/**
+ * Request Serialization Keys
+ *
+ * Maps a method + target to a serialization key and access mode so the
+ * request queue can serialize conflicting mutations while letting independent /
+ * read-only requests run concurrently.
+ *
+ * @module app-server/queue/requestSerialization
+ */
+
+export type RequestAccessMode = 'read' | 'write';
+
+export type RequestSerializationKey =
+  | { kind: 'global'; resource: 'config' | 'credentials' | 'tools' }
+  | { kind: 'session'; sessionKey: string }
+  | { kind: 'approval'; approvalId: string }
+  | { kind: 'connection-local'; connectionId: string }
+  | { kind: 'none' };
+
+export interface SerializationResolution {
+  /** Stable string key used by the scheduler's per-key lock. */
+  key: string;
+  mode: RequestAccessMode;
+}
+
+/** Stringify a serialization key for use as a lock map key. */
+export function serializationKeyString(key: RequestSerializationKey): string {
+  switch (key.kind) {
+    case 'global':
+      return `global:${key.resource}`;
+    case 'session':
+      return `session:${key.sessionKey}`;
+    case 'approval':
+      return `approval:${key.approvalId}`;
+    case 'connection-local':
+      return `conn:${key.connectionId}`;
+    case 'none':
+      return 'none';
+  }
+}
+
+const WRITE = 'write' as const;
+const READ = 'read' as const;
+
+/**
+ * Resolve the serialization key + mode for a method.
+ */
+export function resolveSerialization(
+  method: string,
+  ctx: { sessionKey?: string; connectionId: string; approvalId?: string },
+): SerializationResolution {
+  const session = ctx.sessionKey ?? `conn:${ctx.connectionId}`;
+  const sessionKey: RequestSerializationKey = { kind: 'session', sessionKey: session };
+
+  switch (method) {
+    case 'health':
+      return { key: serializationKeyString({ kind: 'none' }), mode: READ };
+    case 'tools.catalog':
+      return { key: serializationKeyString({ kind: 'global', resource: 'tools' }), mode: READ };
+
+    case 'config.get':
+      return { key: serializationKeyString({ kind: 'global', resource: 'config' }), mode: READ };
+    case 'config.set':
+    case 'config.patch':
+      return { key: serializationKeyString({ kind: 'global', resource: 'config' }), mode: WRITE };
+
+    case 'credentials.list':
+      return { key: serializationKeyString({ kind: 'global', resource: 'credentials' }), mode: READ };
+    case 'credentials.set':
+    case 'credentials.delete':
+      return { key: serializationKeyString({ kind: 'global', resource: 'credentials' }), mode: WRITE };
+
+    case 'sessions.list':
+      return { key: serializationKeyString({ kind: 'none' }), mode: READ };
+    case 'sessions.get':
+    case 'sessions.turns':
+    case 'chat.history':
+      return { key: serializationKeyString(sessionKey), mode: READ };
+    case 'sessions.patch':
+    case 'sessions.reset':
+    case 'sessions.delete':
+    case 'sessions.compact':
+    case 'sessions.rewind':
+    case 'chat.send':
+    case 'chat.abort':
+    case 'chat.inject':
+      return { key: serializationKeyString(sessionKey), mode: WRITE };
+
+    case 'exec.approval.resolve':
+      return {
+        key: serializationKeyString({ kind: 'approval', approvalId: ctx.approvalId ?? 'unknown' }),
+        mode: WRITE,
+      };
+
+    case 'logs.tail':
+      return {
+        key: serializationKeyString({ kind: 'connection-local', connectionId: ctx.connectionId }),
+        mode: READ,
+      };
+
+    default:
+      return { key: serializationKeyString({ kind: 'none' }), mode: READ };
+  }
+}

--- a/src/app-server/status/AppServerStatus.ts
+++ b/src/app-server/status/AppServerStatus.ts
@@ -1,0 +1,70 @@
+/**
+ * App-Server Status Controller
+ *
+ * Holds observable app-server runtime status for the UI/services to render.
+ *
+ * @module app-server/status/AppServerStatus
+ */
+
+export type AppServerState =
+  | 'disabled'
+  | 'starting'
+  | 'ready'
+  | 'error'
+  | 'stopping';
+
+export interface AppServerStatusSnapshot {
+  enabled: boolean;
+  status: AppServerState;
+  url?: string;
+  bindHost?: string;
+  port?: number;
+  socketPath?: string;
+  authMode?: 'capability-token' | 'none';
+  connections: number;
+  lastError?: string;
+}
+
+export class AppServerStatusController {
+  private snapshot: AppServerStatusSnapshot = {
+    enabled: false,
+    status: 'disabled',
+    connections: 0,
+  };
+
+  private listeners = new Set<(s: AppServerStatusSnapshot) => void>();
+
+  getSnapshot(): AppServerStatusSnapshot {
+    return { ...this.snapshot };
+  }
+
+  /** Merge a partial update and notify listeners. */
+  set(partial: Partial<AppServerStatusSnapshot>): void {
+    this.snapshot = { ...this.snapshot, ...partial };
+    this.emit();
+  }
+
+  setConnections(n: number): void {
+    if (this.snapshot.connections !== n) {
+      this.snapshot = { ...this.snapshot, connections: n };
+      this.emit();
+    }
+  }
+
+  /** Subscribe to status changes. Returns an unsubscribe function. */
+  onChange(cb: (s: AppServerStatusSnapshot) => void): () => void {
+    this.listeners.add(cb);
+    return () => this.listeners.delete(cb);
+  }
+
+  private emit(): void {
+    const s = this.getSnapshot();
+    for (const cb of this.listeners) {
+      try {
+        cb(s);
+      } catch (err) {
+        console.error('[AppServerStatus] listener error:', err);
+      }
+    }
+  }
+}

--- a/src/app-server/transport/AppServerWebSocketTransport.ts
+++ b/src/app-server/transport/AppServerWebSocketTransport.ts
@@ -1,0 +1,195 @@
+/**
+ * App-Server WebSocket Transport
+ *
+ * Loopback WebSocket listener with HTTP health endpoints. Accepts and
+ * authenticates byte streams, forwards normalized connection events to the
+ * request processor, and enforces transport-level limits (origin rejection,
+ * connection count, payload size, slow-consumer disconnect).
+ *
+ * @module app-server/transport/AppServerWebSocketTransport
+ */
+
+import { createServer as createHttpServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { existsSync, unlinkSync } from 'node:fs';
+import { platform } from 'node:os';
+import { WS_CLOSE } from '@workx/ws-server';
+import type { AppServerRequestProcessor } from '../AppServerRequestProcessor';
+import type { AppServerStatusController } from '../status/AppServerStatus';
+import type { ConnectionSocket } from '../AppServerConnectionRegistry';
+import { handleHealthRequest } from './httpHealth';
+
+export interface AppServerListenInfo {
+  host: string;
+  port: number;
+  url: string;
+  socketPath?: string;
+}
+
+export interface AppServerWebSocketTransportOptions {
+  host: string;
+  port: number;
+  /**
+   * When set, listen on a Unix domain socket / Windows named pipe instead of a
+   * TCP host:port (Phase 4). On Windows use a `\\.\pipe\...` path.
+   */
+  socketPath?: string;
+  maxConnections: number;
+  maxPayloadBytes: number;
+  maxBufferedBytes: number;
+  rejectBrowserOrigins: boolean;
+  processor: AppServerRequestProcessor;
+  status: AppServerStatusController;
+  profile: string;
+}
+
+const LOOPBACK_ADDRS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+
+export class AppServerWebSocketTransport {
+  private httpServer: Server | null = null;
+  private wss: { close: (cb?: () => void) => void; clients: Set<unknown> } | null = null;
+  private slowConsumerTimer: ReturnType<typeof setInterval> | null = null;
+  private connectionCount = 0;
+  private readonly startedAtMs: number;
+
+  constructor(private readonly opts: AppServerWebSocketTransportOptions) {
+    this.startedAtMs = Date.now();
+  }
+
+  async start(): Promise<AppServerListenInfo> {
+    const { WebSocketServer, WebSocket } = await import('ws');
+
+    const httpServer = createHttpServer((req, res) => this.handleHttp(req, res));
+    this.httpServer = httpServer;
+
+    const wss = new WebSocketServer({
+      server: httpServer,
+      maxPayload: this.opts.maxPayloadBytes,
+      verifyClient: (
+        info: { origin?: string; req: IncomingMessage },
+        cb: (ok: boolean, code?: number, message?: string) => void,
+      ) => {
+        if (this.opts.rejectBrowserOrigins && info.origin) {
+          cb(false, 403, 'Origin not allowed');
+          return;
+        }
+        if (this.connectionCount >= this.opts.maxConnections) {
+          cb(false, 503, 'Connection limit reached');
+          return;
+        }
+        cb(true);
+      },
+    });
+    this.wss = wss as unknown as { close: (cb?: () => void) => void; clients: Set<unknown> };
+
+    wss.on('connection', (ws: import('ws').WebSocket, req: IncomingMessage) => {
+      const connectionId = `appsrv_${randomUUID().replace(/-/g, '').slice(0, 12)}`;
+      const remote = req.socket.remoteAddress ?? '';
+      const isLoopback = LOOPBACK_ADDRS.has(remote);
+      this.connectionCount += 1;
+
+      const socket: ConnectionSocket = {
+        send: (data: string) => {
+          if (ws.readyState === WebSocket.OPEN) ws.send(data);
+        },
+        close: (code: number, reason: string) => ws.close(code, reason),
+        bufferedAmount: () => ws.bufferedAmount,
+      };
+
+      this.opts.processor.onOpen(connectionId, socket, isLoopback);
+
+      ws.on('message', (data: import('ws').RawData) => {
+        const raw = data.toString();
+        if (Buffer.byteLength(raw) > this.opts.maxPayloadBytes) {
+          ws.close(WS_CLOSE.POLICY_VIOLATION, 'Payload too large');
+          return;
+        }
+        void this.opts.processor.onMessage(connectionId, raw);
+      });
+
+      ws.on('close', () => {
+        this.connectionCount = Math.max(0, this.connectionCount - 1);
+        this.opts.processor.onClose(connectionId);
+      });
+
+      ws.on('error', () => {
+        // Errors are followed by 'close'; nothing to do here.
+      });
+    });
+
+    // Slow-consumer sweep: close connections whose outbound buffer is saturated.
+    this.slowConsumerTimer = setInterval(() => {
+      for (const client of wss.clients) {
+        const ws = client as import('ws').WebSocket;
+        if (ws.bufferedAmount > this.opts.maxBufferedBytes) {
+          ws.close(WS_CLOSE.POLICY_VIOLATION, 'SLOW_CONSUMER');
+        }
+      }
+    }, 1000);
+    (this.slowConsumerTimer as { unref?: () => void }).unref?.();
+
+    // Phase 4: Unix domain socket / Windows named pipe.
+    if (this.opts.socketPath) {
+      const sockPath = this.opts.socketPath;
+      // Remove a stale socket file (best-effort, POSIX only — named pipes on
+      // Windows are not filesystem entries).
+      if (platform() !== 'win32' && existsSync(sockPath)) {
+        try {
+          unlinkSync(sockPath);
+        } catch {
+          // If it can't be removed it's likely in use; listen() will surface it.
+        }
+      }
+      await new Promise<void>((resolve, reject) => {
+        httpServer.once('error', reject);
+        httpServer.listen(sockPath, () => resolve());
+      });
+      return { host: this.opts.host, port: 0, url: `ws+unix://${sockPath}`, socketPath: sockPath };
+    }
+
+    const port = await new Promise<number>((resolve, reject) => {
+      httpServer.once('error', reject);
+      httpServer.listen(this.opts.port, this.opts.host, () => {
+        const addr = httpServer.address();
+        resolve(typeof addr === 'object' && addr ? addr.port : this.opts.port);
+      });
+    });
+
+    const url = `ws://${this.opts.host}:${port}`;
+    return { host: this.opts.host, port, url };
+  }
+
+  async stop(_reason?: string): Promise<void> {
+    if (this.slowConsumerTimer) {
+      clearInterval(this.slowConsumerTimer);
+      this.slowConsumerTimer = null;
+    }
+    if (this.wss) {
+      for (const client of this.wss.clients) {
+        (client as import('ws').WebSocket).close(WS_CLOSE.SERVICE_RESTART, 'shutting down');
+      }
+      await new Promise<void>((resolve) => this.wss!.close(() => resolve()));
+      this.wss = null;
+    }
+    if (this.httpServer) {
+      await new Promise<void>((resolve) => this.httpServer!.close(() => resolve()));
+      this.httpServer = null;
+    }
+  }
+
+  private handleHttp(req: IncomingMessage, res: ServerResponse): void {
+    const health = handleHealthRequest(req.method, req.url, {
+      status: this.opts.status.getSnapshot(),
+      profile: this.opts.profile,
+      startedAtMs: this.startedAtMs,
+      now: Date.now(),
+    });
+    if (health) {
+      res.writeHead(health.statusCode, { 'Content-Type': health.contentType });
+      res.end(health.body);
+      return;
+    }
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+  }
+}

--- a/src/app-server/transport/AppServerWebSocketTransport.ts
+++ b/src/app-server/transport/AppServerWebSocketTransport.ts
@@ -43,8 +43,6 @@ export interface AppServerWebSocketTransportOptions {
   profile: string;
 }
 
-const LOOPBACK_ADDRS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
-
 export class AppServerWebSocketTransport {
   private httpServer: Server | null = null;
   private wss: { close: (cb?: () => void) => void; clients: Set<unknown> } | null = null;
@@ -82,10 +80,8 @@ export class AppServerWebSocketTransport {
     });
     this.wss = wss as unknown as { close: (cb?: () => void) => void; clients: Set<unknown> };
 
-    wss.on('connection', (ws: import('ws').WebSocket, req: IncomingMessage) => {
+    wss.on('connection', (ws: import('ws').WebSocket) => {
       const connectionId = `appsrv_${randomUUID().replace(/-/g, '').slice(0, 12)}`;
-      const remote = req.socket.remoteAddress ?? '';
-      const isLoopback = LOOPBACK_ADDRS.has(remote);
       this.connectionCount += 1;
 
       const socket: ConnectionSocket = {
@@ -96,7 +92,7 @@ export class AppServerWebSocketTransport {
         bufferedAmount: () => ws.bufferedAmount,
       };
 
-      this.opts.processor.onOpen(connectionId, socket, isLoopback);
+      this.opts.processor.onOpen(connectionId, socket);
 
       ws.on('message', (data: import('ws').RawData) => {
         const raw = data.toString();

--- a/src/app-server/transport/httpHealth.ts
+++ b/src/app-server/transport/httpHealth.ts
@@ -1,0 +1,65 @@
+/**
+ * App-Server HTTP Health Endpoints
+ *
+ * Pure helpers for /readyz, /healthz, and the /health compatibility alias.
+ * No secrets are ever included.
+ *
+ * @module app-server/transport/httpHealth
+ */
+
+import type { AppServerStatusSnapshot } from '../status/AppServerStatus';
+
+export interface HealthContext {
+  status: AppServerStatusSnapshot;
+  profile: string;
+  startedAtMs: number;
+  now: number;
+}
+
+export interface HttpHealthResponse {
+  statusCode: number;
+  body: string;
+  contentType: string;
+}
+
+/** Build the JSON body for /healthz and /health. */
+export function buildHealthBody(ctx: HealthContext): Record<string, unknown> {
+  return {
+    status: ctx.status.status,
+    profile: ctx.profile,
+    connections: ctx.status.connections,
+    uptimeMs: Math.max(0, ctx.now - ctx.startedAtMs),
+  };
+}
+
+/**
+ * Handle a health-related GET request. Returns null if the path is not a
+ * health endpoint (caller should 404).
+ */
+export function handleHealthRequest(
+  method: string | undefined,
+  url: string | undefined,
+  ctx: HealthContext,
+): HttpHealthResponse | null {
+  if (method !== 'GET') return null;
+  const path = (url ?? '').split('?')[0];
+
+  if (path === '/readyz') {
+    const ready = ctx.status.status === 'ready';
+    return {
+      statusCode: ready ? 200 : 503,
+      contentType: 'text/plain',
+      body: ready ? 'ok' : 'not ready',
+    };
+  }
+
+  if (path === '/healthz' || path === '/health') {
+    return {
+      statusCode: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(buildHealthBody(ctx)),
+    };
+  }
+
+  return null;
+}

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -2,7 +2,7 @@
  * Default centralized agent configuration values
  */
 
-import type { IAgentConfig, IUserPreferences, ICacheSettings, IExtensionSettings, IPermissionSettings, IToolsConfig, IStorageConfig, IStoredConfig, IProviderConfig } from './types';
+import type { IAgentConfig, IUserPreferences, ICacheSettings, IExtensionSettings, IPermissionSettings, IToolsConfig, IStorageConfig, IStoredConfig, IProviderConfig, IAppServerConfig } from './types';
 import { DEFAULT_APPROVAL_CONFIG } from '../core/approval/types';
 import { DEFAULT_MODE } from '../prompts/PromptComposer';
 import defaultProviders from '../core/models/providers/default.json';
@@ -160,6 +160,21 @@ export const DEFAULT_TOOLS_CONFIG: IToolsConfig = {
   }
 };
 
+/** Default app-server config — disabled, loopback, token-required. */
+export const DEFAULT_APP_SERVER_CONFIG: IAppServerConfig = {
+  enabled: false,
+  transport: 'websocket',
+  bindHost: '127.0.0.1',
+  port: 18101,
+  requireAuth: true,
+  rejectBrowserOrigins: true,
+  allowLan: false,
+  maxConnections: 16,
+  maxPayloadBytes: 1_048_576,
+  maxBufferedBytes: 4_194_304,
+  requestQueueCapacity: 128,
+};
+
 // Helper to create default config without module-level execution
 export function getDefaultAgentConfig(): IAgentConfig {
   return {
@@ -174,7 +189,8 @@ export function getDefaultAgentConfig(): IAgentConfig {
     tools: { ...DEFAULT_TOOLS_CONFIG },
     storage: { ...DEFAULT_STORAGE_CONFIG },
     approval: { ...DEFAULT_APPROVAL_CONFIG },
-    enabledPlugins: {}
+    enabledPlugins: {},
+    appServer: { ...DEFAULT_APP_SERVER_CONFIG },
   };
 }
 
@@ -322,7 +338,11 @@ export function mergeWithDefaults(partial: Partial<IAgentConfig>): IAgentConfig 
         ...DEFAULT_APPROVAL_CONFIG.timeouts,
         ...(partial.approval?.timeouts || {})
       }
-    }
+    },
+    appServer: {
+      ...DEFAULT_APP_SERVER_CONFIG,
+      ...(partial.appServer || {}),
+    },
   };
 }
 
@@ -351,7 +371,8 @@ export function getDefaultStoredConfig(): IStoredConfig {
     activeProfile: null,
     tools: { ...DEFAULT_TOOLS_CONFIG },
     storage: { ...DEFAULT_STORAGE_CONFIG },
-    approval: { ...DEFAULT_APPROVAL_CONFIG }
+    approval: { ...DEFAULT_APPROVAL_CONFIG },
+    appServer: { ...DEFAULT_APP_SERVER_CONFIG },
   };
 }
 
@@ -452,7 +473,11 @@ export function buildRuntimeConfig(stored: IStoredConfig | null): IAgentConfig {
       }
     },
     // Track 10: per-plugin enable state round-trips verbatim
-    enabledPlugins: stored.enabledPlugins ?? {}
+    enabledPlugins: stored.enabledPlugins ?? {},
+    appServer: {
+      ...DEFAULT_APP_SERVER_CONFIG,
+      ...(stored.appServer || {}),
+    },
   };
 
   // Track 20: pin admin policy AFTER all merging so the one-level merges above
@@ -494,6 +519,7 @@ export function extractStoredConfig(config: IAgentConfig): IStoredConfig {
     storage: config.storage,
     approval: config.approval,
     // Track 10: persist per-plugin enable state
-    enabledPlugins: config.enabledPlugins
+    enabledPlugins: config.enabledPlugins,
+    appServer: config.appServer,
   };
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -71,6 +71,47 @@ export interface IAgentConfig {
    * `/plugin enable|disable`. Absent → no plugins enabled.
    */
   enabledPlugins?: Record<string, boolean>;
+
+  /**
+   * App-server mode: lets the installed desktop app expose a local callable
+   * WebSocket endpoint alongside the UI. Disabled by default. Not LLM-writable
+   * (intentionally absent from the agent-facing config schema sections).
+   * @see src/app-server/appServerConfig.ts for normalization/validation.
+   */
+  appServer?: IAppServerConfig;
+}
+
+/** App-server transport kind. Only `websocket` in the MVP. */
+export type AppServerTransport = 'websocket' | 'unix-socket';
+
+/**
+ * App-server mode configuration. See `.ai_design/app_server_mode/design.md`.
+ */
+export interface IAppServerConfig {
+  /** Master switch. When false, no listener is started. */
+  enabled: boolean;
+  /** Transport kind. */
+  transport: AppServerTransport;
+  /** Bind host (TCP transport). Loopback by default. */
+  bindHost: string;
+  /** Bind port (TCP transport). 0 = OS-assigned (reported back via status). */
+  port: number;
+  /** Unix socket / named pipe path (when transport = unix-socket). */
+  socketPath?: string;
+  /** Require a capability token during connect. */
+  requireAuth: boolean;
+  /** Reject any upgrade request carrying an Origin header. */
+  rejectBrowserOrigins: boolean;
+  /** Allow binding to a non-loopback host. */
+  allowLan: boolean;
+  /** Maximum concurrent connections. */
+  maxConnections: number;
+  /** Maximum inbound frame size in bytes. */
+  maxPayloadBytes: number;
+  /** Maximum per-connection outbound buffer before slow-consumer disconnect. */
+  maxBufferedBytes: number;
+  /** Bounded inbound request queue capacity. */
+  requestQueueCapacity: number;
 }
 
 // Model pricing information
@@ -584,6 +625,8 @@ export interface IStoredConfig {
   hooks?: HooksConfig;
   /** Track 10: per-plugin enable state, keyed by `<name>@<marketplace>` */
   enabledPlugins?: Record<string, boolean>;
+  /** Desktop app-server settings. Disabled by default. */
+  appServer?: IAppServerConfig;
 }
 
 // Storage interfaces
@@ -641,7 +684,7 @@ export interface IExportData {
 // Event interfaces for config changes
 export interface IConfigChangeEvent {
   type: 'config-changed';
-  section: 'model' | 'provider' | 'profile' | 'preferences' | 'cache' | 'extension' | 'security' | 'approval' | 'hooks' | 'tools' | 'policy' | 'enabledPlugins';
+  section: 'model' | 'provider' | 'profile' | 'preferences' | 'cache' | 'extension' | 'security' | 'approval' | 'hooks' | 'tools' | 'policy' | 'enabledPlugins' | 'appServer';
   oldValue?: any;
   newValue: any;
   timestamp: number;

--- a/src/core/models/types/SessionContracts.ts
+++ b/src/core/models/types/SessionContracts.ts
@@ -95,7 +95,7 @@ export interface SessionListResponse {
  */
 export interface SessionMetadataSummary {
   sessionId: string;
-  type: 'primary' | 'scheduled';
+  type: 'primary' | 'scheduled' | 'api';
   state: 'initializing' | 'active' | 'idle' | 'terminated';
   tabId: number | null;
   tabGroupName: string;

--- a/src/core/registry/types.ts
+++ b/src/core/registry/types.ts
@@ -16,8 +16,12 @@ export type SessionState = 'initializing' | 'active' | 'idle' | 'terminated';
  * Session type discriminator
  * - primary: User's main interactive session (side panel)
  * - scheduled: Session created for scheduled task execution
+ * - api: Dedicated session for an external app-server connection. Never the
+ *   registry's primary session, so app-server clients can't hijack the UI's
+ *   primary-session pointer; created `internal` so it bypasses the user
+ *   concurrency budget (the app-server transport bounds connections itself).
  */
-export type SessionType = 'primary' | 'scheduled';
+export type SessionType = 'primary' | 'scheduled' | 'api';
 
 /**
  * Configuration for creating a new session

--- a/src/desktop-runtime/app-server/DesktopAppServerManager.ts
+++ b/src/desktop-runtime/app-server/DesktopAppServerManager.ts
@@ -1,0 +1,149 @@
+/**
+ * Desktop App-Server Integration
+ *
+ * Desktop-only wiring around the host-agnostic {@link AppServerManager}:
+ *   - reads `IAgentConfig.appServer`,
+ *   - builds the keychain-backed capability token store,
+ *   - registers the app-server channel on the bootstrap,
+ *   - starts the listener and publishes status,
+ *   - exposes `appServer.*` runtime service handlers for the UI.
+ *
+ * App-server startup failure never crashes the sidecar — errors are recorded
+ * in status and the runtime keeps serving the UI.
+ *
+ * @module desktop-runtime/app-server/DesktopAppServerManager
+ */
+
+import path from 'node:path';
+import type { ServerAgentBootstrap } from '@/server/agent/ServerAgentBootstrap';
+import type { ServiceHandler } from '@/core/channels/ServiceRegistry';
+import { getChannelManager } from '@/core/channels/ChannelManager';
+import { AgentConfig } from '@/config/AgentConfig';
+import { AppServerManager } from '@/app-server/AppServerManager';
+import { AppServerAuth } from '@/app-server/connection/AppServerAuth';
+import { normalizeAppServerConfig } from '@/app-server/appServerConfig';
+import type { AppServerStatusSnapshot } from '@/app-server/status/AppServerStatus';
+import { getDesktopRuntimeHost } from '../host';
+import { getDesktopRuntimeControlBridge } from '../protocol/controlBridge';
+import { KeychainTokenStore } from './KeychainTokenStore';
+
+export interface DesktopAppServerManagerOptions {
+  bootstrap: ServerAgentBootstrap;
+}
+
+export class DesktopAppServerManager {
+  private manager: AppServerManager | null = null;
+  private channelRegistered = false;
+
+  constructor(private readonly opts: DesktopAppServerManagerOptions) {}
+
+  /**
+   * Read config and start the app-server if enabled. Never throws — failures
+   * are recorded in status so the desktop runtime keeps running.
+   */
+  async startFromConfig(): Promise<void> {
+    try {
+      const agentConfig = await AgentConfig.getInstance();
+      const rawConfig = agentConfig.getConfig().appServer;
+      const config = normalizeAppServerConfig(rawConfig);
+
+      if (!config.enabled) {
+        return;
+      }
+
+      const host = getDesktopRuntimeHost();
+      const controlBridge = getDesktopRuntimeControlBridge();
+      const tokenStore = new KeychainTokenStore({
+        keychain: controlBridge.keychain,
+        fallbackFilePath: path.join(host.configDir, 'app-server-token'),
+        onFallback: () => {
+          console.warn(
+            '[DesktopAppServerManager] WARN: keychain unavailable — capability token stored in a 0600 file. ' +
+              'A local process that can read this file gains the connection\'s full scope set.',
+          );
+        },
+      });
+
+      const auth = new AppServerAuth({ requireAuth: config.requireAuth, store: tokenStore });
+
+      this.manager = new AppServerManager({
+        config,
+        auth,
+        profile: 'desktop-runtime',
+        sessionFactory: () => this.opts.bootstrap.createSession(),
+        sessionDisposer: (key) => this.opts.bootstrap.releaseSession(key),
+      });
+
+      // Register the channel BEFORE starting the transport so events route as
+      // soon as connections submit work.
+      await this.opts.bootstrap.registerChannel(this.manager.getChannel());
+      this.channelRegistered = true;
+
+      await this.manager.start();
+      const status = this.manager.getStatus();
+      console.error(`[DesktopAppServerManager] app-server ready at ${status.url ?? '(unknown)'}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error('[DesktopAppServerManager] app-server start failed (runtime continues):', message);
+      this.manager?.markError(message);
+    }
+  }
+
+  /** Stop the listener and unregister the channel. */
+  async stop(reason = 'shutdown'): Promise<void> {
+    try {
+      await this.manager?.stop(reason);
+      if (this.channelRegistered && this.manager) {
+        await this.opts.bootstrap.unregisterChannel(this.manager.getChannel().channelId);
+        this.channelRegistered = false;
+      }
+    } catch (err) {
+      console.error('[DesktopAppServerManager] stop error:', err);
+    }
+  }
+
+  getStatus(): AppServerStatusSnapshot {
+    return (
+      this.manager?.getStatus() ?? { enabled: false, status: 'disabled', connections: 0 }
+    );
+  }
+
+  /**
+   * Register `appServer.*` runtime service handlers so the UI can control the
+   * app-server. The UI talks to these services, never to the WS listener.
+   */
+  registerServices(): void {
+    const registry = getChannelManager().getServiceRegistry();
+    const handlers: Record<string, ServiceHandler> = {
+      'appServer.getStatus': async () => this.getStatus(),
+      'appServer.restart': async () => {
+        await this.stop('restart');
+        await this.startFromConfig();
+        return this.getStatus();
+      },
+      'appServer.stop': async () => {
+        await this.stop('stop');
+        return this.getStatus();
+      },
+      'appServer.rotateToken': async () => {
+        if (!this.manager) throw new Error('App-server not running');
+        await this.manager.rotateToken();
+        return { rotated: true };
+      },
+      'appServer.revealToken': async () => {
+        if (!this.manager) throw new Error('App-server not running');
+        return { token: await this.manager.revealToken() };
+      },
+      'appServer.setConfig': async () => {
+        // Config is persisted via the normal config service; this just restarts
+        // the listener so new settings take effect.
+        await this.stop('config-change');
+        await this.startFromConfig();
+        return this.getStatus();
+      },
+    };
+    for (const [name, handler] of Object.entries(handlers)) {
+      registry.register(name, handler);
+    }
+  }
+}

--- a/src/desktop-runtime/app-server/KeychainTokenStore.ts
+++ b/src/desktop-runtime/app-server/KeychainTokenStore.ts
@@ -1,0 +1,79 @@
+/**
+ * Keychain-backed capability token store with a 0600 file fallback.
+ *
+ * Implements the host-agnostic {@link CapabilityTokenStore} seam so the
+ * reusable app-server auth layer stays free of desktop control-bridge imports.
+ *
+ * @module desktop-runtime/app-server/KeychainTokenStore
+ */
+
+import { existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import type { CapabilityTokenStore } from '@/app-server/connection/AppServerAuth';
+import type { KeychainBridge } from '@/desktop-runtime/credentials/ControlFrameCredentialStore';
+
+const KEYCHAIN_SERVICE = 'app-server';
+const KEYCHAIN_ACCOUNT = 'capability-token';
+
+export interface KeychainTokenStoreOptions {
+  keychain: KeychainBridge;
+  /** Filesystem fallback path used only if the keychain is unavailable. */
+  fallbackFilePath: string;
+  /** Called when the fallback path is used, so the UI can warn the user. */
+  onFallback?: () => void;
+}
+
+export class KeychainTokenStore implements CapabilityTokenStore {
+  private usingFallback = false;
+
+  constructor(private readonly opts: KeychainTokenStoreOptions) {}
+
+  async getToken(): Promise<string | null> {
+    try {
+      const fromKeychain = await this.opts.keychain.get(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
+      if (fromKeychain) return fromKeychain;
+      // Fall through to file only if keychain returned nothing AND a fallback
+      // file exists (keychain is the source of truth otherwise).
+      if (existsSync(this.opts.fallbackFilePath)) {
+        return readFileSync(this.opts.fallbackFilePath, 'utf8').trim() || null;
+      }
+      return null;
+    } catch {
+      this.useFallback();
+      return existsSync(this.opts.fallbackFilePath)
+        ? readFileSync(this.opts.fallbackFilePath, 'utf8').trim() || null
+        : null;
+    }
+  }
+
+  async setToken(token: string): Promise<void> {
+    try {
+      await this.opts.keychain.set(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT, token);
+    } catch {
+      this.useFallback();
+      // 0600: owner read/write only.
+      writeFileSync(this.opts.fallbackFilePath, token, { mode: 0o600 });
+    }
+  }
+
+  async clear(): Promise<void> {
+    try {
+      await this.opts.keychain.delete(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
+    } catch {
+      // ignore keychain failure
+    }
+    if (existsSync(this.opts.fallbackFilePath)) {
+      try {
+        rmSync(this.opts.fallbackFilePath);
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  private useFallback(): void {
+    if (!this.usingFallback) {
+      this.usingFallback = true;
+      this.opts.onFallback?.();
+    }
+  }
+}

--- a/src/server/agent/ServerAgentBootstrap.ts
+++ b/src/server/agent/ServerAgentBootstrap.ts
@@ -1403,16 +1403,31 @@ export class ServerAgentBootstrap {
           throw new Error('No sessionId — cannot route chat submission');
         }
         if (!this.registry) throw new Error('AgentRegistry not initialized');
-        // The handshake assigns each connection a routing alias
-        // (`ws:main:<connId>`) that is not itself a registry key. For the main
-        // chat surface that alias maps to the server's primary session, so fall
-        // back to it when the alias doesn't resolve to an explicit session.
+        // A dedicated channel (e.g. the desktop app-server) submits against a
+        // real, per-connection session id and owns its own event stream. The
+        // primary chat surface instead submits under a connection alias
+        // (`ws:main:<connId>`) that is not itself a registry key and maps to the
+        // server's primary session.
+        const isDedicatedChannel =
+          !!context.channelId &&
+          context.channelId !== this.primaryChannelId &&
+          this.channels.has(context.channelId);
+        // Only the aliased primary surface falls back to the primary session.
+        // For a dedicated channel an unresolved session must fail loudly rather
+        // than silently execute the request against the UI's live conversation.
         const targetSession =
-          this.registry.getSession(context.sessionId) ?? this.registry.getPrimarySession();
+          this.registry.getSession(context.sessionId) ??
+          (isDedicatedChannel ? undefined : this.registry.getPrimarySession());
         if (!targetSession?.agent) throw new Error(`Session not found: ${context.sessionId}`);
+        // Route this session's agent events back to the originating channel so a
+        // dedicated connection receives its own stream (and the UI does not).
+        // recordSessionOwner no-ops unless channelId is a registered channel, so
+        // the primary-surface alias keeps default primary-channel routing.
+        this.recordSessionOwner(context.sessionId, context.channelId);
         // Track 13: derive origin from the chat channel (on-host WS chat maps
         // to `local` and skips the gate; remote/relay maps to `remote`).
-        await targetSession.agent.submitOperation(op, {
+        // Return the submission id so callers can surface it as a stable runId.
+        return await targetSession.agent.submitOperation(op, {
           tabId: context.tabId,
           origin: deriveInputOrigin(context),
         });

--- a/src/server/agent/ServerAgentBootstrap.ts
+++ b/src/server/agent/ServerAgentBootstrap.ts
@@ -102,7 +102,10 @@ let _instance: ServerAgentBootstrap | null = null;
 export interface ServerAgentBootstrapOptions {
   profile?: 'server' | 'desktop-runtime';
   dataDir?: string;
+  /** Primary channel (UI/runtime transport). Kept for backward compatibility. */
   channel?: ChannelAdapter;
+  /** Additional channels to register at initialize() time (e.g. app-server). */
+  channels?: ChannelAdapter[];
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -118,6 +121,12 @@ export class ServerAgentBootstrap {
   // /plugin reload, matching claudy's asymmetric enable semantics).
   private pluginRegistry: import('@/core/plugins/PluginRegistry').PluginRegistry | null = null;
   private channel: ChannelAdapter | null = null;
+  /** All registered channels by channelId (multi-channel support). */
+  private channels = new Map<string, ChannelAdapter>();
+  /** The primary channel id — events for unowned sessions route here. */
+  private primaryChannelId: string | null = null;
+  /** sessionId → owning channelId, so events route to the originating channel. */
+  private sessionOwners = new Map<string, string>();
   private sessionIndex: SessionIndex | null = null;
   private transcriptStore: TranscriptStore | null = null;
   private backupManager: BackupManager | null = null;
@@ -141,6 +150,72 @@ export class ServerAgentBootstrap {
   private initialized = false;
 
   constructor(private readonly options: ServerAgentBootstrapOptions = {}) {}
+
+  /**
+   * Record the channel that owns a session so agent events for that session are
+   * routed only to the originating channel. No-op when channelId is absent.
+   */
+  private recordSessionOwner(sessionId: string, channelId?: string): void {
+    if (channelId && this.channels.has(channelId)) {
+      this.sessionOwners.set(sessionId, channelId);
+    }
+  }
+
+  /**
+   * Register an additional channel after initialization (e.g. the app-server
+   * channel started once config is read). Idempotent per channelId.
+   */
+  async registerChannel(channel: ChannelAdapter): Promise<void> {
+    if (this.channels.has(channel.channelId)) return;
+    const channelManager = getChannelManager();
+    await channelManager.registerChannel(channel);
+    this.channels.set(channel.channelId, channel);
+    if (!this.primaryChannelId) this.primaryChannelId = channel.channelId;
+  }
+
+  /**
+   * Unregister a previously registered channel and drop any session ownership
+   * routed to it. The primary channel cannot be unregistered.
+   */
+  async unregisterChannel(channelId: string): Promise<void> {
+    if (channelId === this.primaryChannelId) {
+      throw new Error('Cannot unregister the primary channel');
+    }
+    if (!this.channels.has(channelId)) return;
+    const channelManager = getChannelManager();
+    await channelManager.unregisterChannel(channelId);
+    this.channels.delete(channelId);
+    for (const [sessionId, owner] of this.sessionOwners) {
+      if (owner === channelId) this.sessionOwners.delete(sessionId);
+    }
+  }
+
+  /**
+   * Create a fresh agent session and return its id. Used by callers such as the
+   * app-server that need a dedicated session per external connection.
+   *
+   * Created as `type: 'api'` + `internal: true`: never the registry's primary
+   * session (so external connections can't hijack the UI's primary-session
+   * pointer) and outside the user concurrency budget (the app-server transport
+   * bounds connection count itself).
+   */
+  async createSession(): Promise<string> {
+    if (!this.registry) throw new Error('AgentRegistry not initialized');
+    const session = await this.registry.createSession({ type: 'api', internal: true });
+    return session.sessionId;
+  }
+
+  /**
+   * Tear down a session created via {@link createSession} and drop its event
+   * routing. Called when an app-server connection closes so dedicated sessions
+   * don't accumulate for the life of the runtime.
+   */
+  async releaseSession(sessionId: string): Promise<void> {
+    this.sessionOwners.delete(sessionId);
+    if (this.registry) {
+      await this.registry.removeSession(sessionId);
+    }
+  }
 
   /**
    * Initialize the server agent system.
@@ -398,10 +473,16 @@ export class ServerAgentBootstrap {
           return agent;
         },
         eventDispatcherFactory: (sessionId) => (event) => {
-          // Dispatch to ServerChannel -> WebSocket clients with sessionId
-          channelManager.dispatchEvent({ msg: event.msg, sessionId }, this.channel!.channelId).catch((error) => {
-            console.error('[ServerAgentBootstrap] Failed to dispatch event:', error);
-          });
+          // Route to the channel that owns this session (UI vs app-server
+          // isolation). Falls back to the primary channel for sessions with no
+          // recorded owner (e.g. the initial primary session before any turn).
+          const targetChannelId =
+            this.sessionOwners.get(sessionId) ?? this.primaryChannelId ?? this.channel?.channelId;
+          if (targetChannelId) {
+            channelManager.dispatchEvent({ msg: event.msg, sessionId }, targetChannelId).catch((error) => {
+              console.error('[ServerAgentBootstrap] Failed to dispatch event:', error);
+            });
+          }
 
           // Also log to transcript store (Track 24.5: secret-redacted at rest —
           // non-blocking, the entry is kept, only detected secrets become ***).
@@ -436,6 +517,9 @@ export class ServerAgentBootstrap {
         if (!targetSession?.agent) {
           throw new Error(`Session not found: ${context.sessionId}`);
         }
+        // Record channel ownership so agent events route to the originating
+        // channel only (UI vs app-server isolation).
+        this.recordSessionOwner(context.sessionId, context.channelId);
         console.log('[ServerAgentBootstrap] Processing submission:', op.type, 'session:', context.sessionId);
         // Track 13: thread channel origin so the input funnel can apply the
         // bridge-safe slash gate (connector input must not leak raw /config).
@@ -446,8 +530,16 @@ export class ServerAgentBootstrap {
       };
 
       channelManager.setAgentHandler(agentHandler);
-      await channelManager.registerChannel(this.channel);
-      console.log('[ServerAgentBootstrap] Channel registered');
+
+      // Register the primary channel plus any additional channels (multi-channel
+      // support — e.g. the desktop app-server channel alongside the UI channel).
+      const extraChannels = this.options.channels ?? [];
+      this.primaryChannelId = this.channel.channelId;
+      for (const ch of [this.channel, ...extraChannels]) {
+        await channelManager.registerChannel(ch);
+        this.channels.set(ch.channelId, ch);
+      }
+      console.log(`[ServerAgentBootstrap] Channel(s) registered: ${[...this.channels.keys()].join(', ')}`);
 
       // 8. Initialize persistence
       this.sessionIndex = new SessionIndex(dataDir);

--- a/src/server/channels/ServerChannel.ts
+++ b/src/server/channels/ServerChannel.ts
@@ -17,13 +17,13 @@ import type {
   SubmissionContext,
   ChannelCapabilities,
 } from '@/core/channels/types';
-import type { EventMsg } from '@/core/protocol/events';
 import type { ChannelEvent } from '@/core/channels/types';
 import type { Op } from '@/core/protocol/types';
 import { shouldReceiveEvent } from '../auth/authorize';
 import { makeEvent } from '@workx/ws-server';
 import { getTrackedConnections, touchConnection } from '../connection/watchdog';
 import { redactEventMsgSecrets } from '../security/eventRedaction';
+import { eventMsgToName } from './eventWireName';
 
 type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'error';
 
@@ -91,7 +91,7 @@ export class ServerChannel implements ChannelAdapter {
 
     this.eventSeq++;
     const eventMsg = redactEventMsgSecrets(event.msg);
-    const eventName = this.eventMsgToName(eventMsg);
+    const eventName = eventMsgToName(eventMsg);
     const payload = event.sessionId ? { ...eventMsg, sessionId: event.sessionId } : eventMsg;
     const frame = JSON.stringify(makeEvent(eventName, payload, this.eventSeq));
 
@@ -165,58 +165,5 @@ export class ServerChannel implements ChannelAdapter {
 
   getConnectionState(): ConnectionState {
     return this.connectionState;
-  }
-
-  /**
-   * Map an EventMsg type to a wire event name.
-   */
-  private eventMsgToName(event: EventMsg): string {
-    // Agent message deltas → chat events
-    if (
-      event.type === 'AgentMessageDelta' ||
-      event.type === 'AgentMessage' ||
-      event.type === 'AgentReasoning' ||
-      event.type === 'AgentReasoningDelta'
-    ) {
-      return 'chat';
-    }
-
-    // Tool and execution events → agent events
-    if (
-      event.type === 'ToolExecutionStart' ||
-      event.type === 'ToolExecutionEnd' ||
-      event.type === 'ToolExecutionProgress' ||
-      event.type === 'McpToolCallBegin' ||
-      event.type === 'McpToolCallEnd' ||
-      event.type === 'ExecCommandBegin' ||
-      event.type === 'ExecCommandEnd' ||
-      event.type === 'TurnStarted' ||
-      event.type === 'TurnComplete' ||
-      event.type === 'TaskStarted' ||
-      event.type === 'TaskComplete'
-    ) {
-      return 'agent';
-    }
-
-    // Approval events
-    if (event.type === 'ExecApprovalRequest' || event.type === 'ApplyPatchApprovalRequest') {
-      return 'exec.approval.requested';
-    }
-
-    // Health events
-    if (event.type === 'Error' || event.type === 'StreamError') {
-      return 'health';
-    }
-
-    // Service routing events (message_routing_v2)
-    if (event.type === 'ServiceResponse') {
-      return 'service.response';
-    }
-    if (event.type === 'StateUpdate') {
-      return 'state.update';
-    }
-
-    // Default: use the raw type as event name
-    return event.type;
   }
 }

--- a/src/server/channels/eventWireName.ts
+++ b/src/server/channels/eventWireName.ts
@@ -1,0 +1,65 @@
+/**
+ * Agent event → protocol wire-name mapping.
+ *
+ * Shared by every server-side channel (the headless `ServerChannel` and the
+ * desktop `AppServerChannel`) so the mapping cannot drift between them. A
+ * divergence is not cosmetic: an event that one channel maps to a scoped wire
+ * name (e.g. `chat`/`agent`) but the other leaves as its raw type would fall
+ * through `EVENT_SCOPE_MAP` as unscoped and leak to every authenticated
+ * connection, and would reach the client under a name it cannot interpret.
+ *
+ * @module server/channels/eventWireName
+ */
+
+import type { EventMsg } from '@/core/protocol/events';
+
+/** Map an agent {@link EventMsg} to its protocol wire event name. */
+export function eventMsgToName(event: EventMsg): string {
+  // Agent message deltas → chat events
+  if (
+    event.type === 'AgentMessageDelta' ||
+    event.type === 'AgentMessage' ||
+    event.type === 'AgentReasoning' ||
+    event.type === 'AgentReasoningDelta'
+  ) {
+    return 'chat';
+  }
+
+  // Tool and execution events → agent events
+  if (
+    event.type === 'ToolExecutionStart' ||
+    event.type === 'ToolExecutionEnd' ||
+    event.type === 'ToolExecutionProgress' ||
+    event.type === 'McpToolCallBegin' ||
+    event.type === 'McpToolCallEnd' ||
+    event.type === 'ExecCommandBegin' ||
+    event.type === 'ExecCommandEnd' ||
+    event.type === 'TurnStarted' ||
+    event.type === 'TurnComplete' ||
+    event.type === 'TaskStarted' ||
+    event.type === 'TaskComplete'
+  ) {
+    return 'agent';
+  }
+
+  // Approval events
+  if (event.type === 'ExecApprovalRequest' || event.type === 'ApplyPatchApprovalRequest') {
+    return 'exec.approval.requested';
+  }
+
+  // Health events
+  if (event.type === 'Error' || event.type === 'StreamError') {
+    return 'health';
+  }
+
+  // Service routing events (message_routing_v2)
+  if (event.type === 'ServiceResponse') {
+    return 'service.response';
+  }
+  if (event.type === 'StateUpdate') {
+    return 'state.update';
+  }
+
+  // Default: use the raw type as event name
+  return event.type;
+}

--- a/src/server/connection/handshake.ts
+++ b/src/server/connection/handshake.ts
@@ -25,8 +25,7 @@ import { verifyAuth } from './auth';
 import { resolveScopes, isValidRole, type Role } from '../auth/roles';
 import { setConnectionAuth } from '../auth/authorize';
 import { getServerConfig } from '../config/server-config';
-import { getRegisteredMethods } from '@workx/ws-server';
-import { EVENT_SCOPE_MAP, BROADCAST_EVENTS } from '@workx/ws-server';
+import { getRegisteredMethods, buildAvailableEvents } from '@workx/ws-server';
 import { getHealthStatus } from '../handlers/health';
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -277,27 +276,6 @@ export async function handleConnectRequest(
     clientInfo,
     sessionKey,
   };
-}
-
-/**
- * Build the list of events this connection will receive based on scopes.
- */
-function buildAvailableEvents(scopes: string[]): string[] {
-  const events = new Set<string>();
-
-  // Broadcast events are always included
-  for (const evt of BROADCAST_EVENTS) {
-    events.add(evt);
-  }
-
-  // Add scoped events
-  for (const [eventName, requiredScope] of Object.entries(EVENT_SCOPE_MAP)) {
-    if (scopes.includes(requiredScope)) {
-      events.add(eventName);
-    }
-  }
-
-  return Array.from(events);
 }
 
 /**

--- a/src/server/handlers/chat.ts
+++ b/src/server/handlers/chat.ts
@@ -16,8 +16,24 @@ import type { SubmissionContext } from '@/core/channels/types';
 // ─────────────────────────────────────────────────────────────────────────
 
 export interface ChatHandlerDeps {
-  submitOp: (op: Op, context: SubmissionContext) => Promise<void>;
+  /**
+   * Submit an Op to the agent. Returns the runtime submission id (runId) so
+   * callers (e.g. external app-server automation) get a stable identifier.
+   */
+  submitOp: (op: Op, context: SubmissionContext) => Promise<string | void>;
   getHistory: (sessionKey: string) => Promise<unknown[]>;
+}
+
+/**
+ * Resolve the originating channel for a submission. App-server / multi-channel
+ * callers populate `ctx.channelId`/`ctx.channelType`; the headless server omits
+ * them and falls back to the historical `server-main`/`server` identity.
+ */
+function callerChannel(ctx: MethodContext): { channelId: string; channelType: SubmissionContext['channelType'] } {
+  return {
+    channelId: ctx.channelId ?? 'server-main',
+    channelType: (ctx.channelType as SubmissionContext['channelType']) ?? 'server',
+  };
 }
 
 let _deps: ChatHandlerDeps | null = null;
@@ -63,16 +79,16 @@ async function handleChatSend(
   };
 
   const submissionContext: SubmissionContext = {
-    channelId: 'server-main',
-    channelType: 'server',
+    ...callerChannel(ctx),
     userId: ctx.userId,
     sessionId: ctx.sessionKey,
   };
 
-  // Submit asynchronously — response streaming is handled by events
-  await _deps.submitOp(op, submissionContext);
+  // Submit asynchronously — response streaming is handled by events.
+  // The submission id is surfaced as runId for stable automation.
+  const runId = await _deps.submitOp(op, submissionContext);
 
-  return { status: 'started', sessionKey: ctx.sessionKey };
+  return { status: 'started', sessionKey: ctx.sessionKey, runId: runId ?? undefined, accepted: true };
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -88,8 +104,7 @@ async function handleChatAbort(
   const op: Op = { type: 'Interrupt' };
 
   const submissionContext: SubmissionContext = {
-    channelId: 'server-main',
-    channelType: 'server',
+    ...callerChannel(ctx),
     userId: ctx.userId,
     sessionId: ctx.sessionKey,
   };
@@ -138,8 +153,7 @@ async function handleChatInject(
   };
 
   const submissionContext: SubmissionContext = {
-    channelId: 'server-main',
-    channelType: 'server',
+    ...callerChannel(ctx),
     userId: ctx.userId,
     sessionId: ctx.sessionKey,
   };


### PR DESCRIPTION
## Summary
Adds the desktop **app-server** subsystem, split out of #266 and rebased onto `main`. Self-contained additive feature: all new files under `src/app-server/` and `src/desktop-runtime/app-server/`, plus config and server wiring.

## Contents (33 files)
- `src/app-server/*` — channel, request processor, connection registry/auth/gates, request queue, transport, status/health
- `src/desktop-runtime/app-server/*` — DesktopAppServerManager, KeychainTokenStore
- wiring: `src/config/{defaults,types}.ts`, `src/server/agent/ServerAgentBootstrap.ts`, `src/server/handlers/chat.ts`, `packages/ws-server/src/{errors,methods}.ts`, `src/core/registry/types.ts`, `src/core/models/types/SessionContracts.ts`
- design docs: `.ai_design/app_server_mode/*`

## Validation
- `npx tsc --noEmit` — clean
- `npx vitest run src/app-server` — 64/64 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)