### PR TITLE
Input dispatch correctness: key-definition table + click options (web-tool T04–T06)

### DIFF
--- a/src/extension/tools/DOMTool.ts
+++ b/src/extension/tools/DOMTool.ts
@@ -371,7 +371,10 @@ Snapshots only return elements visible in the current viewport (inViewport: true
 
     // Always use CDP-based implementation (content-script implementation removed)
     const domService = await DomService.forTab(tabId);
-    return await domService.click(nodeId);
+    return await domService.click(nodeId, {
+      button: options?.button,
+      clickCount: options?.clickType === 'double' ? 2 : 1,
+    });
   }
 
   /**

--- a/src/extension/tools/__tests__/DOMTool.test.ts
+++ b/src/extension/tools/__tests__/DOMTool.test.ts
@@ -475,7 +475,10 @@ describe('DOMTool', () => {
         withTab(1)
       );
       expect(result.success).toBe(true);
-      expect(mockDomServiceInstance.click).toHaveBeenCalledWith('0:42');
+      expect(mockDomServiceInstance.click).toHaveBeenCalledWith(
+        '0:42',
+        expect.objectContaining({ clickCount: 1 })
+      );
     });
 
     it('should route type to DomService.type with node_id, text, and options', async () => {

--- a/src/extension/tools/dom/DomService.ts
+++ b/src/extension/tools/dom/DomService.ts
@@ -15,6 +15,7 @@ import { computeHeuristics, classifyNode, determineInteractionType, detectFramew
 import type { TypeOptions } from '../../../types/domTool';
 import { DomAddon, type DomAddonContext } from './addons/DomAddon';
 import { googleDocAddon } from './addons/GoogleDocAddon';
+import { dispatchKey } from '../input/InputDispatcher';
 import type { DebuggerClient, CDPEventCallback } from '../../../core/tools/browser/DebuggerClient';
 // Static import — forTab() is only used in extension builds where DOMTool is registered.
 // Dynamic import() is banned in Chrome extension service workers.
@@ -2676,18 +2677,10 @@ export class DomService {
         if (modifiers.includes('Meta')) modifierBits |= 4;
       }
 
-      await this.sendCommand('Input.dispatchKeyEvent', {
-        type: 'keyDown',
-        key,
-        code: `Key${key.toUpperCase()}`,
-        modifiers: modifierBits
-      });
-
-      await this.sendCommand('Input.dispatchKeyEvent', {
-        type: 'keyUp',
-        key,
-        code: `Key${key.toUpperCase()}`,
-        modifiers: modifierBits
+      // Correct key synthesis: real `code`/`windowsVirtualKeyCode`/`text` so
+      // pages (and legacy keyCode handlers) actually receive the keypress.
+      await dispatchKey((method, params) => this.sendCommand(method, params), key, {
+        modifiers: modifierBits,
       });
 
       // Invalidate snapshot - let getSerializedDom() rebuild when needed

--- a/src/extension/tools/dom/DomService.ts
+++ b/src/extension/tools/dom/DomService.ts
@@ -15,7 +15,14 @@ import { computeHeuristics, classifyNode, determineInteractionType, detectFramew
 import type { TypeOptions } from '../../../types/domTool';
 import { DomAddon, type DomAddonContext } from './addons/DomAddon';
 import { googleDocAddon } from './addons/GoogleDocAddon';
-import { dispatchKey } from '../input/InputDispatcher';
+import { dispatchKey, click as dispatchClick, type MouseButton } from '../input/InputDispatcher';
+
+/** Options for {@link DomService.click}. */
+export interface ClickActionOptions {
+  button?: MouseButton;
+  clickCount?: number;
+  modifiers?: number;
+}
 import type { DebuggerClient, CDPEventCallback } from '../../../core/tools/browser/DebuggerClient';
 // Static import — forTab() is only used in extension builds where DOMTool is registered.
 // Dynamic import() is banned in Chrome extension service workers.
@@ -1009,7 +1016,7 @@ export class DomService {
   }
 
   // Action methods (T037-T045 will implement these)
