### PR TITLE
fix(ui): show WorkX welcome banner instead of old BrowserX/Apple Pi art

### DIFF
--- a/src/webfront/constants/welcomeAscii.ts
+++ b/src/webfront/constants/welcomeAscii.ts
@@ -1,25 +1,12 @@
-import { platform } from '../stores/platformStore';
-
 const workxAsciiLines: Array<{ text: string; color: string }> = [
-  { text: '██████╗ ██████╗  ██████╗ ██╗    ██╗███████╗███████╗██████╗ ██╗  ██╗', color: 'text-term-blue' },
-  { text: '██╔══██╗██╔══██╗██╔═══██╗██║    ██║██╔════╝██╔════╝██╔══██╗╚██╗██╔╝', color: 'text-term-blue' },
-  { text: '██████╔╝██████╔╝██║   ██║██║ █╗ ██║███████╗█████╗  ██████╔╝ ╚███╔╝ ', color: 'text-term-blue' },
-  { text: '██╔══██╗██╔══██╗██║   ██║██║███╗██║╚════██║██╔══╝  ██╔══██╗ ██╔██╗ ', color: 'text-term-blue' },
-  { text: '██████╔╝██║  ██║╚██████╔╝╚███╔███╔╝███████║███████╗██║  ██║██╔╝ ██╗', color: 'text-term-blue' },
-  { text: '╚═════╝ ╚═╝  ╚═╝ ╚═════╝  ╚══╝╚══╝ ╚══════╝╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝', color: 'text-term-blue' },
+  { text: '██╗    ██╗ ██████╗ ██████╗ ██╗  ██╗██╗  ██╗', color: 'text-term-blue' },
+  { text: '██║    ██║██╔═══██╗██╔══██╗██║ ██╔╝╚██╗██╔╝', color: 'text-term-blue' },
+  { text: '██║ █╗ ██║██║   ██║██████╔╝█████╔╝  ╚███╔╝ ', color: 'text-term-blue' },
+  { text: '██║███╗██║██║   ██║██╔══██╗██╔═██╗  ██╔██╗ ', color: 'text-term-blue' },
+  { text: '╚███╔███╔╝╚██████╔╝██║  ██║██║  ██╗██╔╝ ██╗', color: 'text-term-blue' },
+  { text: ' ╚══╝╚══╝  ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝', color: 'text-term-blue' },
   { text: '', color: 'text-term-blue' }
 ];
 
-const piAsciiLines: Array<{ text: string; color: string }> = [
-  { text: ' █████╗ ██████╗ ██████╗ ██╗     ███████╗    ██████╗ ██╗', color: 'text-term-blue' },
-  { text: '██╔══██╗██╔══██╗██╔══██╗██║     ██╔════╝    ██╔══██╗╚═╝', color: 'text-term-blue' },
-  { text: '███████║██████╔╝██████╔╝██║     █████╗      ██████╔╝██╗', color: 'text-term-blue' },
-  { text: '██╔══██║██╔═══╝ ██╔═══╝ ██║     ██╔══╝      ██╔═══╝ ██║', color: 'text-term-blue' },
-  { text: '██║  ██║██║     ██║     ███████╗███████╗    ██║     ██║', color: 'text-term-blue' },
-  { text: '╚═╝  ╚═╝╚═╝     ╚═╝     ╚══════╝╚══════╝    ╚═╝     ╚═╝', color: 'text-term-blue' },
-  { text: '', color: 'text-term-blue' }
-];
-
-export const welcomeAsciiLines = platform.platformName === 'extension'
-  ? workxAsciiLines
-  : piAsciiLines;
+// Unified WorkX brand across all surfaces (extension + desktop).
+export const welcomeAsciiLines = workxAsciiLines;


### PR DESCRIPTION
## What
Replaces the welcome-screen ASCII logo, which still rendered pre-rename brand names:
- Extension surface rendered **`BROWSERX`**
- Desktop surface rendered **`APPLE PI`**

Both are now a single unified **`WORKX`** banner (same ANSI Shadow font), and the per-surface split is removed since the product is unified as WorkX.

## New banner
```
██╗    ██╗ ██████╗ ██████╗ ██╗  ██╗██╗  ██╗
██║    ██║██╔═══██╗██╔══██╗██║ ██╔╝╚██╗██╔╝
██║ █╗ ██║██║   ██║██████╔╝█████╔╝  ╚███╔╝ 
██║███╗██║██║   ██║██╔══██╗██╔═██╗  ██╔██╗ 
╚███╔███╔╝╚██████╔╝██║  ██║██║  ██╗██╔╝ ██╗
 ╚══╝╚══╝  ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝
```

## Notes
- Only consumer is `src/webfront/pages/chat/Main.svelte` (imports `welcomeAsciiLines`, still exported). No other references to the removed symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)