### PR TITLE
chore(i18n): rename leftover Apple_Pi_* message key to WorkX_*

### DIFF
--- a/_locales/ar_BH/messages.json
+++ b/_locales/ar_BH/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "دائمًا فاتح"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: الذكاء الاصطناعي الشخصي الخاص بك (ألفا)"
   },
   "Approval_Safety": {

--- a/_locales/bg_BG/messages.json
+++ b/_locales/bg_BG/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Винаги светло"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Вашият личен AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/bn_BD/messages.json
+++ b/_locales/bn_BD/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "সর্বদা হালকা"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: আপনার ব্যক্তিগত AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/ca_ES/messages.json
+++ b/_locales/ca_ES/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Sempre clar"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: La teva IA personal (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/ceb_PH/messages.json
+++ b/_locales/ceb_PH/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Kanunay hayag"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Ang imong personal nga AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/cs_CZ/messages.json
+++ b/_locales/cs_CZ/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Vždy světlý"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Váš osobní AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/da_DK/messages.json
+++ b/_locales/da_DK/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Altid lys"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Din personlige AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/de_DE/messages.json
+++ b/_locales/de_DE/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Immer hell"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Ihre persönliche KI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/dg_DG/messages.json
+++ b/_locales/dg_DG/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "always light wow"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: very personal AI (Alpha) wow"
   },
   "Approval_Safety": {

--- a/_locales/el_GR/messages.json
+++ b/_locales/el_GR/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Πάντα φωτεινό"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Η προσωπική σας AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -179,7 +179,7 @@
   "Always_light": {
     "message": "Always light"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Your personal AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/en_GB/messages.json
+++ b/_locales/en_GB/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Always light"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Your personal AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/es_ES/messages.json
+++ b/_locales/es_ES/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Siempre claro"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Su IA personal (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/fa_IR/messages.json
+++ b/_locales/fa_IR/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "همیشه روشن"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: هوش مصنوعی شخصی شما (آلفا)"
   },
   "Approval_Safety": {

--- a/_locales/fi_FI/messages.json
+++ b/_locales/fi_FI/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Aina vaalea"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Henkilökohtainen AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/fr_CA/messages.json
+++ b/_locales/fr_CA/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Toujours clair"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX : votre IA personnelle (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/fr_FR/messages.json
+++ b/_locales/fr_FR/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Toujours clair"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX : votre IA personnelle (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/he_IL/messages.json
+++ b/_locales/he_IL/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "תמיד מואר"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: ה‑AI האישי שלך (אלפא)"
   },
   "Approval_Safety": {

--- a/_locales/hi_IN/messages.json
+++ b/_locales/hi_IN/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "हमेशा लाइट"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: आपका व्यक्तिगत AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/hr_HR/messages.json
+++ b/_locales/hr_HR/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Uvijek svijetlo"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Vaš osobni AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/hu_HU/messages.json
+++ b/_locales/hu_HU/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Mindig világos"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: A személyes AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/id_ID/messages.json
+++ b/_locales/id_ID/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Selalu terang"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: AI pribadi Anda (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/it_IT/messages.json
+++ b/_locales/it_IT/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Sempre chiaro"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: La sua IA personale (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/ja_JP/messages.json
+++ b/_locales/ja_JP/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "常にライト"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: あなたのパーソナルAI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/ka_GE/messages.json
+++ b/_locales/ka_GE/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "ყოველთვის ნათელი"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: თქვენი პერსონალური AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/key_map.json
+++ b/_locales/key_map.json
@@ -322,7 +322,7 @@
   "All actions are auto-approved on these domains.": "All_actions_are_auto_approved_on_these_d_ffda",
   "All actions are denied on these domains.": "All_actions_are_denied_on_these_domains",
   "Always Approve": "Always_Approve",
-  "WorkX: Your personal AI (Alpha)": "Apple_Pi_Your_personal_AI_Alpha",
+  "WorkX: Your personal AI (Alpha)": "WorkX_Your_personal_AI_Alpha",
   "Approval Required": "Approval_Required",
   "Approval Required: Apply Patch": "Approval_Required_Apply_Patch",
   "Approval Required: Execute Command": "Approval_Required_Execute_Command",

--- a/_locales/ko_KR/messages.json
+++ b/_locales/ko_KR/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "항상 밝은 모드"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: 개인 AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/lt_LT/messages.json
+++ b/_locales/lt_LT/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Visada šviesus"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Jūsų asmeninis AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/mr_IN/messages.json
+++ b/_locales/mr_IN/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "नेहमी उजळ"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: तुमचा वैयक्तिक AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/ms_MY/messages.json
+++ b/_locales/ms_MY/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Sentiasa terang"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: AI peribadi anda (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/nb_NO/messages.json
+++ b/_locales/nb_NO/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Alltid lys"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Din personlige AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/nl_NL/messages.json
+++ b/_locales/nl_NL/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Altijd licht"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: jouw persoonlijke AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/pa_IN/messages.json
+++ b/_locales/pa_IN/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "ਹਮੇਸ਼ਾ ਰੋਸ਼ਨੀ"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: ਤੁਹਾਡਾ ਨਿੱਜੀ AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/pl_PL/messages.json
+++ b/_locales/pl_PL/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Zawsze jasny"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Twój osobisty AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Sempre claro"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: sua IA pessoal (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Sempre claro"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: A sua IA pessoal (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/ro_RO/messages.json
+++ b/_locales/ro_RO/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Întotdeauna luminos"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: AI-ul tău personal (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/ru_RU/messages.json
+++ b/_locales/ru_RU/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Всегда светлый"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: ваш персональный ИИ (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/sk_SK/messages.json
+++ b/_locales/sk_SK/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Vždy svetlý"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Váš osobný AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/sl_SI/messages.json
+++ b/_locales/sl_SI/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Vedno svetlo"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: vaš osebni AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/sr_RS/messages.json
+++ b/_locales/sr_RS/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Увек светло"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Ваш лични AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/sv_SE/messages.json
+++ b/_locales/sv_SE/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Alltid ljust"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Din personliga AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/sw_KE/messages.json
+++ b/_locales/sw_KE/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Daima mwanga"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: AI yako binafsi (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/ta_IN/messages.json
+++ b/_locales/ta_IN/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "எப்போதும் ஒளி"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: உங்கள் தனிப்பட்ட AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/te_IN/messages.json
+++ b/_locales/te_IN/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "ఎప్పుడూ వెలుగు"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: మీ వ్యక్తిగత AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/th_TH/messages.json
+++ b/_locales/th_TH/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "สว่างเสมอ"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX:ปัญญาประดิษฐ์ส่วนตัวของคุณ(Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/tr_TR/messages.json
+++ b/_locales/tr_TR/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Her zaman aydınlık"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Kişisel AI'niz (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/uk_UA/messages.json
+++ b/_locales/uk_UA/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Завжди світлий"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: Ваш особистий ШІ (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/vi_VN/messages.json
+++ b/_locales/vi_VN/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "Luôn sáng"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: AI cá nhân của bạn (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "始终亮色"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX: 您的个人 AI (Alpha)"
   },
   "Approval_Safety": {

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -176,7 +176,7 @@
   "Always_light": {
     "message": "永遠亮色"
   },
-  "Apple_Pi_Your_personal_AI_Alpha": {
+  "WorkX_Your_personal_AI_Alpha": {
     "message": "WorkX：您的個人 AI（Alpha）"
   },
   "Approval_Safety": {


### PR DESCRIPTION
## What
Renames the one i18n key the earlier rename PRs (#268, #273) missed:
`Apple_Pi_Your_personal_AI_Alpha` → `WorkX_Your_personal_AI_Alpha`, across all 50 locale `messages.json` files and `key_map.json`.

## Why
The message **value** already reads `"WorkX: Your personal AI (Alpha)"` — only the **key** still carried the old product name. This finishes the Apple Pi → WorkX rename at the i18n layer.

## Notes
- Pure key rename: 51 files, +1/-1 each, no value changes.
- The key is currently **unreferenced in code** (no `getMessage('Apple_Pi_Your_personal_AI_Alpha')` call on `main`), so this is naming-consistency cleanup with no functional impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)