-  async click(nodeId: number | string): Promise<ActionResult> {
+  async click(nodeId: number | string, options?: ClickActionOptions): Promise<ActionResult> {
     const start = Date.now();
 
     // Parse frame-scoped node ID
@@ -1125,20 +1132,13 @@ export class DomService {
       // CDP MIGRATION: Trigger ripple visual effect BEFORE click (with correct coordinates)
       await this.triggerVisualEffect('ripple', centerX, centerY);
 
-      // Dispatch click at the correct position
-      await this.sendCommand('Input.dispatchMouseEvent', {
-        type: 'mousePressed',
-        x: centerX,
-        y: centerY,
-        button: 'left',
-        clickCount: 1
-      });
-
-      await this.sendCommand('Input.dispatchMouseEvent', {
-        type: 'mouseReleased',
-        x: centerX,
-        y: centerY,
-        button: 'left'
+      // Dispatch click at the correct position. Routes through the shared
+      // dispatcher: mouseMoved -> mousePressed -> mouseReleased with correct
+      // `buttons` bookkeeping, honoring the requested button/clickCount.
+      await dispatchClick((method, params) => this.sendCommand(method, params), centerX, centerY, {
+        button: options?.button,
+        clickCount: options?.clickCount,
+        modifiers: options?.modifiers,
       });
 
       // Invalidate snapshot - let getSerializedDom() rebuild when needed

--- a/src/extension/tools/input/InputDispatcher.ts
+++ b/src/extension/tools/input/InputDispatcher.ts
@@ -1,0 +1,140 @@
+/**
+ * InputDispatcher — correct CDP input synthesis.
+ *
+ * Stateless helpers that emit `Input.*` CDP events with the fields real
+ * browsers expect: proper `code`/`windowsVirtualKeyCode`/`text` for keys, and a
+ * `mouseMoved → mousePressed → mouseReleased` sequence with correct `buttons`
+ * bookkeeping for clicks. Takes a `send` function so it works against any
+ * target (tab or, later, an OOPIF).
+ *
+ * @module extension/tools/input/InputDispatcher
+ */
+
+import { getKeyDefinition } from './keyDefinitions';
+
+/** Sends a CDP command; satisfied by DomService/CoordinateActionService senders. */
+export type CdpSend = <T = unknown>(method: string, params: Record<string, unknown>) => Promise<T>;
+
+/** CDP modifier bitmask. */
+export const MODIFIER_BITS = { alt: 1, ctrl: 2, meta: 4, shift: 8 } as const;
+
+/** CDP mouse `buttons` bitmask (held buttons). */
+const BUTTON_MASK: Record<MouseButton, number> = { left: 1, right: 2, middle: 4 };
+
+export type MouseButton = 'left' | 'right' | 'middle';
+
+export interface ModifierFlags {
+  alt?: boolean;
+  ctrl?: boolean;
+  meta?: boolean;
+  shift?: boolean;
+}
+
+export interface DispatchKeyOptions {
+  /** CDP modifier bitmask (see {@link encodeModifiers}). */
+  modifiers?: number;
+}
+
+export interface ClickOptions {
+  button?: MouseButton;
+  clickCount?: number;
+  /** CDP modifier bitmask. */
+  modifiers?: number;
+}
+
+/** Encode modifier flags to the CDP bitmask (Alt=1, Ctrl=2, Meta=4, Shift=8). */
+export function encodeModifiers(flags?: ModifierFlags): number {
+  if (!flags) return 0;
+  let bits = 0;
+  if (flags.alt) bits |= MODIFIER_BITS.alt;
+  if (flags.ctrl) bits |= MODIFIER_BITS.ctrl;
+  if (flags.meta) bits |= MODIFIER_BITS.meta;
+  if (flags.shift) bits |= MODIFIER_BITS.shift;
+  return bits;
+}
+
+/**
+ * Dispatch a single key press (keyDown/rawKeyDown + keyUp) with correct
+ * `code`, `windowsVirtualKeyCode`, and `text` for printable keys.
+ */
+export async function dispatchKey(
+  send: CdpSend,
+  key: string,
+  options?: DispatchKeyOptions
+): Promise<void> {
+  const def = getKeyDefinition(key);
+  const modifiers = options?.modifiers ?? 0;
+
+  let text = def.text;
+  // With Shift held, a letter produces its uppercase character.
+  if (text && modifiers & MODIFIER_BITS.shift && /^[a-z]$/.test(text)) {
+    text = text.toUpperCase();
+  }
+  const isPrintable = text !== undefined;
+
+  const base: Record<string, unknown> = {
+    key: def.key,
+    code: def.code,
+    windowsVirtualKeyCode: def.keyCode,
+    nativeVirtualKeyCode: def.keyCode,
+    modifiers,
+  };
+  if (def.location !== undefined) base.location = def.location;
+
+  await send('Input.dispatchKeyEvent', {
+    // Printable keys produce a character event; non-text keys (navigation,
+    // modifiers) use rawKeyDown so no spurious text is inserted.
+    type: isPrintable ? 'keyDown' : 'rawKeyDown',
+    ...base,
+    ...(isPrintable ? { text } : {}),
+  });
+  await send('Input.dispatchKeyEvent', { type: 'keyUp', ...base });
+}
+
+/**
+ * Dispatch a mouse click as `mouseMoved → mousePressed → mouseReleased`. The
+ * leading move lets hover-gated controls (menus, row actions) react, and some
+ * frameworks gate `click` on a prior `mousemove`. `buttons` reflects currently
+ * held buttons: set on press, cleared on release.
+ */
+export async function click(send: CdpSend, x: number, y: number, options?: ClickOptions): Promise<void> {
+  const button = options?.button ?? 'left';
+  const clickCount = options?.clickCount ?? 1;
+  const modifiers = options?.modifiers ?? 0;
+  const heldButtons = BUTTON_MASK[button];
+
+  await send('Input.dispatchMouseEvent', {
+    type: 'mouseMoved',
+    x,
+    y,
+    button: 'none',
+    buttons: 0,
+    modifiers,
+    pointerType: 'mouse',
+  });
+  await send('Input.dispatchMouseEvent', {
+    type: 'mousePressed',
+    x,
+    y,
+    button,
+    buttons: heldButtons,
+    clickCount,
+    modifiers,
+    pointerType: 'mouse',
+  });
+  await send('Input.dispatchMouseEvent', {
+    type: 'mouseReleased',
+    x,
+    y,
+    button,
+    buttons: 0,
+    clickCount,
+    modifiers,
+    pointerType: 'mouse',
+  });
+}
+
+/** Insert text directly (fast path for bulk typing; not per-key synthesis). */
+export async function insertText(send: CdpSend, text: string): Promise<void> {
+  await send('Input.insertText', { text });
+}

--- a/src/extension/tools/input/InputDispatcher.ts
+++ b/src/extension/tools/input/InputDispatcher.ts
@@ -63,12 +63,18 @@ export async function dispatchKey(
   options?: DispatchKeyOptions
 ): Promise<void> {
   const def = getKeyDefinition(key);
-  const modifiers = options?.modifiers ?? 0;
+  let modifiers = options?.modifiers ?? 0;
 
   let text = def.text;
   // With Shift held, a letter produces its uppercase character.
   if (text && modifiers & MODIFIER_BITS.shift && /^[a-z]$/.test(text)) {
     text = text.toUpperCase();
+  }
+  // An already-uppercase letter implies Shift — encode it so the synthesized
+  // KeyboardEvent (event.shiftKey, code+shiftKey reconstruction) matches a real
+  // keystroke rather than reporting shiftKey:false for 'A'.
+  if (text && /^[A-Z]$/.test(text)) {
+    modifiers |= MODIFIER_BITS.shift;
   }
   const isPrintable = text !== undefined;
 
@@ -99,7 +105,7 @@ export async function dispatchKey(
  */
 export async function click(send: CdpSend, x: number, y: number, options?: ClickOptions): Promise<void> {
   const button = options?.button ?? 'left';
-  const clickCount = options?.clickCount ?? 1;
+  const clickCount = Math.max(1, options?.clickCount ?? 1);
   const modifiers = options?.modifiers ?? 0;
   const heldButtons = BUTTON_MASK[button];
 
@@ -112,26 +118,33 @@ export async function click(send: CdpSend, x: number, y: number, options?: Click
     modifiers,
     pointerType: 'mouse',
   });
-  await send('Input.dispatchMouseEvent', {
-    type: 'mousePressed',
-    x,
-    y,
-    button,
-    buttons: heldButtons,
-    clickCount,
-    modifiers,
-    pointerType: 'mouse',
-  });
-  await send('Input.dispatchMouseEvent', {
-    type: 'mouseReleased',
-    x,
-    y,
-    button,
-    buttons: 0,
-    clickCount,
-    modifiers,
-    pointerType: 'mouse',
-  });
+
+  // A double-click is NOT one press/release with clickCount:2 — the renderer
+  // derives `dblclick` only after observing successive click cycles with an
+  // incrementing clickCount. So emit `clickCount` full press/release cycles
+  // (count 1, then 2, …), matching Puppeteer/Playwright.
+  for (let n = 1; n <= clickCount; n++) {
+    await send('Input.dispatchMouseEvent', {
+      type: 'mousePressed',
+      x,
+      y,
+      button,
+      buttons: heldButtons,
+      clickCount: n,
+      modifiers,
+      pointerType: 'mouse',
+    });
+    await send('Input.dispatchMouseEvent', {
+      type: 'mouseReleased',
+      x,
+      y,
+      button,
+      buttons: 0,
+      clickCount: n,
+      modifiers,
+      pointerType: 'mouse',
+    });
+  }
 }
 
 /** Insert text directly (fast path for bulk typing; not per-key synthesis). */

--- a/src/extension/tools/input/InputDispatcher.ts
+++ b/src/extension/tools/input/InputDispatcher.ts
@@ -10,7 +10,7 @@
  * @module extension/tools/input/InputDispatcher
  */
 
-import { getKeyDefinition } from './keyDefinitions';
+import { getKeyDefinition, SHIFTED_CHARS } from './keyDefinitions';
 
 /** Sends a CDP command; satisfied by DomService/CoordinateActionService senders. */
 export type CdpSend = <T = unknown>(method: string, params: Record<string, unknown>) => Promise<T>;
@@ -70,10 +70,11 @@ export async function dispatchKey(
   if (text && modifiers & MODIFIER_BITS.shift && /^[a-z]$/.test(text)) {
     text = text.toUpperCase();
   }
-  // An already-uppercase letter implies Shift — encode it so the synthesized
-  // KeyboardEvent (event.shiftKey, code+shiftKey reconstruction) matches a real
-  // keystroke rather than reporting shiftKey:false for 'A'.
-  if (text && /^[A-Z]$/.test(text)) {
+  // A character that requires Shift on a US layout (uppercase letter, or a
+  // shifted symbol like '?', '!', '~') implies Shift — encode it so the
+  // synthesized KeyboardEvent (event.shiftKey, code+shiftKey reconstruction)
+  // matches a real keystroke rather than reporting shiftKey:false.
+  if (text && (/^[A-Z]$/.test(text) || SHIFTED_CHARS.has(text))) {
     modifiers |= MODIFIER_BITS.shift;
   }
   const isPrintable = text !== undefined;

--- a/src/extension/tools/input/__tests__/InputDispatcher.test.ts
+++ b/src/extension/tools/input/__tests__/InputDispatcher.test.ts
@@ -99,10 +99,37 @@ describe('click', () => {
     }));
   });
 
-  it('supports right-click and double-click', async () => {
+  it('supports right-click', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
-    await click(send, 1, 2, { button: 'right', clickCount: 2 });
-    expect(send.mock.calls[1][1]).toMatchObject({ button: 'right', buttons: 2, clickCount: 2 });
-    expect(send.mock.calls[2][1]).toMatchObject({ button: 'right', buttons: 0, clickCount: 2 });
+    await click(send, 1, 2, { button: 'right' });
+    expect(send.mock.calls[1][1]).toMatchObject({ type: 'mousePressed', button: 'right', buttons: 2, clickCount: 1 });
+    expect(send.mock.calls[2][1]).toMatchObject({ type: 'mouseReleased', button: 'right', buttons: 0, clickCount: 1 });
+  });
+
+  it('double-click emits two full press/release cycles with incrementing clickCount', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await click(send, 1, 2, { clickCount: 2 });
+    // mouseMoved, press(1), release(1), press(2), release(2)
+    expect(send).toHaveBeenCalledTimes(5);
+    expect(send.mock.calls[0][1]).toMatchObject({ type: 'mouseMoved' });
+    expect(send.mock.calls[1][1]).toMatchObject({ type: 'mousePressed', clickCount: 1 });
+    expect(send.mock.calls[2][1]).toMatchObject({ type: 'mouseReleased', clickCount: 1 });
+    expect(send.mock.calls[3][1]).toMatchObject({ type: 'mousePressed', clickCount: 2 });
+    expect(send.mock.calls[4][1]).toMatchObject({ type: 'mouseReleased', clickCount: 2 });
+  });
+});
+
+describe('keyDefinitions punctuation + dispatchKey shift', () => {
+  it('maps punctuation to a real code + virtual key code (not ASCII)', () => {
+    expect(getKeyDefinition('.')).toMatchObject({ code: 'Period', keyCode: 190, text: '.' });
+    expect(getKeyDefinition('/')).toMatchObject({ code: 'Slash', keyCode: 191, text: '/' });
+    // No bogus ASCII-derived keyCode (e.g. '.' must not be 46 = VK_DELETE).
+    expect(getKeyDefinition('.').keyCode).not.toBe(46);
+  });
+
+  it('encodes the Shift modifier for an already-uppercase letter', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await dispatchKey(send, 'A');
+    expect(send.mock.calls[0][1]).toMatchObject({ type: 'keyDown', text: 'A', modifiers: MODIFIER_BITS.shift });
   });
 });

--- a/src/extension/tools/input/__tests__/InputDispatcher.test.ts
+++ b/src/extension/tools/input/__tests__/InputDispatcher.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getKeyDefinition } from '../keyDefinitions';
+import { dispatchKey, click, encodeModifiers, MODIFIER_BITS } from '../InputDispatcher';
+
+describe('getKeyDefinition', () => {
+  it('maps Enter with text and keyCode 13', () => {
+    expect(getKeyDefinition('Enter')).toMatchObject({ code: 'Enter', keyCode: 13, text: '\r' });
+  });
+
+  it('maps Tab with keyCode 9 and no text', () => {
+    const def = getKeyDefinition('Tab');
+    expect(def).toMatchObject({ code: 'Tab', keyCode: 9 });
+    expect(def.text).toBeUndefined();
+  });
+
+  it('maps lowercase and uppercase letters to KeyA / keyCode 65', () => {
+    expect(getKeyDefinition('a')).toMatchObject({ code: 'KeyA', keyCode: 65, text: 'a' });
+    expect(getKeyDefinition('A')).toMatchObject({ code: 'KeyA', keyCode: 65, text: 'A' });
+  });
+
+  it('maps digits to DigitN', () => {
+    expect(getKeyDefinition('1')).toMatchObject({ code: 'Digit1', keyCode: 49, text: '1' });
+  });
+
+  it('maps navigation keys without text', () => {
+    expect(getKeyDefinition('ArrowDown')).toMatchObject({ code: 'ArrowDown', keyCode: 40 });
+    expect(getKeyDefinition('ArrowDown').text).toBeUndefined();
+  });
+
+  it('resolves aliases', () => {
+    expect(getKeyDefinition('Esc').code).toBe('Escape');
+    expect(getKeyDefinition('Up').code).toBe('ArrowUp');
+    expect(getKeyDefinition('Return').code).toBe('Enter');
+  });
+
+  it('maps function keys', () => {
+    expect(getKeyDefinition('F5')).toMatchObject({ code: 'F5', keyCode: 116 });
+    expect(getKeyDefinition('F12')).toMatchObject({ code: 'F12', keyCode: 123 });
+  });
+
+  it('never produces the legacy KeyENTER-style code', () => {
+    expect(getKeyDefinition('Enter').code).not.toBe('KeyENTER');
+    expect(getKeyDefinition('Tab').code).not.toBe('KeyTAB');
+  });
+});
+
+describe('encodeModifiers', () => {
+  it('encodes the CDP bitmask', () => {
+    expect(encodeModifiers()).toBe(0);
+    expect(encodeModifiers({ ctrl: true })).toBe(MODIFIER_BITS.ctrl);
+    expect(encodeModifiers({ alt: true, shift: true })).toBe(MODIFIER_BITS.alt | MODIFIER_BITS.shift);
+  });
+});
+
+describe('dispatchKey', () => {
+  it('sends keyDown with text + windowsVirtualKeyCode then keyUp for a printable key', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await dispatchKey(send, 'Enter');
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', expect.objectContaining({
+      type: 'keyDown', key: 'Enter', code: 'Enter', windowsVirtualKeyCode: 13, text: '\r',
+    }));
+    expect(send).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', expect.objectContaining({
+      type: 'keyUp', code: 'Enter', windowsVirtualKeyCode: 13,
+    }));
+  });
+
+  it('uses rawKeyDown with no text for navigation keys', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await dispatchKey(send, 'ArrowDown');
+    const first = send.mock.calls[0][1];
+    expect(first.type).toBe('rawKeyDown');
+    expect(first.text).toBeUndefined();
+    expect(first.windowsVirtualKeyCode).toBe(40);
+  });
+
+  it('uppercases a letter when Shift is held', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await dispatchKey(send, 'a', { modifiers: MODIFIER_BITS.shift });
+    expect(send.mock.calls[0][1]).toMatchObject({ type: 'keyDown', text: 'A' });
+  });
+});
+
+describe('click', () => {
+  it('emits mouseMoved → mousePressed → mouseReleased with correct buttons', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await click(send, 10, 20);
+
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(send).toHaveBeenNthCalledWith(1, 'Input.dispatchMouseEvent', expect.objectContaining({
+      type: 'mouseMoved', x: 10, y: 20, button: 'none', buttons: 0,
+    }));
+    expect(send).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', expect.objectContaining({
+      type: 'mousePressed', button: 'left', buttons: 1, clickCount: 1,
+    }));
+    expect(send).toHaveBeenNthCalledWith(3, 'Input.dispatchMouseEvent', expect.objectContaining({
+      type: 'mouseReleased', button: 'left', buttons: 0, clickCount: 1,
+    }));
+  });
+
+  it('supports right-click and double-click', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await click(send, 1, 2, { button: 'right', clickCount: 2 });
+    expect(send.mock.calls[1][1]).toMatchObject({ button: 'right', buttons: 2, clickCount: 2 });
+    expect(send.mock.calls[2][1]).toMatchObject({ button: 'right', buttons: 0, clickCount: 2 });
+  });
+});

