### PR TITLE
chore(docker): default WORKX_SERVER_AUTH_MODE to none for browser UI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,11 @@ services:
     environment:
       - WORKX_SERVER_PORT=18100
       - WORKX_SERVER_BIND=auto
-      - WORKX_SERVER_AUTH_MODE=token
+      # Web UI connects from the server's own origin; `none` mode accepts
+      # loopback + same-origin browser connections (see buildExpectedOrigins
+      # in src/server/connection/auth.ts). Use `token` for network-exposed
+      # deployments without the browser UI.
+      - WORKX_SERVER_AUTH_MODE=${WORKX_SERVER_AUTH_MODE:-none}
       - WORKX_SERVER_TOKEN=${WORKX_SERVER_TOKEN}
       - WORKX_DATA_DIR=/data
       - WORKX_CONFIG_PATH=/app/config.json


### PR DESCRIPTION
## What
Change the Docker Compose default for `WORKX_SERVER_AUTH_MODE` from `token` to `${WORKX_SERVER_AUTH_MODE:-none}`, with an explanatory comment.

## Why
The compose stack serves the web UI from the server's own origin. In `none` mode the server accepts **loopback + same-origin** browser connections only (gated by `buildExpectedOrigins` in `src/server/connection/auth.ts:163`; see also the `'none'` case at `auth.ts:40-58`). With `token` as the default, the bundled browser UI can't connect without manual token wiring.

## Notes
- Still overridable via the environment — set `WORKX_SERVER_AUTH_MODE=token` for network-exposed deployments that run without the browser UI.
- `none` is **not** an "auth off" mode: non-loopback, cross-origin connections are still rejected (`auth.ts:58`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)