### PR TITLE
Vision DPR hotfix: downscale screenshots to CSS pixels (web-tool T08)

### DIFF
--- a/src/extension/tools/screenshot/ScreenshotService.ts
+++ b/src/extension/tools/screenshot/ScreenshotService.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ScreenshotCaptureOptions, ViewportBounds, ScrollOffset } from './types';
+import { downscalePngToCssPixels } from './downscale';
 
 export class ScreenshotService {
   private tabId: number;
@@ -30,18 +31,22 @@ export class ScreenshotService {
     viewport: ViewportBounds;
   }> {
     try {
-      // Get viewport bounds before capture
-      const viewport = await this.getViewportBounds();
+      // Get viewport bounds (+ DPR) before capture
+      const { devicePixelRatio, ...viewport } = await this.getViewportBounds();
 
-      // Capture screenshot using CDP
+      // Capture screenshot using CDP (device pixels)
       const screenshot = await this.sendCommand<{ data: string }>('Page.captureScreenshot', {
         format: options?.format || 'png',
         quality: options?.quality,
         captureBeyondViewport: false // Only capture visible viewport
       });
 
+      // Downscale to CSS pixels so the image the model sees matches the
+      // coordinate space clicks are dispatched in (no-op when DPR == 1).
+      const base64Data = await downscalePngToCssPixels(screenshot.data, devicePixelRatio);
+
       return {
-        base64Data: screenshot.data,
+        base64Data,
         viewport
       };
     } catch (error: any) {
@@ -101,19 +106,20 @@ export class ScreenshotService {
   /**
    * Get current viewport bounds
    */
-  private async getViewportBounds(): Promise<ViewportBounds> {
+  private async getViewportBounds(): Promise<ViewportBounds & { devicePixelRatio: number }> {
     const result = await this.sendCommand<any>('Runtime.evaluate', {
-      expression: '({ width: window.innerWidth, height: window.innerHeight, scroll_x: window.scrollX, scroll_y: window.scrollY })',
+      expression: '({ width: window.innerWidth, height: window.innerHeight, scroll_x: window.scrollX, scroll_y: window.scrollY, device_pixel_ratio: window.devicePixelRatio })',
       returnByValue: true
     });
 
-    const { width, height, scroll_x, scroll_y } = result.result.value;
+    const { width, height, scroll_x, scroll_y, device_pixel_ratio } = result.result.value;
 
     return {
       width,
       height,
       scroll_x,
-      scroll_y
+      scroll_y,
+      devicePixelRatio: device_pixel_ratio ?? 1
     };
   }
 

--- a/src/extension/tools/screenshot/ScreenshotService.ts
+++ b/src/extension/tools/screenshot/ScreenshotService.ts
@@ -35,15 +35,20 @@ export class ScreenshotService {
       const { devicePixelRatio, ...viewport } = await this.getViewportBounds();
 
       // Capture screenshot using CDP (device pixels)
+      const format = options?.format || 'png';
       const screenshot = await this.sendCommand<{ data: string }>('Page.captureScreenshot', {
-        format: options?.format || 'png',
+        format,
         quality: options?.quality,
         captureBeyondViewport: false // Only capture visible viewport
       });
 
       // Downscale to CSS pixels so the image the model sees matches the
       // coordinate space clicks are dispatched in (no-op when DPR == 1).
-      const base64Data = await downscalePngToCssPixels(screenshot.data, devicePixelRatio);
+      // Preserve the requested image format when re-encoding.
+      const base64Data = await downscalePngToCssPixels(screenshot.data, devicePixelRatio, {
+        mimeType: `image/${format}`,
+        quality: options?.quality != null ? options.quality / 100 : undefined,
+      });
 
       return {
         base64Data,

--- a/src/extension/tools/screenshot/__tests__/ScreenshotService.test.ts
+++ b/src/extension/tools/screenshot/__tests__/ScreenshotService.test.ts
@@ -70,7 +70,7 @@ describe('ScreenshotService', () => {
       await service.captureViewport();
 
       expect(mockSendCommand).toHaveBeenCalledWith('Runtime.evaluate', {
-        expression: '({ width: window.innerWidth, height: window.innerHeight, scroll_x: window.scrollX, scroll_y: window.scrollY })',
+        expression: '({ width: window.innerWidth, height: window.innerHeight, scroll_x: window.scrollX, scroll_y: window.scrollY, device_pixel_ratio: window.devicePixelRatio })',
         returnByValue: true,
       });
     });

--- a/src/extension/tools/screenshot/__tests__/downscale.test.ts
+++ b/src/extension/tools/screenshot/__tests__/downscale.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { downscalePngToCssPixels } from '../downscale';
+
+describe('downscalePngToCssPixels', () => {
+  const sample = btoa('PNGDATA');
+  let origBitmap: any;
+  let origCanvas: any;
+
+  beforeEach(() => {
+    origBitmap = (globalThis as any).createImageBitmap;
+    origCanvas = (globalThis as any).OffscreenCanvas;
+  });
+
+  afterEach(() => {
+    (globalThis as any).createImageBitmap = origBitmap;
+    (globalThis as any).OffscreenCanvas = origCanvas;
+  });
+
+  it('returns the input unchanged when dpr <= 1', async () => {
+    expect(await downscalePngToCssPixels(sample, 1)).toBe(sample);
+  });
+
+  it('returns the input unchanged when image APIs are unavailable', async () => {
+    (globalThis as any).createImageBitmap = undefined;
+    (globalThis as any).OffscreenCanvas = undefined;
+    expect(await downscalePngToCssPixels(sample, 2)).toBe(sample);
+  });
+
+  it('downscales by dpr using OffscreenCanvas when dpr > 1', async () => {
+    const drawImage = vi.fn();
+    const closed = vi.fn();
+    (globalThis as any).createImageBitmap = vi.fn(async () => ({ width: 200, height: 100, close: closed }));
+
+    let canvasW = 0;
+    let canvasH = 0;
+    (globalThis as any).OffscreenCanvas = class {
+      width: number;
+      height: number;
+      constructor(w: number, h: number) {
+        this.width = w;
+        this.height = h;
+        canvasW = w;
+        canvasH = h;
+      }
+      getContext() {
+        return { drawImage };
+      }
+      convertToBlob() {
+        return Promise.resolve({ arrayBuffer: async () => new Uint8Array([9, 9, 9]).buffer });
+      }
+    };
+
+    const out = await downscalePngToCssPixels(sample, 2);
+
+    // Canvas sized to CSS pixels (device / dpr).
+    expect(canvasW).toBe(100);
+    expect(canvasH).toBe(50);
+    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 100, 50);
+    expect(closed).toHaveBeenCalled();
+    // Output is the re-encoded bytes, not the original device-pixel image.
+    expect(out).toBe(btoa(String.fromCharCode(9, 9, 9)));
+    expect(out).not.toBe(sample);
+  });
+
+  it('falls back to the original image if the pipeline throws', async () => {
+    (globalThis as any).createImageBitmap = vi.fn(async () => {
+      throw new Error('decode failed');
+    });
+    (globalThis as any).OffscreenCanvas = class {};
+    expect(await downscalePngToCssPixels(sample, 2)).toBe(sample);
+  });
+});

--- a/src/extension/tools/screenshot/__tests__/downscale.test.ts
+++ b/src/extension/tools/screenshot/__tests__/downscale.test.ts
@@ -62,6 +62,24 @@ describe('downscalePngToCssPixels', () => {
     expect(out).not.toBe(sample);
   });
 
+  it('preserves the requested image format when re-encoding', async () => {
+    const convertArgs: any[] = [];
+    (globalThis as any).createImageBitmap = vi.fn(async () => ({ width: 200, height: 100, close: vi.fn() }));
+    (globalThis as any).OffscreenCanvas = class {
+      constructor(public width: number, public height: number) {}
+      getContext() {
+        return { drawImage: vi.fn() };
+      }
+      convertToBlob(opts: any) {
+        convertArgs.push(opts);
+        return Promise.resolve({ arrayBuffer: async () => new Uint8Array([1]).buffer });
+      }
+    };
+
+    await downscalePngToCssPixels(sample, 2, { mimeType: 'image/jpeg', quality: 0.8 });
+    expect(convertArgs[0]).toEqual({ type: 'image/jpeg', quality: 0.8 });
+  });
+
   it('falls back to the original image if the pipeline throws', async () => {
     (globalThis as any).createImageBitmap = vi.fn(async () => {
       throw new Error('decode failed');

--- a/src/extension/tools/screenshot/downscale.ts
+++ b/src/extension/tools/screenshot/downscale.ts
@@ -1,0 +1,63 @@
+/**
+ * Downscale a device-pixel PNG to CSS pixels.
+ *
+ * `page_vision` captures at device resolution (`Page.captureScreenshot` applies
+ * no scale), yet the model is told to report image-pixel coordinates and those
+ * are dispatched as CSS-pixel `Input` events. On DPR>1 displays that mismatch
+ * made every vision click land at DPR× the intended position (then silently
+ * clamped to the viewport edge). Downscaling the captured PNG to
+ * `innerWidth × innerHeight` makes image pixels == CSS pixels == input
+ * coordinates, with no DPR math downstream.
+ *
+ * Uses `OffscreenCanvas` / `createImageBitmap`, both available in MV3 service
+ * workers. No-ops when `devicePixelRatio <= 1` or the image APIs are
+ * unavailable (e.g. `chrome://`, PDF viewer, or a non-worker context), falling
+ * back to the original image rather than failing the capture.
+ *
+ * @module extension/tools/screenshot/downscale
+ */
+
+export async function downscalePngToCssPixels(
+  base64Data: string,
+  devicePixelRatio: number
+): Promise<string> {
+  if (!(devicePixelRatio > 1)) return base64Data;
+  if (typeof createImageBitmap !== 'function' || typeof OffscreenCanvas === 'undefined') {
+    return base64Data;
+  }
+
+  try {
+    const bytes = base64ToBytes(base64Data);
+    const bitmap = await createImageBitmap(new Blob([bytes], { type: 'image/png' }));
+    const targetWidth = Math.max(1, Math.round(bitmap.width / devicePixelRatio));
+    const targetHeight = Math.max(1, Math.round(bitmap.height / devicePixelRatio));
+
+    const canvas = new OffscreenCanvas(targetWidth, targetHeight);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      bitmap.close?.();
+      return base64Data;
+    }
+    ctx.drawImage(bitmap, 0, 0, targetWidth, targetHeight);
+    bitmap.close?.();
+
+    const blob = await canvas.convertToBlob({ type: 'image/png' });
+    return bytesToBase64(new Uint8Array(await blob.arrayBuffer()));
+  } catch (error) {
+    console.warn('[ScreenshotService] DPR downscale failed; using device-pixel image:', error);
+    return base64Data;
+  }
+}
+
+function base64ToBytes(base64: string): Uint8Array<ArrayBuffer> {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(new ArrayBuffer(binary.length));
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+}

--- a/src/extension/tools/screenshot/downscale.ts
+++ b/src/extension/tools/screenshot/downscale.ts
@@ -17,18 +17,28 @@
  * @module extension/tools/screenshot/downscale
  */
 
+export interface DownscaleOptions {
+  /** Image MIME type to decode and re-encode as (default 'image/png'). */
+  mimeType?: string;
+  /** Encoder quality for lossy formats (jpeg/webp), 0–1. */
+  quality?: number;
+}
+
 export async function downscalePngToCssPixels(
   base64Data: string,
-  devicePixelRatio: number
+  devicePixelRatio: number,
+  options?: DownscaleOptions
 ): Promise<string> {
   if (!(devicePixelRatio > 1)) return base64Data;
   if (typeof createImageBitmap !== 'function' || typeof OffscreenCanvas === 'undefined') {
     return base64Data;
   }
 
+  const mimeType = options?.mimeType ?? 'image/png';
+
   try {
     const bytes = base64ToBytes(base64Data);
-    const bitmap = await createImageBitmap(new Blob([bytes], { type: 'image/png' }));
+    const bitmap = await createImageBitmap(new Blob([bytes], { type: mimeType }));
     const targetWidth = Math.max(1, Math.round(bitmap.width / devicePixelRatio));
     const targetHeight = Math.max(1, Math.round(bitmap.height / devicePixelRatio));
 
@@ -41,7 +51,9 @@ export async function downscalePngToCssPixels(
     ctx.drawImage(bitmap, 0, 0, targetWidth, targetHeight);
     bitmap.close?.();
 
-    const blob = await canvas.convertToBlob({ type: 'image/png' });
+    // Preserve the requested format so a jpeg/webp capture isn't silently
+    // turned into PNG bytes.
+    const blob = await canvas.convertToBlob({ type: mimeType, quality: options?.quality });
     return bytesToBase64(new Uint8Array(await blob.arrayBuffer()));
   } catch (error) {
     console.warn('[ScreenshotService] DPR downscale failed; using device-pixel image:', error);


### PR DESCRIPTION
## Summary

PR-1 task **T08** (`.ai_design/improve_webtool_from_codex` §3.3 / §1.6 #1). Fixes vision clicks landing in the wrong place on Retina/HiDPI displays.

## The bug

`page_vision` captures with `Page.captureScreenshot` at **device** resolution (no scale), but the tool prompt tells the model to report **image-pixel** coordinates, and those are dispatched as **CSS-pixel** `Input` events. On a DPR=2 display the model reads a 2× image, names a coordinate up to 2× too large, and the click lands at ~DPR× the intended position — then gets silently clamped to the viewport edge, so it reads as "clicked the wrong element" instead of an obvious error. It only reproduces on DPR>1 screens, which is why it survived.

## The fix

Downscale the captured PNG to `innerWidth × innerHeight` (CSS pixels) so **image pixels == CSS pixels == input coordinates**, with no DPR math downstream.

- New `downscale.ts`: `downscalePngToCssPixels(base64, dpr)` using `OffscreenCanvas` / `createImageBitmap` (available in MV3 service workers). No-ops when `dpr <= 1` or the image APIs are unavailable (`chrome://`, PDF viewer); falls back to the original image on any error rather than failing the capture.
- `ScreenshotService.captureViewport` reads `devicePixelRatio` (folded into the existing viewport eval) and downscales the result.

### Why not `clip.scale = 1/dpr`

The design doc explicitly rejected that approach (§1.6 #1): `clip.scale` is the **page-scale** factor, not a `deviceScaleFactor` override, and in the current `captureBeyondViewport: false` mode its interaction with device DPR is Chrome-version-dependent and lossy on fractional DPR (1.25/1.5/1.75). This PR ships the agreed downscale instead.

The structural fix (`Emulation.setDeviceMetricsOverride({ deviceScaleFactor: 1 })`) remains PR-2 / T09.

## Tests

- `downscale` helper: no-op when dpr ≤ 1, no-op when image APIs absent, dpr=2 pipeline (canvas sized to CSS pixels, re-encoded output), error fallback.
- Updated the viewport-eval expression assertion. Suites green; `type-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)