--- a/src/extension/tools/input/__tests__/InputDispatcher.test.ts
+++ b/src/extension/tools/input/__tests__/InputDispatcher.test.ts
@@ -132,4 +132,23 @@ describe('keyDefinitions punctuation + dispatchKey shift', () => {
     await dispatchKey(send, 'A');
     expect(send.mock.calls[0][1]).toMatchObject({ type: 'keyDown', text: 'A', modifiers: MODIFIER_BITS.shift });
   });
+
+  it('maps shifted number-row symbols to the digit code and encodes Shift', async () => {
+    expect(getKeyDefinition('!')).toMatchObject({ code: 'Digit1', keyCode: 49, text: '!' });
+    const send = vi.fn().mockResolvedValue(undefined);
+    await dispatchKey(send, '!');
+    expect(send.mock.calls[0][1]).toMatchObject({ type: 'keyDown', code: 'Digit1', modifiers: MODIFIER_BITS.shift });
+  });
+
+  it('encodes Shift for a shifted punctuation symbol', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await dispatchKey(send, '?');
+    expect(send.mock.calls[0][1]).toMatchObject({ type: 'keyDown', code: 'Slash', modifiers: MODIFIER_BITS.shift });
+  });
+
+  it('does not encode Shift for an unshifted symbol', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await dispatchKey(send, '/');
+    expect(send.mock.calls[0][1]).toMatchObject({ type: 'keyDown', code: 'Slash', modifiers: 0 });
+  });
 });

--- a/src/extension/tools/input/keyDefinitions.ts
+++ b/src/extension/tools/input/keyDefinitions.ts
@@ -73,6 +73,21 @@ const ALIASES: Record<string, string> = {
 const A_CODE = 'a'.charCodeAt(0);
 const Z_CODE = 'z'.charCodeAt(0);
 
+/** US punctuation → physical `code` + Windows virtual key code. */
+const PUNCTUATION: Record<string, { code: string; keyCode: number }> = {
+  '`': { code: 'Backquote', keyCode: 192 }, '~': { code: 'Backquote', keyCode: 192 },
+  '-': { code: 'Minus', keyCode: 189 }, '_': { code: 'Minus', keyCode: 189 },
+  '=': { code: 'Equal', keyCode: 187 }, '+': { code: 'Equal', keyCode: 187 },
+  '[': { code: 'BracketLeft', keyCode: 219 }, '{': { code: 'BracketLeft', keyCode: 219 },
+  ']': { code: 'BracketRight', keyCode: 221 }, '}': { code: 'BracketRight', keyCode: 221 },
+  '\\': { code: 'Backslash', keyCode: 220 }, '|': { code: 'Backslash', keyCode: 220 },
+  ';': { code: 'Semicolon', keyCode: 186 }, ':': { code: 'Semicolon', keyCode: 186 },
+  "'": { code: 'Quote', keyCode: 222 }, '"': { code: 'Quote', keyCode: 222 },
+  ',': { code: 'Comma', keyCode: 188 }, '<': { code: 'Comma', keyCode: 188 },
+  '.': { code: 'Period', keyCode: 190 }, '>': { code: 'Period', keyCode: 190 },
+  '/': { code: 'Slash', keyCode: 191 }, '?': { code: 'Slash', keyCode: 191 },
+};
+
 /**
  * Resolve a key string to its CDP definition. Handles named keys, aliases,
  * function keys (F1–F24), single letters/digits, and falls back to treating an
@@ -101,9 +116,14 @@ export function getKeyDefinition(key: string): KeyDefinition {
     if (ch >= '0' && ch <= '9') {
       return { key: ch, code: `Digit${ch}`, keyCode: ch.charCodeAt(0), text: ch };
     }
-    // Other printable single character (punctuation/symbols): provide text so
-    // it inserts; we don't model a precise physical code for every symbol.
-    return { key: ch, code: '', keyCode: ch.toUpperCase().charCodeAt(0), text: ch };
+    const punct = PUNCTUATION[ch];
+    if (punct) {
+      return { key: ch, code: punct.code, keyCode: punct.keyCode, text: ch };
+    }
+    // Other printable single character: provide text so it inserts. We don't
+    // model a physical code for it, and we deliberately emit keyCode:0 rather
+    // than a wrong virtual key code derived from the character's ASCII value.
+    return { key: ch, code: '', keyCode: 0, text: ch };
   }
 
   // Unknown multi-char key: pass through with no virtual code.

--- a/src/extension/tools/input/keyDefinitions.ts
+++ b/src/extension/tools/input/keyDefinitions.ts
@@ -86,7 +86,24 @@ const PUNCTUATION: Record<string, { code: string; keyCode: number }> = {
   ',': { code: 'Comma', keyCode: 188 }, '<': { code: 'Comma', keyCode: 188 },
   '.': { code: 'Period', keyCode: 190 }, '>': { code: 'Period', keyCode: 190 },
   '/': { code: 'Slash', keyCode: 191 }, '?': { code: 'Slash', keyCode: 191 },
+  // Shifted number-row symbols share the digit's physical code.
+  '!': { code: 'Digit1', keyCode: 49 }, '@': { code: 'Digit2', keyCode: 50 },
+  '#': { code: 'Digit3', keyCode: 51 }, '$': { code: 'Digit4', keyCode: 52 },
+  '%': { code: 'Digit5', keyCode: 53 }, '^': { code: 'Digit6', keyCode: 54 },
+  '&': { code: 'Digit7', keyCode: 55 }, '*': { code: 'Digit8', keyCode: 56 },
+  '(': { code: 'Digit9', keyCode: 57 }, ')': { code: 'Digit0', keyCode: 48 },
 };
+
+/**
+ * Characters that require Shift on a US layout. Dispatching these should encode
+ * the Shift modifier so the synthesized KeyboardEvent matches a real keystroke
+ * (event.shiftKey true), like the uppercase-letter path. Uppercase A–Z are
+ * handled separately by a regex.
+ */
+export const SHIFTED_CHARS = new Set([
+  '~', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+',
+  '{', '}', '|', ':', '"', '<', '>', '?',
+]);
 
 /**
  * Resolve a key string to its CDP definition. Handles named keys, aliases,

--- a/src/extension/tools/input/keyDefinitions.ts
+++ b/src/extension/tools/input/keyDefinitions.ts
@@ -1,0 +1,111 @@
+/**
+ * US-keyboard key-definition table.
+ *
+ * Maps a `key` value (as supplied by the agent — e.g. "Enter", "ArrowDown",
+ * "a", "1") to the fields CDP's `Input.dispatchKeyEvent` needs: a correct
+ * `code`, a `windowsVirtualKeyCode` (so `KeyboardEvent.keyCode`/`which` is
+ * populated for legacy handlers), and `text` for printable keys.
+ *
+ * This replaces the previous `code: \`Key${key.toUpperCase()}\`` defect, which
+ * produced invalid codes like `KeyENTER`/`KeyTAB` and sent no virtual key code
+ * or text — so many pages ignored synthesized keypresses entirely.
+ *
+ * Shape ported from Puppeteer's USKeyboardLayout (Apache-2.0).
+ *
+ * @module extension/tools/input/keyDefinitions
+ */
+
+export interface KeyDefinition {
+  /** `KeyboardEvent.key` value. */
+  key: string;
+  /** `KeyboardEvent.code` value (physical key). */
+  code: string;
+  /** Windows virtual key code → CDP `windowsVirtualKeyCode`. */
+  keyCode: number;
+  /** Character produced, when printable. Presence marks the key as text-producing. */
+  text?: string;
+  /** `KeyboardEvent.location` (1 = left modifier, 3 = numpad). */
+  location?: number;
+}
+
+/** Named / non-printable keys and aliases the agent commonly supplies. */
+const NAMED_KEYS: Record<string, KeyDefinition> = {
+  Enter: { key: 'Enter', code: 'Enter', keyCode: 13, text: '\r' },
+  NumpadEnter: { key: 'Enter', code: 'NumpadEnter', keyCode: 13, text: '\r', location: 3 },
+  Tab: { key: 'Tab', code: 'Tab', keyCode: 9 },
+  Backspace: { key: 'Backspace', code: 'Backspace', keyCode: 8 },
+  Delete: { key: 'Delete', code: 'Delete', keyCode: 46 },
+  Escape: { key: 'Escape', code: 'Escape', keyCode: 27 },
+  ArrowUp: { key: 'ArrowUp', code: 'ArrowUp', keyCode: 38 },
+  ArrowDown: { key: 'ArrowDown', code: 'ArrowDown', keyCode: 40 },
+  ArrowLeft: { key: 'ArrowLeft', code: 'ArrowLeft', keyCode: 37 },
+  ArrowRight: { key: 'ArrowRight', code: 'ArrowRight', keyCode: 39 },
+  Home: { key: 'Home', code: 'Home', keyCode: 36 },
+  End: { key: 'End', code: 'End', keyCode: 35 },
+  PageUp: { key: 'PageUp', code: 'PageUp', keyCode: 33 },
+  PageDown: { key: 'PageDown', code: 'PageDown', keyCode: 34 },
+  Insert: { key: 'Insert', code: 'Insert', keyCode: 45 },
+  ' ': { key: ' ', code: 'Space', keyCode: 32, text: ' ' },
+  // Modifiers (left variants).
+  Shift: { key: 'Shift', code: 'ShiftLeft', keyCode: 16, location: 1 },
+  Control: { key: 'Control', code: 'ControlLeft', keyCode: 17, location: 1 },
+  Alt: { key: 'Alt', code: 'AltLeft', keyCode: 18, location: 1 },
+  Meta: { key: 'Meta', code: 'MetaLeft', keyCode: 91, location: 1 },
+};
+
+/** Friendly aliases → canonical key names. */
+const ALIASES: Record<string, string> = {
+  Esc: 'Escape',
+  Del: 'Delete',
+  Space: ' ',
+  Spacebar: ' ',
+  Up: 'ArrowUp',
+  Down: 'ArrowDown',
+  Left: 'ArrowLeft',
+  Right: 'ArrowRight',
+  Ctrl: 'Control',
+  Command: 'Meta',
+  Cmd: 'Meta',
+  Win: 'Meta',
+  Return: 'Enter',
+};
+
+const A_CODE = 'a'.charCodeAt(0);
+const Z_CODE = 'z'.charCodeAt(0);
+
+/**
+ * Resolve a key string to its CDP definition. Handles named keys, aliases,
+ * function keys (F1–F24), single letters/digits, and falls back to treating an
+ * unknown single character as printable text.
+ */
+export function getKeyDefinition(key: string): KeyDefinition {
+  const canonical = ALIASES[key] ?? key;
+  const named = NAMED_KEYS[canonical];
+  if (named) return named;
+
+  // Function keys F1–F24 → keyCode 112–135.
+  const fnMatch = /^F([1-9]|1[0-9]|2[0-4])$/.exec(canonical);
+  if (fnMatch) {
+    const n = Number(fnMatch[1]);
+    return { key: canonical, code: canonical, keyCode: 111 + n };
+  }
+
+  if (canonical.length === 1) {
+    const ch = canonical;
+    const lower = ch.toLowerCase();
+    const lc = lower.charCodeAt(0);
+    if (lc >= A_CODE && lc <= Z_CODE) {
+      const letter = lower.toUpperCase();
+      return { key: ch, code: `Key${letter}`, keyCode: lower.toUpperCase().charCodeAt(0), text: ch };
+    }
+    if (ch >= '0' && ch <= '9') {
+      return { key: ch, code: `Digit${ch}`, keyCode: ch.charCodeAt(0), text: ch };
+    }
+    // Other printable single character (punctuation/symbols): provide text so
+    // it inserts; we don't model a precise physical code for every symbol.
+    return { key: ch, code: '', keyCode: ch.toUpperCase().charCodeAt(0), text: ch };
+  }
+
+  // Unknown multi-char key: pass through with no virtual code.
+  return { key: canonical, code: canonical, keyCode: 0 };
+}

--- a/src/extension/tools/screenshot/CoordinateActionService.ts
+++ b/src/extension/tools/screenshot/CoordinateActionService.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Coordinates, KeyModifiers, CoordinateActionOptions } from './types';
-import { dispatchKey } from '../input/InputDispatcher';
+import { dispatchKey, click as dispatchClick } from '../input/InputDispatcher';
 
 export class CoordinateActionService {
   private tabId: number;
@@ -35,24 +35,12 @@ export class CoordinateActionService {
       const clickCount = options?.clickCount || 1;
       const modifiers = this.encodeModifiers(options?.modifiers);
 
-      // Dispatch mouse pressed event
-      await this.sendCommand('Input.dispatchMouseEvent', {
-        type: 'mousePressed',
-        x: coordinates.x,
-        y: coordinates.y,
+      // Route through the shared dispatcher: mouseMoved -> mousePressed ->
+      // mouseReleased with correct `buttons` bookkeeping.
+      await dispatchClick((method, params) => this.sendCommand(method, params), coordinates.x, coordinates.y, {
         button,
         clickCount,
-        modifiers
-      });
-
-      // Dispatch mouse released event
-      await this.sendCommand('Input.dispatchMouseEvent', {
-        type: 'mouseReleased',
-        x: coordinates.x,
-        y: coordinates.y,
-        button,
-        clickCount,
-        modifiers
+        modifiers,
       });
 
       // Wait after action if specified

--- a/src/extension/tools/screenshot/CoordinateActionService.ts
+++ b/src/extension/tools/screenshot/CoordinateActionService.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Coordinates, KeyModifiers, CoordinateActionOptions } from './types';
+import { dispatchKey } from '../input/InputDispatcher';
 
 export class CoordinateActionService {
   private tabId: number;
@@ -150,21 +151,8 @@ export class CoordinateActionService {
     try {
       const modifiers = this.encodeModifiers(options?.modifiers);
 
-      // Dispatch key down event
-      await this.sendCommand('Input.dispatchKeyEvent', {
-        type: 'keyDown',
-        key,
-        code: `Key${key.toUpperCase()}`,
-        modifiers
-      });
-
-      // Dispatch key up event
-      await this.sendCommand('Input.dispatchKeyEvent', {
-        type: 'keyUp',
-        key,
-        code: `Key${key.toUpperCase()}`,
-        modifiers
-      });
+      // Correct key synthesis via the shared dispatcher (real code/keyCode/text).
+      await dispatchKey((method, params) => this.sendCommand(method, params), key, { modifiers });
 
       // Wait after action if specified
       if (options?.waitAfter) {

--- a/src/extension/tools/screenshot/__tests__/CoordinateActionService.test.ts
+++ b/src/extension/tools/screenshot/__tests__/CoordinateActionService.test.ts
@@ -412,33 +412,36 @@ describe('CoordinateActionService', () => {
   // keypressAt
   // ==========================================================================
   describe('keypressAt', () => {
-    it('sends keyDown then keyUp with correct key and code', async () => {
+    it('sends keyDown then keyUp with correct key, code, virtual key code, and text', async () => {
       await service.keypressAt('Enter');
 
       expect(mockSendCommand).toHaveBeenCalledTimes(2);
 
-      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', {
+      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', expect.objectContaining({
         type: 'keyDown',
         key: 'Enter',
-        code: 'KeyENTER',
+        code: 'Enter',
+        windowsVirtualKeyCode: 13,
+        text: '\r',
         modifiers: 0,
-      });
+      }));
 
-      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', {
+      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', expect.objectContaining({
         type: 'keyUp',
         key: 'Enter',
-        code: 'KeyENTER',
+        code: 'Enter',
+        windowsVirtualKeyCode: 13,
         modifiers: 0,
-      });
+      }));
     });
 
-    it('generates uppercase code from the key name', async () => {
+    it('uses the correct physical code for a letter', async () => {
       await service.keypressAt('a');
 
       expect(mockSendCommand).toHaveBeenNthCalledWith(
         1,
         'Input.dispatchKeyEvent',
-        expect.objectContaining({ key: 'a', code: 'KeyA' })
+        expect.objectContaining({ key: 'a', code: 'KeyA', windowsVirtualKeyCode: 65, text: 'a' })
       );
     });
 
@@ -447,19 +450,19 @@ describe('CoordinateActionService', () => {
         modifiers: { ctrl: true },
       });
 
-      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', {
+      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', expect.objectContaining({
         type: 'keyDown',
         key: 'c',
         code: 'KeyC',
         modifiers: 2,
-      });
+      }));
 
-      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', {
+      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', expect.objectContaining({
         type: 'keyUp',
         key: 'c',
         code: 'KeyC',
         modifiers: 2,
-      });
+      }));
     });
 
     it('encodes combined modifiers on keypress events', async () => {
@@ -487,7 +490,7 @@ describe('CoordinateActionService', () => {
       expect(mockSendCommand).toHaveBeenNthCalledWith(
         1,
         'Input.dispatchKeyEvent',
-        expect.objectContaining({ key: 'Tab', code: 'KeyTAB' })
+        expect.objectContaining({ key: 'Tab', code: 'Tab', windowsVirtualKeyCode: 9 })
       );
     });
 
@@ -497,7 +500,7 @@ describe('CoordinateActionService', () => {
       expect(mockSendCommand).toHaveBeenNthCalledWith(
         1,
         'Input.dispatchKeyEvent',
-        expect.objectContaining({ key: 'Escape', code: 'KeyESCAPE' })
+        expect.objectContaining({ key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 })
       );
     });
 

--- a/src/extension/tools/screenshot/__tests__/CoordinateActionService.test.ts
+++ b/src/extension/tools/screenshot/__tests__/CoordinateActionService.test.ts
@@ -32,19 +32,30 @@ describe('CoordinateActionService', () => {
       }));
     });
 
-    it('uses custom button, clickCount, and modifiers from options', async () => {
+    it('uses custom button and modifiers from options', async () => {
       await service.clickAt(
         { x: 50, y: 75 },
-        { button: 'right', clickCount: 2, modifiers: { shift: true } }
+        { button: 'right', modifiers: { shift: true } }
       );
 
       expect(mockSendCommand).toHaveBeenCalledTimes(3);
 
       expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', expect.objectContaining({
-        type: 'mousePressed', x: 50, y: 75, button: 'right', buttons: 2, clickCount: 2, modifiers: 8,
+        type: 'mousePressed', x: 50, y: 75, button: 'right', buttons: 2, clickCount: 1, modifiers: 8,
       }));
       expect(mockSendCommand).toHaveBeenNthCalledWith(3, 'Input.dispatchMouseEvent', expect.objectContaining({
-        type: 'mouseReleased', x: 50, y: 75, button: 'right', buttons: 0, clickCount: 2, modifiers: 8,
+        type: 'mouseReleased', x: 50, y: 75, button: 'right', buttons: 0, clickCount: 1, modifiers: 8,
+      }));
+    });
+
+    it('double-click emits two press/release cycles (5 events)', async () => {
+      await service.clickAt({ x: 1, y: 2 }, { clickCount: 2 });
+      expect(mockSendCommand).toHaveBeenCalledTimes(5);
+      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mousePressed', clickCount: 1,
+      }));
+      expect(mockSendCommand).toHaveBeenNthCalledWith(4, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mousePressed', clickCount: 2,
       }));
     });
 

--- a/src/extension/tools/screenshot/__tests__/CoordinateActionService.test.ts
+++ b/src/extension/tools/screenshot/__tests__/CoordinateActionService.test.ts
@@ -16,28 +16,20 @@ describe('CoordinateActionService', () => {
   // clickAt
   // ==========================================================================
   describe('clickAt', () => {
-    it('sends mousePressed then mouseReleased with correct coordinates', async () => {
+    it('sends mouseMoved, mousePressed, then mouseReleased with correct coordinates', async () => {
       await service.clickAt({ x: 100, y: 200 });
 
-      expect(mockSendCommand).toHaveBeenCalledTimes(2);
+      expect(mockSendCommand).toHaveBeenCalledTimes(3);
 
-      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchMouseEvent', {
-        type: 'mousePressed',
-        x: 100,
-        y: 200,
-        button: 'left',
-        clickCount: 1,
-        modifiers: 0,
-      });
-
-      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', {
-        type: 'mouseReleased',
-        x: 100,
-        y: 200,
-        button: 'left',
-        clickCount: 1,
-        modifiers: 0,
-      });
+      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mouseMoved', x: 100, y: 200, button: 'none', buttons: 0,
+      }));
+      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mousePressed', x: 100, y: 200, button: 'left', buttons: 1, clickCount: 1, modifiers: 0,
+      }));
+      expect(mockSendCommand).toHaveBeenNthCalledWith(3, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mouseReleased', x: 100, y: 200, button: 'left', buttons: 0, clickCount: 1, modifiers: 0,
+      }));
     });
 
     it('uses custom button, clickCount, and modifiers from options', async () => {
@@ -46,38 +38,22 @@ describe('CoordinateActionService', () => {
         { button: 'right', clickCount: 2, modifiers: { shift: true } }
       );
 
-      expect(mockSendCommand).toHaveBeenCalledTimes(2);
+      expect(mockSendCommand).toHaveBeenCalledTimes(3);
 
-      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchMouseEvent', {
-        type: 'mousePressed',
-        x: 50,
-        y: 75,
-        button: 'right',
-        clickCount: 2,
-        modifiers: 8,
-      });
-
-      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', {
-        type: 'mouseReleased',
-        x: 50,
-        y: 75,
-        button: 'right',
-        clickCount: 2,
-        modifiers: 8,
-      });
+      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mousePressed', x: 50, y: 75, button: 'right', buttons: 2, clickCount: 2, modifiers: 8,
+      }));
+      expect(mockSendCommand).toHaveBeenNthCalledWith(3, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mouseReleased', x: 50, y: 75, button: 'right', buttons: 0, clickCount: 2, modifiers: 8,
+      }));
     });
 
     it('defaults button to left, clickCount to 1, modifiers to 0 when options is undefined', async () => {
       await service.clickAt({ x: 0, y: 0 });
 
-      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchMouseEvent', {
-        type: 'mousePressed',
-        x: 0,
-        y: 0,
-        button: 'left',
-        clickCount: 1,
-        modifiers: 0,
-      });
+      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mousePressed', x: 0, y: 0, button: 'left', buttons: 1, clickCount: 1, modifiers: 0,
+      }));
     });
 
     it('wraps sendCommand errors with COORDINATE_CLICK_FAILED', async () => {
@@ -200,30 +176,21 @@ describe('CoordinateActionService', () => {
       await vi.advanceTimersByTimeAsync(100);
       await promise;
 
-      // clickAt produces 2 calls (mousePressed + mouseReleased), then insertText = 3 total
-      expect(mockSendCommand).toHaveBeenCalledTimes(3);
+      // clickAt produces 3 calls (mouseMoved, mousePressed, mouseReleased), then insertText = 4 total
+      expect(mockSendCommand).toHaveBeenCalledTimes(4);
 
-      // First two calls are the click (mousePressed, mouseReleased)
-      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchMouseEvent', {
-        type: 'mousePressed',
-        x: 300,
-        y: 400,
-        button: 'left',
-        clickCount: 1,
-        modifiers: 0,
-      });
+      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mouseMoved', x: 300, y: 400,
+      }));
+      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mousePressed', x: 300, y: 400, button: 'left', clickCount: 1,
+      }));
+      expect(mockSendCommand).toHaveBeenNthCalledWith(3, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mouseReleased', x: 300, y: 400, button: 'left', clickCount: 1,
+      }));
 
-      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', {
-        type: 'mouseReleased',
-        x: 300,
-        y: 400,
-        button: 'left',
-        clickCount: 1,
-        modifiers: 0,
-      });
-
-      // Third call is the text insertion
-      expect(mockSendCommand).toHaveBeenNthCalledWith(3, 'Input.insertText', {
+      // Last call is the text insertion
+      expect(mockSendCommand).toHaveBeenNthCalledWith(4, 'Input.insertText', {
         text: 'Hello World',
       });
     });
@@ -237,11 +204,11 @@ describe('CoordinateActionService', () => {
       await vi.advanceTimersByTimeAsync(100);
       await promise;
 
-      // Internal click should always use clickCount: 1
+      // Internal click (mousePressed = 2nd call) should always use clickCount: 1
       expect(mockSendCommand).toHaveBeenNthCalledWith(
-        1,
+        2,
         'Input.dispatchMouseEvent',
-        expect.objectContaining({ clickCount: 1 })
+        expect.objectContaining({ type: 'mousePressed', clickCount: 1 })
       );
     });
 
@@ -256,8 +223,9 @@ describe('CoordinateActionService', () => {
     });
 
     it('wraps errors from insertText with COORDINATE_TYPE_FAILED', async () => {
-      // Click succeeds, but insertText fails
+      // Click succeeds (mouseMoved, mousePressed, mouseReleased), but insertText fails
       mockSendCommand
+        .mockResolvedValueOnce(undefined) // mouseMoved
         .mockResolvedValueOnce(undefined) // mousePressed
         .mockResolvedValueOnce(undefined) // mouseReleased
         .mockRejectedValueOnce(new Error('Input domain error'));


### PR DESCRIPTION
## Summary

PR-1 tasks **T04, T05, T06** of the web-tool hardening plan (`.ai_design/improve_webtool_from_codex`, §3.4). Fixes the input-synthesis defects that made keypresses and clicks unreliable on real pages.

Independent of the registry PR (#280) — branches off `main`.

## The bugs

- **Keyboard:** both `DomService.keypress` and `CoordinateActionService.keypressAt` computed `code: \`Key${key.toUpperCase()}\`` → invalid codes like `KeyENTER`/`KeyTAB`, with **no** `windowsVirtualKeyCode` and **no** `text`. Legacy `e.keyCode`-based handlers saw `0`, and printable keys produced no character — so many pages ignored synthesized keypresses entirely.
- **Click options dropped:** `DOMTool` advertises `button`/`clickType` but `executeClick` ignored them and `DomService.click` hardcoded left/single. Right-click and double-click didn't work despite being documented.
- **No `mouseMoved` precursor:** clicks dispatched `mousePressed` cold, so hover-gated controls (menus, row actions) never saw `mouseenter`, and some frameworks gate `click` on a prior `mousemove`.

## What changed

- **`input/keyDefinitions.ts`** — US key-definition table: `key → { code, keyCode (windowsVirtualKeyCode), text?, location? }` for named/navigation/modifier/function keys, letters, digits, and printable symbols, plus aliases (`Esc`, `Up`, `Return`, `Cmd`, …). `Enter` → `text: "\r"`; navigation keys carry no text.
- **`input/InputDispatcher.ts`** — `dispatchKey` (keyDown/rawKeyDown + keyUp with correct fields; Shift uppercases letters), `click` (`mouseMoved → mousePressed → mouseReleased` with correct `buttons` bookkeeping: set on press, cleared on release), `insertText`, and `encodeModifiers`.
- **Wiring:** `DomService.keypress`/`click` and `CoordinateActionService.keypressAt`/`clickAt` route through the dispatcher; `DOMTool.executeClick` forwards `button` and maps `clickType: 'double'` → `clickCount: 2`.

## Tests

- New `InputDispatcher` suite (key table, dispatchKey, click sequence, modifiers, right/double-click).
- Updated `CoordinateActionService`/`DOMTool` tests that asserted the old `KeyENTER`/`KeyTAB` codes and the 2-event click sequence.
- Affected suites: **1180 tests green**; `type-check` clean. (Pre-existing `@vscode/ripgrep` failures unrelated.)

## Follow-ups (remaining PR-1)

- **T08** — vision DPR hotfix (downscale screenshot to CSS pixels).
- **T07** — `DOM.getContentQuads` coordinate targeting + viewport-intersection visibility (behind a `useContentQuads` flag with `getBoxModel` fallback). Riskier coordinate-space change; its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)