### PR TITLE
Web-tool hardening: full implementation (PR-1 → PR-4, T01–T30)

### DIFF
--- a/src/core/RepublicAgent.ts
+++ b/src/core/RepublicAgent.ts
@@ -1084,6 +1084,8 @@ export class RepublicAgent {
         });
 
         this.session.setTabId(createdTabId);
+        // Record ownership: the agent created this tab (best-effort; extension-only).
+        void this.platformAdapter.claimTabLease?.(createdTabId, this.session.getId(), 'agent').catch(() => {});
 
         this.emitEvent({
           type: 'StateUpdate',
@@ -1128,6 +1130,7 @@ export class RepublicAgent {
       if (!this.platformAdapter.hasRealTabs) {
         // Desktop/server: just update session tabId
         this.session.setTabId(newTabId);
+        void this.platformAdapter.claimTabLease?.(newTabId, this.session.getId(), 'user').catch(() => {});
       } else {
         // Extension: validate tab before switching
         const validation = await this.platformAdapter.validateTab(newTabId);
@@ -1146,6 +1149,11 @@ export class RepublicAgent {
         try {
           await this.platformAdapter.switchTab(currentTabId, newTabId);
           this.session.setTabId(newTabId);
+          // Release the previous tab's lease and claim the new one (user-origin).
+          if (currentTabId !== -1) {
+            void this.platformAdapter.releaseTabLease?.(currentTabId, this.session.getId()).catch(() => {});
+          }
+          void this.platformAdapter.claimTabLease?.(newTabId, this.session.getId(), 'user').catch(() => {});
         } catch (error) {
           const errorMsg = error instanceof Error ? error.message : 'Unknown error during tab switching';
 

--- a/src/core/TabLeaseStore.ts
+++ b/src/core/TabLeaseStore.ts
@@ -1,0 +1,153 @@
+/**
+ * TabLeaseStore — ownership records for tabs an agent session operates.
+ *
+ * Records which session owns which tab and whether the tab was created by the
+ * agent (`agent`) or borrowed from the user (`user`). Backed by
+ * `chrome.storage.session` so leases survive MV3 service-worker restarts within
+ * a browsing session but are dropped when the browser closes.
+ *
+ * Design: `.ai_design/improve_webtool_from_codex/design.md` §3.6 / §7.4.
+ * Claims/releases are serialized per session by {@link LeaseLifecycleQueue};
+ * `gcStale` drops leases whose tab no longer exists (run at SW/session start).
+ *
+ * @module core/TabLeaseStore
+ */
+
+const STORAGE_KEY = 'workx:tab_leases';
+
+export type TabOrigin = 'agent' | 'user';
+
+export interface TabLease {
+  tabId: number;
+  sessionId: string;
+  turnId?: string;
+  origin: TabOrigin;
+  claimedAt: number;
+}
+
+export class TabLeasedError extends Error {
+  constructor(
+    public readonly tabId: number,
+    public readonly ownerSessionId: string
+  ) {
+    super(`TAB_LEASED: tab ${tabId} is leased to session ${ownerSessionId}`);
+    this.name = 'TabLeasedError';
+  }
+}
+
+/** Abstracts the small key/value surface we need (chrome.storage.session). */
+export interface LeaseStorage {
+  get(key: string): Promise<Record<string, unknown> | undefined>;
+  set(key: string, value: unknown): Promise<void>;
+}
+
+/** Whether a tab still exists (chrome.tabs.get wrapper); used by gcStale. */
+export type TabExists = (tabId: number) => Promise<boolean>;
+
+export class TabLeaseStore {
+  constructor(
+    private readonly storage: LeaseStorage,
+    private readonly tabExists: TabExists,
+    /** `() => now` injected so tests are deterministic. */
+    private readonly now: () => number = () => Date.now()
+  ) {}
+
+  /**
+   * Claim a tab for a session. Re-claiming by the same session updates the
+   * lease (e.g. new turnId). Throws {@link TabLeasedError} if a *different*
+   * live session owns it.
+   */
+  async claim(lease: Omit<TabLease, 'claimedAt'>): Promise<void> {
+    const leases = await this.readAll();
+    const existing = leases[lease.tabId];
+    if (existing && existing.sessionId !== lease.sessionId) {
+      if (await this.tabExists(lease.tabId)) {
+        throw new TabLeasedError(lease.tabId, existing.sessionId);
+      }
+      // Owner's tab is gone — the lease is stale; take it over.
+    }
+    leases[lease.tabId] = { ...lease, claimedAt: this.now() };
+    await this.writeAll(leases);
+  }
+
+  /** Release a tab held by a session. No-op if not held by that session. */
+  async release(sessionId: string, tabId: number): Promise<void> {
+    const leases = await this.readAll();
+    const existing = leases[tabId];
+    if (existing && existing.sessionId === sessionId) {
+      delete leases[tabId];
+      await this.writeAll(leases);
+    }
+  }
+
+  /** Release every tab held by a session (session cleanup). */
+  async releaseAll(sessionId: string): Promise<void> {
+    const leases = await this.readAll();
+    let changed = false;
+    for (const [tabId, lease] of Object.entries(leases)) {
+      if (lease.sessionId === sessionId) {
+        delete leases[Number(tabId)];
+        changed = true;
+      }
+    }
+    if (changed) await this.writeAll(leases);
+  }
+
+  async getOwner(tabId: number): Promise<string | null> {
+    const leases = await this.readAll();
+    return leases[tabId]?.sessionId ?? null;
+  }
+
+  async getLease(tabId: number): Promise<TabLease | null> {
+    const leases = await this.readAll();
+    return leases[tabId] ?? null;
+  }
+
+  /** Drop leases whose tab no longer exists. Returns the number dropped. */
+  async gcStale(): Promise<number> {
+    const leases = await this.readAll();
+    let dropped = 0;
+    for (const [tabId, lease] of Object.entries(leases)) {
+      if (!(await this.tabExists(lease.tabId))) {
+        delete leases[Number(tabId)];
+        dropped++;
+      }
+    }
+    if (dropped > 0) await this.writeAll(leases);
+    return dropped;
+  }
+
+  private async readAll(): Promise<Record<number, TabLease>> {
+    const raw = await this.storage.get(STORAGE_KEY);
+    const value = raw?.[STORAGE_KEY];
+    return (value as Record<number, TabLease>) ?? {};
+  }
+
+  private async writeAll(leases: Record<number, TabLease>): Promise<void> {
+    await this.storage.set(STORAGE_KEY, leases);
+  }
+}
+
+/**
+ * Serializes lease mutations (claim / release / GC) per session so they can't
+ * interleave — the analogue of Codex's `lifecycleQueue` (design §3.6.2). The
+ * startup GC must run through the same queue to avoid a GC-vs-claim race.
+ */
+export class LeaseLifecycleQueue {
+  private chains = new Map<string, Promise<unknown>>();
+
+  run<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
+    const prev = this.chains.get(sessionId) ?? Promise.resolve();
+    const run = prev.then(() => fn());
+    const tail = run.then(
+      () => undefined,
+      () => undefined
+    );
+    this.chains.set(sessionId, tail);
+    void tail.then(() => {
+      if (this.chains.get(sessionId) === tail) this.chains.delete(sessionId);
+    });
+    return run;
+  }
+}
+

--- a/src/core/TabLeaseStore.ts
+++ b/src/core/TabLeaseStore.ts
@@ -106,13 +106,17 @@ export class TabLeaseStore {
   /** Drop leases whose tab no longer exists. Returns the number dropped. */
   async gcStale(): Promise<number> {
     const leases = await this.readAll();
+    const entries = Object.entries(leases);
+    // Check liveness in parallel so we don't hold the lease lock for N
+    // sequential chrome.tabs.get round-trips.
+    const liveness = await Promise.all(entries.map(([, lease]) => this.tabExists(lease.tabId)));
     let dropped = 0;
-    for (const [tabId, lease] of Object.entries(leases)) {
-      if (!(await this.tabExists(lease.tabId))) {
+    entries.forEach(([tabId], i) => {
+      if (!liveness[i]) {
         delete leases[Number(tabId)];
         dropped++;
       }
-    }
+    });
     if (dropped > 0) await this.writeAll(leases);
     return dropped;
   }

--- a/src/core/__tests__/TabLeaseStore.test.ts
+++ b/src/core/__tests__/TabLeaseStore.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TabLeaseStore, LeaseLifecycleQueue, TabLeasedError, type LeaseStorage } from '../TabLeaseStore';
+
+/** In-memory LeaseStorage. */
+function memStorage(): LeaseStorage & { dump(): any } {
+  const data: Record<string, unknown> = {};
+  return {
+    async get(key: string) {
+      return key in data ? { [key]: data[key] } : undefined;
+    },
+    async set(key: string, value: unknown) {
+      data[key] = value;
+    },
+    dump: () => data,
+  };
+}
+
+describe('TabLeaseStore', () => {
+  it('claims a tab and reports the owner', async () => {
+    const store = new TabLeaseStore(memStorage(), async () => true);
+    await store.claim({ tabId: 1, sessionId: 'S1', origin: 'agent' });
+    expect(await store.getOwner(1)).toBe('S1');
+  });
+
+  it('rejects a claim on a tab leased to another live session', async () => {
+    const store = new TabLeaseStore(memStorage(), async () => true);
+    await store.claim({ tabId: 1, sessionId: 'S1', origin: 'user' });
+    await expect(store.claim({ tabId: 1, sessionId: 'S2', origin: 'user' })).rejects.toBeInstanceOf(
+      TabLeasedError
+    );
+  });
+
+  it('allows the same session to re-claim (e.g. new turn)', async () => {
+    const store = new TabLeaseStore(memStorage(), async () => true, () => 123);
+    await store.claim({ tabId: 1, sessionId: 'S1', origin: 'user', turnId: 't1' });
+    await store.claim({ tabId: 1, sessionId: 'S1', origin: 'user', turnId: 't2' });
+    expect(await store.getLease(1)).toMatchObject({ sessionId: 'S1', turnId: 't2', claimedAt: 123 });
+  });
+
+  it('takes over a lease whose tab no longer exists', async () => {
+    // Owner's tab is reported gone when the new session tries to claim.
+    const store = new TabLeaseStore(memStorage(), async () => false);
+    await store.claim({ tabId: 1, sessionId: 'S1', origin: 'agent' });
+    await store.claim({ tabId: 1, sessionId: 'S2', origin: 'user' }); // stale → takeover
+    expect(await store.getOwner(1)).toBe('S2');
+  });
+
+  it('releases only the holder’s lease', async () => {
+    const store = new TabLeaseStore(memStorage(), async () => true);
+    await store.claim({ tabId: 1, sessionId: 'S1', origin: 'agent' });
+    await store.release('S2', 1); // not the holder → no-op
+    expect(await store.getOwner(1)).toBe('S1');
+    await store.release('S1', 1);
+    expect(await store.getOwner(1)).toBeNull();
+  });
+
+  it('releaseAll drops every lease for a session', async () => {
+    const store = new TabLeaseStore(memStorage(), async () => true);
+    await store.claim({ tabId: 1, sessionId: 'S1', origin: 'agent' });
+    await store.claim({ tabId: 2, sessionId: 'S1', origin: 'user' });
+    await store.claim({ tabId: 3, sessionId: 'S2', origin: 'user' });
+    await store.releaseAll('S1');
+    expect(await store.getOwner(1)).toBeNull();
+    expect(await store.getOwner(2)).toBeNull();
+    expect(await store.getOwner(3)).toBe('S2');
+  });
+
+  it('gcStale drops leases whose tab is gone', async () => {
+    const alive = new Set([2]);
+    const store = new TabLeaseStore(memStorage(), async (t) => alive.has(t));
+    await store.claim({ tabId: 1, sessionId: 'S1', origin: 'agent' });
+    await store.claim({ tabId: 2, sessionId: 'S1', origin: 'user' });
+    const dropped = await store.gcStale();
+    expect(dropped).toBe(1);
+    expect(await store.getOwner(1)).toBeNull();
+    expect(await store.getOwner(2)).toBe('S1');
+  });
+});
+
+describe('LeaseLifecycleQueue', () => {
+  it('serializes operations per session', async () => {
+    const queue = new LeaseLifecycleQueue();
+    const order: string[] = [];
+    const mk = (label: string, delay: number) => () =>
+      new Promise<void>((resolve) => setTimeout(() => { order.push(label); resolve(); }, delay));
+
+    await Promise.all([
+      queue.run('S1', mk('a', 30)),
+      queue.run('S1', mk('b', 5)),
+      queue.run('S1', mk('c', 1)),
+    ]);
+
+    expect(order).toEqual(['a', 'b', 'c']); // strict FIFO despite differing delays
+  });
+
+  it('a rejected op does not poison the chain', async () => {
+    const queue = new LeaseLifecycleQueue();
+    await expect(queue.run('S1', async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+    await expect(queue.run('S1', async () => 'ok')).resolves.toBe('ok');
+  });
+});

--- a/src/core/platform/IPlatformAdapter.ts
+++ b/src/core/platform/IPlatformAdapter.ts
@@ -98,6 +98,15 @@ export interface IPlatformAdapter {
   validateTab(tabId: number): Promise<TabValidationResult>;
   switchTab(fromTabId: number, toTabId: number): Promise<void>;
 
+  /**
+   * Record/clear tab ownership for a session (extension-only; optional). Used by
+   * the tab-lease system so a tab leased to one live session can't be claimed by
+   * another, and so leases are GC'd across service-worker restarts. Best-effort:
+   * callers ignore failures so lease bookkeeping never breaks tab binding.
+   */
+  claimTabLease?(tabId: number, sessionId: string, origin: 'agent' | 'user'): Promise<void>;
+  releaseTabLease?(tabId: number, sessionId: string): Promise<void>;
+
   // Browser Controller
   getBrowserController(tabId: number): Promise<IBrowserController | null>;
 

--- a/src/core/tools/browser/DebuggerSessionRegistry.ts
+++ b/src/core/tools/browser/DebuggerSessionRegistry.ts
@@ -1,0 +1,85 @@
+/**
+ * Debugger Session Registry
+ *
+ * Centralizes Chrome debugger attachment so that the multiple services that
+ * operate a tab (DomService, ScreenshotService, CoordinateActionService) share
+ * a SINGLE underlying `chrome.debugger` attachment per tab instead of each
+ * attaching independently.
+ *
+ * Why this exists (see `.ai_design/improve_webtool_from_codex/design.md` §3.1):
+ * chrome.debugger allows only one debugger client per tab, yet today three
+ * services each attach independently with a racy `Runtime.evaluate('1+1')`
+ * probe, and the screenshot services never detach. The agent loop runs up to
+ * `MAX_SAFE_TOOL_CALL_CONCURRENCY` concurrency-safe tool calls in parallel
+ * (e.g. `browser_dom` snapshot + `page_vision` screenshot on the same tab), so
+ * these uncoordinated attaches genuinely race.
+ *
+ * The registry hands out a refcounted {@link DebuggerHandle}. The shared
+ * attachment is established on first `acquire` and torn down when the last
+ * holder `release`s. A single `chrome.debugger.onDetach` reconciler (owned by
+ * the implementation) keeps registry state consistent when the user closes the
+ * debugger infobar or the tab dies.
+ *
+ * @module core/tools/browser/DebuggerSessionRegistry
+ */
+
+import type { DebuggerClient } from './DebuggerClient';
+
+/**
+ * Called when the shared session for a tab detaches outside our control
+ * (debugger infobar closed, tab navigated away/closed, or a forced detach).
+ *
+ * @param reason - chrome.debugger detach reason, or `'force_detach'`.
+ */
+export type DebuggerDetachCallback = (reason: string) => void;
+
+/**
+ * A refcounted handle to a shared per-tab debugger session.
+ *
+ * Extends {@link DebuggerClient} so existing consumers that already program
+ * against that interface need minimal changes. Note that {@link release} — not
+ * `detach` — is what relinquishes this holder's reference; `detach()` is kept
+ * only for interface compatibility and is an alias for `release()`.
+ */
+export interface DebuggerHandle extends DebuggerClient {
+  /** The tab this handle is bound to. */
+  readonly tabId: number;
+
+  /**
+   * Subscribe to external/forced detach of the shared session. The callback
+   * fires at most once for a given detach. Returns an unsubscribe function.
+   */
+  onDetach(callback: DebuggerDetachCallback): () => void;
+
+  /**
+   * Decrement the shared session's refcount; the underlying tab is detached
+   * when the count reaches zero. Idempotent (a second call is a no-op) and
+   * NEVER throws.
+   */
+  release(): Promise<void>;
+}
+
+/**
+ * Owns the shared per-tab debugger attachments.
+ */
+export interface DebuggerSessionRegistry {
+  /**
+   * Attach to the tab if not already attached (idempotent, serialized per tab),
+   * and increment the refcount. Returns a handle scoped to this acquisition.
+   *
+   * @throws Error with an `ALREADY_ATTACHED:` prefix when a foreign debugger
+   *   (e.g. DevTools) holds the tab.
+   */
+  acquire(tabId: number): Promise<DebuggerHandle>;
+
+  /**
+   * Tear down the shared session immediately, ignoring refcounts and detach
+   * errors: clears registry state first, then detaches. Outstanding handles'
+   * `release()` calls become no-ops. Used on CDP-command timeouts and onDetach
+   * reconciliation.
+   */
+  forceDetach(tabId: number): Promise<void>;
+
+  /** Whether a shared session currently exists for the tab. */
+  isAttached(tabId: number): boolean;
+}

--- a/src/core/tools/browser/DebuggerSessionRegistry.ts
+++ b/src/core/tools/browser/DebuggerSessionRegistry.ts
@@ -34,6 +34,32 @@ import type { DebuggerClient } from './DebuggerClient';
 export type DebuggerDetachCallback = (reason: string) => void;
 
 /**
+ * Thrown when a single CDP command does not resolve within its timeout. The
+ * registry force-detaches the (presumed wedged) tab before rethrowing, so the
+ * next `acquire` re-attaches cleanly.
+ */
+export class CdpCommandTimeoutError extends Error {
+  constructor(
+    public readonly method: string,
+    public readonly timeoutMs: number
+  ) {
+    super(`CDP_COMMAND_TIMEOUT: '${method}' did not resolve within ${timeoutMs}ms`);
+    this.name = 'CdpCommandTimeoutError';
+  }
+}
+
+/** Options for a single CDP command sent through a {@link DebuggerHandle}. */
+export interface SendCommandOptions {
+  /**
+   * Override the per-command timeout (ms). Defaults to a per-method budget:
+   * a short default for interactive commands, a longer one for snapshot-heavy
+   * commands (`DOM.getDocument`, `Accessibility.getFullAXTree`,
+   * `DOMSnapshot.captureSnapshot`, `Page.captureScreenshot`).
+   */
+  timeoutMs?: number;
+}
+
+/**
  * A refcounted handle to a shared per-tab debugger session.
  *
  * Extends {@link DebuggerClient} so existing consumers that already program
@@ -44,6 +70,17 @@ export type DebuggerDetachCallback = (reason: string) => void;
 export interface DebuggerHandle extends DebuggerClient {
   /** The tab this handle is bound to. */
   readonly tabId: number;
+
+  /**
+   * Send a CDP command, raced against a per-command timeout. On timeout the
+   * registry force-detaches the tab and throws {@link CdpCommandTimeoutError}.
+   * Widens {@link DebuggerClient.sendCommand} with an optional `opts`.
+   */
+  sendCommand<T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    opts?: SendCommandOptions
+  ): Promise<T>;
 
   /**
    * Subscribe to external/forced detach of the shared session. The callback

--- a/src/core/utils/__tests__/withTimeout.test.ts
+++ b/src/core/utils/__tests__/withTimeout.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { withTimeout, TimeoutError } from '../withTimeout';
+
+const slow = <T>(value: T, ms: number) => new Promise<T>((r) => setTimeout(() => r(value), ms));
+
+describe('withTimeout', () => {
+  it('resolves with the promise value when it wins', async () => {
+    await expect(withTimeout(slow('ok', 1), 50)).resolves.toBe('ok');
+  });
+
+  it('rejects with TimeoutError when no fallback and the promise is too slow', async () => {
+    await expect(withTimeout(slow('late', 50), 5)).rejects.toBeInstanceOf(TimeoutError);
+  });
+
+  it('resolves to the fallback on timeout when provided', async () => {
+    await expect(withTimeout(slow('late', 50), 5, { fallback: 'fb' })).resolves.toBe('fb');
+  });
+
+  it('propagates rejection from the underlying promise', async () => {
+    await expect(withTimeout(Promise.reject(new Error('boom')), 50)).rejects.toThrow('boom');
+  });
+});

--- a/src/core/utils/withTimeout.ts
+++ b/src/core/utils/withTimeout.ts
@@ -1,0 +1,43 @@
+/**
+ * withTimeout — race a promise against a timeout.
+ *
+ * Shared helper replacing the ad-hoc `setTimeout`/`Promise.race` patterns
+ * scattered across services (design §3.10). The timer is always cleared so it
+ * can't fire after the promise settles.
+ *
+ * - With a `fallback`, resolves to it on timeout.
+ * - Without one, rejects with a `TimeoutError` on timeout.
+ *
+ * @module core/utils/withTimeout
+ */
+
+export class TimeoutError extends Error {
+  constructor(public readonly timeoutMs: number, label?: string) {
+    super(`TIMEOUT: ${label ?? 'operation'} did not complete within ${timeoutMs}ms`);
+    this.name = 'TimeoutError';
+  }
+}
+
+export function withTimeout<T>(promise: Promise<T>, ms: number, label?: string): Promise<T>;
+export function withTimeout<T, F>(promise: Promise<T>, ms: number, options: { fallback: F; label?: string }): Promise<T | F>;
+export function withTimeout<T, F>(
+  promise: Promise<T>,
+  ms: number,
+  labelOrOptions?: string | { fallback: F; label?: string }
+): Promise<T | F> {
+  const hasFallback = typeof labelOrOptions === 'object' && labelOrOptions !== null && 'fallback' in labelOrOptions;
+  const label = typeof labelOrOptions === 'string' ? labelOrOptions : labelOrOptions?.label;
+
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<T | F>((resolve, reject) => {
+    timer = setTimeout(() => {
+      if (hasFallback) {
+        resolve((labelOrOptions as { fallback: F }).fallback);
+      } else {
+        reject(new TimeoutError(ms, label));
+      }
+    }, ms);
+  });
+
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}

--- a/src/extension/background/DownloadWatcher.ts
+++ b/src/extension/background/DownloadWatcher.ts
@@ -1,0 +1,80 @@
+/**
+ * DownloadWatcher — surface browser downloads to the agent.
+ *
+ * Tracks `chrome.downloads.onCreated/onChanged` into a small state machine and
+ * emits `started/completed/interrupted` events (with filename + url) so an agent
+ * that clicks "Export CSV" can learn whether/where the file landed. Active only
+ * while browser control is active (start/stop), per design §3.9.
+ *
+ * Events are delivered via the injected `emit` callback; the service worker
+ * connects this to the session event bus (Session.emitEvent — §1.6 #9), NOT to
+ * a per-tool-call onProgress which is gone by the time a download completes.
+ *
+ * @module extension/background/DownloadWatcher
+ */
+
+export type DownloadStatus = 'started' | 'completed' | 'interrupted';
+
+export interface DownloadEvent {
+  id: number;
+  filename: string;
+  url: string;
+  status: DownloadStatus;
+}
+
+export class DownloadWatcher {
+  private readonly tracked = new Map<number, { filename: string; url: string }>();
+  private active = false;
+  private readonly onCreatedBound = (item: chrome.downloads.DownloadItem) => this.onCreated(item);
+  private readonly onChangedBound = (delta: chrome.downloads.DownloadDelta) => this.onChanged(delta);
+
+  constructor(private readonly emit: (event: DownloadEvent) => void) {}
+
+  start(): void {
+    if (this.active) return;
+    this.active = true;
+    chrome.downloads?.onCreated.addListener(this.onCreatedBound);
+    chrome.downloads?.onChanged.addListener(this.onChangedBound);
+  }
+
+  stop(): void {
+    if (!this.active) return;
+    this.active = false;
+    chrome.downloads?.onCreated.removeListener(this.onCreatedBound);
+    chrome.downloads?.onChanged.removeListener(this.onChangedBound);
+    this.tracked.clear();
+  }
+
+  /** Last-N tracked downloads (for a browser_downloads tool action / tool result). */
+  recent(limit = 10): Array<{ id: number; filename: string; url: string }> {
+    const entries = [...this.tracked.entries()].slice(-limit);
+    return entries.map(([id, v]) => ({ id, ...v }));
+  }
+
+  private onCreated(item: chrome.downloads.DownloadItem): void {
+    if (!this.active) return;
+    const url = item.finalUrl || item.url || '';
+    const filename = item.filename || '';
+    this.tracked.set(item.id, { filename, url });
+    this.emit({ id: item.id, filename, url, status: 'started' });
+  }
+
+  private onChanged(delta: chrome.downloads.DownloadDelta): void {
+    if (!this.active) return;
+    const entry = this.tracked.get(delta.id);
+    if (!entry) return;
+
+    if (delta.filename?.current) {
+      entry.filename = delta.filename.current;
+    }
+
+    const state = delta.state?.current;
+    if (state === 'complete') {
+      this.emit({ id: delta.id, filename: entry.filename, url: entry.url, status: 'completed' });
+      this.tracked.delete(delta.id);
+    } else if (state === 'interrupted') {
+      this.emit({ id: delta.id, filename: entry.filename, url: entry.url, status: 'interrupted' });
+      this.tracked.delete(delta.id);
+    }
+  }
+}

--- a/src/extension/background/__tests__/DownloadWatcher.test.ts
+++ b/src/extension/background/__tests__/DownloadWatcher.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DownloadWatcher, type DownloadEvent } from '../DownloadWatcher';
+
+function installDownloadsMock() {
+  const created: Array<(i: any) => void> = [];
+  const changed: Array<(d: any) => void> = [];
+  (globalThis as any).chrome = {
+    ...(globalThis as any).chrome,
+    downloads: {
+      onCreated: {
+        addListener: (cb: any) => created.push(cb),
+        removeListener: (cb: any) => {
+          const i = created.indexOf(cb);
+          if (i !== -1) created.splice(i, 1);
+        },
+      },
+      onChanged: {
+        addListener: (cb: any) => changed.push(cb),
+        removeListener: (cb: any) => {
+          const i = changed.indexOf(cb);
+          if (i !== -1) changed.splice(i, 1);
+        },
+      },
+    },
+  };
+  return {
+    fireCreated: (item: any) => created.forEach((cb) => cb(item)),
+    fireChanged: (delta: any) => changed.forEach((cb) => cb(delta)),
+    listenerCounts: () => ({ created: created.length, changed: changed.length }),
+  };
+}
+
+describe('DownloadWatcher', () => {
+  let env: ReturnType<typeof installDownloadsMock>;
+  let events: DownloadEvent[];
+  let watcher: DownloadWatcher;
+
+  beforeEach(() => {
+    env = installDownloadsMock();
+    events = [];
+    watcher = new DownloadWatcher((e) => events.push(e));
+  });
+
+  it('emits started on creation and completed on state change', () => {
+    watcher.start();
+    env.fireCreated({ id: 1, filename: 'report.csv', url: 'https://x/r.csv', finalUrl: 'https://x/r.csv' });
+    env.fireChanged({ id: 1, state: { previous: 'in_progress', current: 'complete' } });
+
+    expect(events).toEqual([
+      { id: 1, filename: 'report.csv', url: 'https://x/r.csv', status: 'started' },
+      { id: 1, filename: 'report.csv', url: 'https://x/r.csv', status: 'completed' },
+    ]);
+  });
+
+  it('tracks filename updates and emits interrupted', () => {
+    watcher.start();
+    env.fireCreated({ id: 2, filename: '', url: 'https://x/f' });
+    env.fireChanged({ id: 2, filename: { current: '/downloads/final.pdf' } });
+    env.fireChanged({ id: 2, state: { current: 'interrupted' } });
+
+    expect(events[events.length - 1]).toEqual({
+      id: 2,
+      filename: '/downloads/final.pdf',
+      url: 'https://x/f',
+      status: 'interrupted',
+    });
+  });
+
+  it('ignores events when stopped and removes listeners', () => {
+    watcher.start();
+    expect(env.listenerCounts()).toEqual({ created: 1, changed: 1 });
+    watcher.stop();
+    expect(env.listenerCounts()).toEqual({ created: 0, changed: 0 });
+    env.fireCreated({ id: 3, filename: 'x', url: 'y' });
+    expect(events).toHaveLength(0);
+  });
+
+  it('ignores onChanged for an untracked download', () => {
+    watcher.start();
+    env.fireChanged({ id: 99, state: { current: 'complete' } });
+    expect(events).toHaveLength(0);
+  });
+});

--- a/src/extension/background/__tests__/ensureContentScript.test.ts
+++ b/src/extension/background/__tests__/ensureContentScript.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ensureContentScript, __resetEnsureContentScriptForTests } from '../ensureContentScript';
+
+describe('ensureContentScript', () => {
+  let sendMessage: ReturnType<typeof vi.fn>;
+  let executeScript: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    __resetEnsureContentScriptForTests();
+    sendMessage = vi.fn();
+    executeScript = vi.fn().mockResolvedValue([{ result: true }]);
+    (globalThis as any).chrome = {
+      ...(globalThis as any).chrome,
+      tabs: { sendMessage },
+      scripting: { executeScript },
+    };
+  });
+
+  it('returns true without injecting when the ping succeeds', async () => {
+    sendMessage.mockResolvedValue({ pong: true });
+    const ok = await ensureContentScript(1);
+    expect(ok).toBe(true);
+    expect(executeScript).not.toHaveBeenCalled();
+  });
+
+  it('injects then re-pings when the first ping fails', async () => {
+    // First ping rejects (no listener); after inject, ping succeeds.
+    sendMessage.mockRejectedValueOnce(new Error('no receiver')).mockResolvedValueOnce({ pong: true });
+    const ok = await ensureContentScript(2);
+    expect(ok).toBe(true);
+    expect(executeScript).toHaveBeenCalledWith({
+      target: { tabId: 2 },
+      files: ['content.js'],
+      injectImmediately: true,
+    });
+  });
+
+  it('dedupes concurrent injections for the same tab', async () => {
+    sendMessage.mockRejectedValueOnce(new Error('no receiver')) // ping A
+      .mockRejectedValueOnce(new Error('no receiver')) // ping B (both miss before inject)
+      .mockResolvedValue({ pong: true }); // re-pings after inject
+    const [a, b] = await Promise.all([ensureContentScript(3), ensureContentScript(3)]);
+    expect(a).toBe(true);
+    expect(b).toBe(true);
+    // Only one injection despite two concurrent callers.
+    expect(executeScript).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false when injection fails', async () => {
+    sendMessage.mockRejectedValue(new Error('no receiver'));
+    executeScript.mockRejectedValue(new Error('cannot access'));
+    const ok = await ensureContentScript(4);
+    expect(ok).toBe(false);
+  });
+});

--- a/src/extension/background/__tests__/extensionLifecycle.test.ts
+++ b/src/extension/background/__tests__/extensionLifecycle.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getExtensionInstanceId, DeferredReload } from '../extensionLifecycle';
+
+describe('getExtensionInstanceId', () => {
+  let store: Record<string, unknown>;
+
+  beforeEach(() => {
+    store = {};
+    (globalThis as any).chrome = {
+      ...(globalThis as any).chrome,
+      storage: {
+        local: {
+          get: vi.fn(async (key: string) => (key in store ? { [key]: store[key] } : {})),
+          set: vi.fn(async (obj: Record<string, unknown>) => {
+            Object.assign(store, obj);
+          }),
+        },
+      },
+    };
+  });
+
+  it('generates and persists a UUID on first call', async () => {
+    const id = await getExtensionInstanceId();
+    expect(id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(store['workx:extension_instance_id']).toBe(id);
+  });
+
+  it('returns the persisted UUID on subsequent calls', async () => {
+    store['workx:extension_instance_id'] = 'existing';
+    expect(await getExtensionInstanceId()).toBe('existing');
+  });
+});
+
+describe('DeferredReload', () => {
+  let updateListener: (() => void) | null;
+
+  beforeEach(() => {
+    updateListener = null;
+    (globalThis as any).chrome = {
+      ...(globalThis as any).chrome,
+      runtime: {
+        onUpdateAvailable: { addListener: (cb: () => void) => (updateListener = cb) },
+      },
+    };
+  });
+
+  it('defers reload while a session is active, then reloads when it ends', () => {
+    let active = true;
+    const reload = vi.fn();
+    const dr = new DeferredReload(() => active, reload);
+    dr.register();
+
+    updateListener?.(); // update arrives mid-session
+    expect(reload).not.toHaveBeenCalled();
+
+    active = false;
+    dr.onSessionEnded();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads immediately when idle at update time', () => {
+    const reload = vi.fn();
+    const dr = new DeferredReload(() => false, reload);
+    dr.register();
+    updateListener?.();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when no update is pending', () => {
+    const reload = vi.fn();
+    const dr = new DeferredReload(() => false, reload);
+    dr.register();
+    dr.onSessionEnded();
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/src/extension/background/ensureContentScript.ts
+++ b/src/extension/background/ensureContentScript.ts
@@ -1,0 +1,67 @@
+/**
+ * ensureContentScript — make sure the content script is live in a tab.
+ *
+ * Ping-or-inject (design §3.5): ping the tab; on no reply, programmatically
+ * inject `content.js` (`injectImmediately`, isolated world — not subject to page
+ * CSP) and re-ping. Concurrent calls for the same tab are deduped. Re-injecting
+ * a tab that already has the script is harmless — the content script guards with
+ * `window.__workx_content_script_loaded__`.
+ *
+ * Fixes the silent no-op when visual effects target a tab whose content script
+ * never loaded (CSP at document_start, tabs open before install, file://).
+ *
+ * @module extension/background/ensureContentScript
+ */
+
+const PING_TIMEOUT_MS = 300;
+const inflight = new Map<number, Promise<boolean>>();
+
+async function withTimeout<T>(p: Promise<T>, ms: number): Promise<T | undefined> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<undefined>((resolve) => {
+    timer = setTimeout(() => resolve(undefined), ms);
+  });
+  return Promise.race([p, timeout]).finally(() => clearTimeout(timer));
+}
+
+async function ping(tabId: number): Promise<boolean> {
+  try {
+    const res = await withTimeout(
+      chrome.tabs.sendMessage(tabId, { type: 'WORKX_PING' }) as Promise<unknown>,
+      PING_TIMEOUT_MS
+    );
+    return res != null;
+  } catch {
+    return false;
+  }
+}
+
+async function inject(tabId: number): Promise<boolean> {
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      files: ['content.js'],
+      injectImmediately: true,
+    });
+  } catch (error) {
+    console.warn(`[ensureContentScript] inject failed for tab ${tabId}:`, error);
+    return false;
+  }
+  return ping(tabId);
+}
+
+export async function ensureContentScript(tabId: number): Promise<boolean> {
+  if (await ping(tabId)) return true;
+
+  let pending = inflight.get(tabId);
+  if (!pending) {
+    pending = inject(tabId).finally(() => inflight.delete(tabId));
+    inflight.set(tabId, pending);
+  }
+  return pending;
+}
+
+/** Test-only: clear the in-flight dedupe map. */
+export function __resetEnsureContentScriptForTests(): void {
+  inflight.clear();
+}

--- a/src/extension/background/extensionLifecycle.ts
+++ b/src/extension/background/extensionLifecycle.ts
@@ -1,0 +1,54 @@
+/**
+ * Extension lifecycle hardening (design §3.10).
+ *
+ * - `getExtensionInstanceId` (T28): a stable per-install UUID for telemetry /
+ *   disambiguating multiple Chrome profiles.
+ * - `DeferredReload` (T27): when an extension update is pending, defer
+ *   `chrome.runtime.reload()` until no agent session is active, so an in-flight
+ *   turn isn't killed by a restart.
+ *
+ * @module extension/background/extensionLifecycle
+ */
+
+const INSTANCE_ID_KEY = 'workx:extension_instance_id';
+
+export async function getExtensionInstanceId(): Promise<string> {
+  const stored = await chrome.storage.local.get(INSTANCE_ID_KEY);
+  const existing = stored[INSTANCE_ID_KEY] as string | undefined;
+  if (existing) return existing;
+  const id = crypto.randomUUID();
+  await chrome.storage.local.set({ [INSTANCE_ID_KEY]: id });
+  return id;
+}
+
+/**
+ * Defers reload-on-update until a predicate reports no active session. Wire
+ * `register()` to `chrome.runtime.onUpdateAvailable`, and call `onSessionEnded()`
+ * whenever a session finishes so a pending reload can fire.
+ */
+export class DeferredReload {
+  private pending = false;
+
+  constructor(
+    private readonly isSessionActive: () => boolean,
+    private readonly reload: () => void = () => chrome.runtime.reload()
+  ) {}
+
+  register(): void {
+    chrome.runtime?.onUpdateAvailable?.addListener(() => {
+      this.pending = true;
+      this.maybeReload();
+    });
+  }
+
+  /** Call when a session ends; reloads now if an update is pending and idle. */
+  onSessionEnded(): void {
+    this.maybeReload();
+  }
+
+  private maybeReload(): void {
+    if (this.pending && !this.isSessionActive()) {
+      this.reload();
+    }
+  }
+}

--- a/src/extension/background/service-worker.ts
+++ b/src/extension/background/service-worker.ts
@@ -1814,6 +1814,8 @@ async function performRolloutCleanup(): Promise<void> {
  */
 chrome.runtime.onStartup.addListener(() => {
   initialize();
+  // Drop tab leases whose tab no longer exists (orphans from a prior session).
+  void import('../tools/browser/tabLeaseStore').then(({ gcStaleTabLeases }) => gcStaleTabLeases());
 });
 
 /**

--- a/src/extension/background/service-worker.ts
+++ b/src/extension/background/service-worker.ts
@@ -1815,7 +1815,9 @@ async function performRolloutCleanup(): Promise<void> {
 chrome.runtime.onStartup.addListener(() => {
   initialize();
   // Drop tab leases whose tab no longer exists (orphans from a prior session).
-  void import('../tools/browser/tabLeaseStore').then(({ gcStaleTabLeases }) => gcStaleTabLeases());
+  void import('../tools/browser/tabLeaseStore')
+    .then(({ gcStaleTabLeases }) => gcStaleTabLeases())
+    .catch(() => {});
 });
 
 /**

--- a/src/extension/content/content-script.ts
+++ b/src/extension/content/content-script.ts
@@ -19,6 +19,7 @@ console.log(`[WorkX] Content script loading - Instance ID: ${INSTANCE_ID}, Frame
 
 let visualEffectController: any = null;
 let visualEffectShadowHost: HTMLElement | null = null;
+let visualEffectObserver: MutationObserver | null = null;
 
 interface PageContext {
 	url: string;
@@ -125,6 +126,19 @@ function initializeVisualEffects(): void {
 		// Append to document body
 		document.body.appendChild(visualEffectShadowHost);
 
+		// Self-heal: some SPAs prune unknown nodes on hydration, permanently
+		// removing our overlay. Re-mount the host if the page disconnects it.
+		// Guard re-entrancy — the re-append is itself a childList mutation — by
+		// disconnecting the observer around the re-append.
+		visualEffectObserver = new MutationObserver(() => {
+			if (visualEffectShadowHost && !visualEffectShadowHost.isConnected && document.body) {
+				visualEffectObserver?.disconnect();
+				document.body.appendChild(visualEffectShadowHost);
+				visualEffectObserver?.observe(document.body, { childList: true });
+			}
+		});
+		visualEffectObserver.observe(document.body, { childList: true });
+
 		console.log(`[WorkX] Instance ${INSTANCE_ID} - Visual effects initialized successfully`);
 
 		// Log all cursors in the DOM for debugging
@@ -179,6 +193,10 @@ window.addEventListener('pagehide', () => {
 		unmount(visualEffectController);
 		visualEffectController = null;
 		console.log(`[WorkX] Instance ${INSTANCE_ID} - Visual effects destroyed`);
+	}
+	if (visualEffectObserver) {
+		visualEffectObserver.disconnect();
+		visualEffectObserver = null;
 	}
 	if (visualEffectShadowHost && visualEffectShadowHost.parentNode) {
 		visualEffectShadowHost.parentNode.removeChild(visualEffectShadowHost);

--- a/src/extension/content/content-script.ts
+++ b/src/extension/content/content-script.ts
@@ -21,6 +21,20 @@ let visualEffectController: any = null;
 let visualEffectShadowHost: HTMLElement | null = null;
 let visualEffectObserver: MutationObserver | null = null;
 
+// Respond to readiness pings from the background's ping-or-inject
+// (ensureContentScript). Registered at module scope so it answers even for a
+// duplicate instance whose initialize() returns early. Without this, the ping
+// always fails and the background re-injects on every call.
+if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
+	chrome.runtime.onMessage.addListener((msg: any, _sender, sendResponse) => {
+		if (msg?.type === 'WORKX_PING') {
+			sendResponse({ pong: true, instanceId: INSTANCE_ID });
+			return true;
+		}
+		return undefined;
+	});
+}
+
 interface PageContext {
 	url: string;
 	title: string;

--- a/src/extension/platform/ExtensionPlatformAdapter.ts
+++ b/src/extension/platform/ExtensionPlatformAdapter.ts
@@ -51,6 +51,20 @@ export class ExtensionPlatformAdapter implements IPlatformAdapter {
     }
   }
 
+  async claimTabLease(tabId: number, sessionId: string, origin: 'agent' | 'user'): Promise<void> {
+    const { getTabLeaseStore, getLeaseLifecycleQueue } = await import('../tools/browser/tabLeaseStore');
+    await getLeaseLifecycleQueue().run(sessionId, () =>
+      getTabLeaseStore().claim({ tabId, sessionId, origin })
+    );
+  }
+
+  async releaseTabLease(tabId: number, sessionId: string): Promise<void> {
+    const { getTabLeaseStore, getLeaseLifecycleQueue } = await import('../tools/browser/tabLeaseStore');
+    await getLeaseLifecycleQueue().run(sessionId, () =>
+      getTabLeaseStore().release(sessionId, tabId)
+    );
+  }
+
   async validateTab(tabId: number): Promise<TabValidationResult> {
     const validation = await this.tabManager.validateTab(tabId);
 

--- a/src/extension/platform/ExtensionPlatformAdapter.ts
+++ b/src/extension/platform/ExtensionPlatformAdapter.ts
@@ -52,15 +52,17 @@ export class ExtensionPlatformAdapter implements IPlatformAdapter {
   }
 
   async claimTabLease(tabId: number, sessionId: string, origin: 'agent' | 'user'): Promise<void> {
-    const { getTabLeaseStore, getLeaseLifecycleQueue } = await import('../tools/browser/tabLeaseStore');
-    await getLeaseLifecycleQueue().run(sessionId, () =>
+    const { getTabLeaseStore, getLeaseLifecycleQueue, LEASE_QUEUE_KEY } = await import('../tools/browser/tabLeaseStore');
+    // Serialize on a single global key — the store is one shared blob, so a
+    // per-session key would let different sessions' read-modify-writes race.
+    await getLeaseLifecycleQueue().run(LEASE_QUEUE_KEY, () =>
       getTabLeaseStore().claim({ tabId, sessionId, origin })
     );
   }
 
   async releaseTabLease(tabId: number, sessionId: string): Promise<void> {
-    const { getTabLeaseStore, getLeaseLifecycleQueue } = await import('../tools/browser/tabLeaseStore');
-    await getLeaseLifecycleQueue().run(sessionId, () =>
+    const { getTabLeaseStore, getLeaseLifecycleQueue, LEASE_QUEUE_KEY } = await import('../tools/browser/tabLeaseStore');
+    await getLeaseLifecycleQueue().run(LEASE_QUEUE_KEY, () =>
       getTabLeaseStore().release(sessionId, tabId)
     );
   }

--- a/src/extension/tools/DOMTool.ts
+++ b/src/extension/tools/DOMTool.ts
@@ -371,7 +371,10 @@ Snapshots only return elements visible in the current viewport (inViewport: true
 
     // Always use CDP-based implementation (content-script implementation removed)
     const domService = await DomService.forTab(tabId);
-    return await domService.click(nodeId);
+    return await domService.click(nodeId, {
+      button: options?.button,
+      clickCount: options?.clickType === 'double' ? 2 : 1,
+    });
   }
 
   /**

--- a/src/extension/tools/PageVisionTool.ts
+++ b/src/extension/tools/PageVisionTool.ts
@@ -250,9 +250,11 @@ Simply provide coordinates based on visual analysis of the screenshot image.
     tabId: number,
     request: ScreenshotToolRequest
   ): Promise<ScreenshotResponseData> {
+    // Acquire the shared debugger session once for this action; released below.
+    // Acquired inside the try so a forTab failure is still logged.
+    let screenshotService: ScreenshotService | undefined;
     try {
-      // Create screenshot service
-      const screenshotService = await ScreenshotService.forTab(tabId);
+      screenshotService = await ScreenshotService.forTab(tabId);
 
       // Capture screenshot (with or without scroll)
       const { base64Data, viewport } = request.scroll_offset
@@ -272,6 +274,8 @@ Simply provide coordinates based on visual analysis of the screenshot image.
     } catch (error: any) {
       this.log('error', `Screenshot failed: ${error.message}`, { tabId });
       throw error;
+    } finally {
+      await screenshotService?.release();
     }
   }
 
@@ -286,23 +290,27 @@ Simply provide coordinates based on visual analysis of the screenshot image.
       throw new Error('VALIDATION_ERROR: coordinates required for click action');
     }
 
-    // Validate coordinates
-    await this.validateCoordinates(tabId, request.coordinates);
-
-    // Create coordinate action service
+    // Acquire the shared debugger session once for this action. Acquired before
+    // validateCoordinates so the tab stays attached for the whole sequence.
     const actionService = await CoordinateActionService.forTab(tabId);
+    try {
+      // Validate coordinates
+      await this.validateCoordinates(tabId, request.coordinates);
 
-    // Execute click
-    await actionService.clickAt(request.coordinates, {
-      button: request.options?.button,
-      modifiers: request.options?.modifiers,
-      waitAfter: request.options?.wait_after_action || 100,
-    });
+      // Execute click
+      await actionService.clickAt(request.coordinates, {
+        button: request.options?.button,
+        modifiers: request.options?.modifiers,
+        waitAfter: request.options?.wait_after_action || 100,
+      });
 
-    return {
-      coordinates_used: request.coordinates,
-      action_timestamp: new Date().toISOString(),
-    };
+      return {
+        coordinates_used: request.coordinates,
+        action_timestamp: new Date().toISOString(),
+      };
+    } finally {
+      await actionService.release();
+    }
   }
 
   /**
@@ -319,21 +327,24 @@ Simply provide coordinates based on visual analysis of the screenshot image.
       throw new Error('VALIDATION_ERROR: text required for type action');
     }
 
-    // Validate coordinates
-    await this.validateCoordinates(tabId, request.coordinates);
-
-    // Create coordinate action service
+    // Acquire once for this action (before validateCoordinates).
     const actionService = await CoordinateActionService.forTab(tabId);
+    try {
+      // Validate coordinates
+      await this.validateCoordinates(tabId, request.coordinates);
 
-    // Execute type
-    await actionService.typeAt(request.coordinates, request.text, {
-      waitAfter: request.options?.wait_after_action || 100,
-    });
+      // Execute type
+      await actionService.typeAt(request.coordinates, request.text, {
+        waitAfter: request.options?.wait_after_action || 100,
+      });
 
-    return {
-      coordinates_used: request.coordinates,
-      action_timestamp: new Date().toISOString(),
-    };
+      return {
+        coordinates_used: request.coordinates,
+        action_timestamp: new Date().toISOString(),
+      };
+    } finally {
+      await actionService.release();
+    }
   }
 
   /**
@@ -347,18 +358,21 @@ Simply provide coordinates based on visual analysis of the screenshot image.
       throw new Error('VALIDATION_ERROR: coordinates required for scroll action');
     }
 
-    // Create coordinate action service
+    // Acquire once for this action.
     const actionService = await CoordinateActionService.forTab(tabId);
+    try {
+      // Execute scroll
+      await actionService.scrollTo(request.coordinates, {
+        waitAfter: request.options?.wait_after_action || 200,
+      });
 
-    // Execute scroll
-    await actionService.scrollTo(request.coordinates, {
-      waitAfter: request.options?.wait_after_action || 200,
-    });
-
-    return {
-      coordinates_used: request.coordinates,
-      action_timestamp: new Date().toISOString(),
-    };
+      return {
+        coordinates_used: request.coordinates,
+        action_timestamp: new Date().toISOString(),
+      };
+    } finally {
+      await actionService.release();
+    }
   }
 
   /**
@@ -372,18 +386,21 @@ Simply provide coordinates based on visual analysis of the screenshot image.
       throw new Error('VALIDATION_ERROR: key required for keypress action');
     }
 
-    // Create coordinate action service
+    // Acquire once for this action.
     const actionService = await CoordinateActionService.forTab(tabId);
+    try {
+      // Execute keypress
+      await actionService.keypressAt(request.key, {
+        modifiers: request.options?.modifiers,
+        waitAfter: request.options?.wait_after_action || 100,
+      });
 
-    // Execute keypress
-    await actionService.keypressAt(request.key, {
-      modifiers: request.options?.modifiers,
-      waitAfter: request.options?.wait_after_action || 100,
-    });
-
-    return {
-      action_timestamp: new Date().toISOString(),
-    };
+      return {
+        action_timestamp: new Date().toISOString(),
+      };
+    } finally {
+      await actionService.release();
+    }
   }
 
   /**

--- a/src/extension/tools/PageVisionTool.ts
+++ b/src/extension/tools/PageVisionTool.ts
@@ -295,7 +295,7 @@ Simply provide coordinates based on visual analysis of the screenshot image.
     const actionService = await CoordinateActionService.forTab(tabId);
     try {
       // Validate coordinates
-      await this.validateCoordinates(tabId, request.coordinates);
+      await this.validateCoordinates(actionService, request.coordinates);
 
       // Execute click
       await actionService.clickAt(request.coordinates, {
@@ -331,7 +331,7 @@ Simply provide coordinates based on visual analysis of the screenshot image.
     const actionService = await CoordinateActionService.forTab(tabId);
     try {
       // Validate coordinates
-      await this.validateCoordinates(tabId, request.coordinates);
+      await this.validateCoordinates(actionService, request.coordinates);
 
       // Execute type
       await actionService.typeAt(request.coordinates, request.text, {
@@ -417,20 +417,16 @@ Simply provide coordinates based on visual analysis of the screenshot image.
    * @returns Clipped coordinates guaranteed to be within viewport bounds
    */
   private async validateCoordinates(
-    tabId: number,
+    actionService: CoordinateActionService,
     coordinates: { x: number; y: number }
   ): Promise<{ x: number; y: number; clipped: boolean }> {
-    // Get viewport bounds via CDP
-    const result = await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
-      expression: '({ width: window.innerWidth, height: window.innerHeight })',
-      returnByValue: true
-    }) as { result?: { value: { width: number; height: number } } };
+    // Get viewport bounds via the acquired shared session (not a raw
+    // chrome.debugger call), so this stays coordinated with the registry.
+    const viewport = await actionService.getViewportSize();
 
-    if (!result?.result?.value) {
+    if (!viewport || typeof viewport.width !== 'number' || typeof viewport.height !== 'number') {
       throw new Error('INVALID_COORDINATES: Failed to get viewport bounds');
     }
-
-    const viewport = result.result.value;
 
     // Calculate valid bounds (0 to width-1, 0 to height-1)
     const maxX = viewport.width - 1;

--- a/src/extension/tools/ViewportTool.ts
+++ b/src/extension/tools/ViewportTool.ts
@@ -27,7 +27,12 @@ interface ViewportToolRequest extends BaseToolRequest {
 }
 
 /** Handles held per tab while an override is active (module-scoped state). */
-const activeOverrides = new Map<number, DebuggerHandle>();
+interface ActiveOverride {
+  handle: DebuggerHandle;
+  /** Unsubscribe from the session's detach notification. */
+  unsub: () => void;
+}
+const activeOverrides = new Map<number, ActiveOverride>();
 
 export class ViewportTool extends BaseTool {
   protected toolDefinition: ToolDefinition = createToolDefinition(
@@ -83,30 +88,43 @@ export class ViewportTool extends BaseTool {
   private async set(tabId: number, request: ViewportToolRequest): Promise<unknown> {
     // Reuse a held handle for this tab, or acquire one and keep it so the
     // override survives subsequent tool calls until reset.
-    const handle = activeOverrides.get(tabId) ?? (await getDebuggerSessionRegistry().acquire(tabId));
+    let entry = activeOverrides.get(tabId);
+    const freshlyAcquired = !entry;
+    if (!entry) {
+      const handle = await getDebuggerSessionRegistry().acquire(tabId);
+      // Clean up if the session detaches externally (tab closed, infobar closed,
+      // force-detach) so we don't leak a dead handle or a stuck override entry.
+      const unsub = handle.onDetach(() => {
+        activeOverrides.delete(tabId);
+      });
+      entry = { handle, unsub };
+    }
     try {
-      const service = new ViewportOverrideService((method, params) => handle.sendCommand(method, params));
+      const service = new ViewportOverrideService((method, params) => entry!.handle.sendCommand(method, params));
       const applied = await service.setOverride({ width: request.width, height: request.height });
-      activeOverrides.set(tabId, handle);
+      activeOverrides.set(tabId, entry);
       return { action: 'set', applied };
     } catch (error) {
-      // On failure, don't leak the handle if we just acquired it.
-      if (!activeOverrides.has(tabId)) {
-        await handle.release();
+      // On failure, don't leak a freshly-acquired handle.
+      if (freshlyAcquired) {
+        entry.unsub();
+        activeOverrides.delete(tabId);
+        await entry.handle.release();
       }
       throw error;
     }
   }
 
   private async reset(tabId: number): Promise<unknown> {
-    const handle = activeOverrides.get(tabId);
-    if (!handle) {
+    const entry = activeOverrides.get(tabId);
+    if (!entry) {
       return { action: 'reset', wasActive: false };
     }
     activeOverrides.delete(tabId);
-    const service = new ViewportOverrideService((method, params) => handle.sendCommand(method, params));
+    entry.unsub();
+    const service = new ViewportOverrideService((method, params) => entry.handle.sendCommand(method, params));
     await service.clearOverride();
-    await handle.release();
+    await entry.handle.release();
     return { action: 'reset', wasActive: true };
   }
 }

--- a/src/extension/tools/ViewportTool.ts
+++ b/src/extension/tools/ViewportTool.ts
@@ -1,0 +1,117 @@
+/**
+ * ViewportTool (browser_viewport) — set/reset a deterministic viewport.
+ *
+ * Lets the agent pin a viewport size (for responsive/breakpoint testing) with
+ * `deviceScaleFactor: 1`. While an override is active the tab is kept attached
+ * (a registry handle is held) because detaching the debugger clears emulation;
+ * `reset` clears the override and releases the handle.
+ *
+ * @module extension/tools/ViewportTool
+ */
+
+import {
+  BaseTool,
+  createToolDefinition,
+  type BaseToolRequest,
+  type BaseToolOptions,
+  type ToolDefinition,
+} from '../../tools/BaseTool';
+import { getDebuggerSessionRegistry } from './browser/ChromeDebuggerSessionRegistry';
+import { ViewportOverrideService } from './browser/ViewportOverrideService';
+import type { DebuggerHandle } from '@/core/tools/browser/DebuggerSessionRegistry';
+
+interface ViewportToolRequest extends BaseToolRequest {
+  action: 'set' | 'reset';
+  width?: number;
+  height?: number;
+}
+
+/** Handles held per tab while an override is active (module-scoped state). */
+const activeOverrides = new Map<number, DebuggerHandle>();
+
+export class ViewportTool extends BaseTool {
+  protected toolDefinition: ToolDefinition = createToolDefinition(
+    'browser_viewport',
+    `Set or reset a deterministic browser viewport (with deviceScaleFactor: 1) for responsive/breakpoint testing.
+
+## ACTIONS
+- **set**: Apply a viewport of {width}x{height} CSS pixels. If width/height are omitted, pins the tab's current size (useful before screenshots so image pixels == CSS pixels). Example: set 375x667 for a mobile layout.
+- **reset**: Clear the override and restore the browser's normal viewport.
+
+## IMPORTANT
+- Always **reset** the override before finishing your task — a left-over override resizes the page the user sees.`,
+    {
+      action: {
+        type: 'string',
+        description: 'set (apply a viewport override) or reset (clear it)',
+        enum: ['set', 'reset'],
+      },
+      width: { type: 'number', description: 'Viewport width in CSS pixels (for set)' },
+      height: { type: 'number', description: 'Viewport height in CSS pixels (for set)' },
+    },
+    {
+      required: ['action'],
+      category: 'browser',
+      version: '1.0.0',
+      metadata: {
+        capabilities: ['viewport_override'],
+        permissions: ['activeTab', 'debugger'],
+        platforms: ['extension'],
+      },
+    }
+  );
+
+  constructor() {
+    super();
+  }
+
+  protected async executeImpl(request: BaseToolRequest, options?: BaseToolOptions): Promise<unknown> {
+    const typedRequest = request as ViewportToolRequest;
+    this.validateChromeContext();
+
+    const tabId = options?.metadata?.tabId;
+    if (tabId === undefined || tabId === null || tabId === -1) {
+      throw new Error('Target tab cannot be found. Please ensure a tab is bound to the current session.');
+    }
+
+    if (typedRequest.action === 'reset') {
+      return await this.reset(tabId);
+    }
+    return await this.set(tabId, typedRequest);
+  }
+
+  private async set(tabId: number, request: ViewportToolRequest): Promise<unknown> {
+    // Reuse a held handle for this tab, or acquire one and keep it so the
+    // override survives subsequent tool calls until reset.
+    const handle = activeOverrides.get(tabId) ?? (await getDebuggerSessionRegistry().acquire(tabId));
+    try {
+      const service = new ViewportOverrideService((method, params) => handle.sendCommand(method, params));
+      const applied = await service.setOverride({ width: request.width, height: request.height });
+      activeOverrides.set(tabId, handle);
+      return { action: 'set', applied };
+    } catch (error) {
+      // On failure, don't leak the handle if we just acquired it.
+      if (!activeOverrides.has(tabId)) {
+        await handle.release();
+      }
+      throw error;
+    }
+  }
+
+  private async reset(tabId: number): Promise<unknown> {
+    const handle = activeOverrides.get(tabId);
+    if (!handle) {
+      return { action: 'reset', wasActive: false };
+    }
+    activeOverrides.delete(tabId);
+    const service = new ViewportOverrideService((method, params) => handle.sendCommand(method, params));
+    await service.clearOverride();
+    await handle.release();
+    return { action: 'reset', wasActive: true };
+  }
+}
+
+/** Test-only: drop held override handles. */
+export function __resetViewportOverridesForTests(): void {
+  activeOverrides.clear();
+}

--- a/src/extension/tools/__tests__/DOMTool.test.ts
+++ b/src/extension/tools/__tests__/DOMTool.test.ts
@@ -475,7 +475,10 @@ describe('DOMTool', () => {
         withTab(1)
       );
       expect(result.success).toBe(true);
-      expect(mockDomServiceInstance.click).toHaveBeenCalledWith('0:42');
+      expect(mockDomServiceInstance.click).toHaveBeenCalledWith(
+        '0:42',
+        expect.objectContaining({ clickCount: 1 })
+      );
     });
 
     it('should route type to DomService.type with node_id, text, and options', async () => {

--- a/src/extension/tools/__tests__/PageVisionTool.test.ts
+++ b/src/extension/tools/__tests__/PageVisionTool.test.ts
@@ -110,6 +110,7 @@ function setupScreenshotMocks(
   mocks.screenshotServiceForTab.mockResolvedValue({
     captureViewport: mocks.screenshotServiceCaptureViewport,
     captureWithScroll: mocks.screenshotServiceCaptureWithScroll,
+    release: vi.fn().mockResolvedValue(undefined),
   });
   mocks.screenshotFileManagerSaveScreenshot.mockResolvedValue(undefined);
 }
@@ -125,6 +126,7 @@ function setupCoordinateActionMocks() {
     typeAt: mocks.coordinateActionServiceTypeAt,
     scrollTo: mocks.coordinateActionServiceScrollTo,
     keypressAt: mocks.coordinateActionServiceKeypressAt,
+    release: vi.fn().mockResolvedValue(undefined),
   });
 }
 

--- a/src/extension/tools/__tests__/PageVisionTool.test.ts
+++ b/src/extension/tools/__tests__/PageVisionTool.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => {
     coordinateActionServiceTypeAt: vi.fn(),
     coordinateActionServiceScrollTo: vi.fn(),
     coordinateActionServiceKeypressAt: vi.fn(),
+    coordinateActionServiceGetViewportSize: vi.fn(),
   };
 });
 
@@ -85,7 +86,7 @@ function makeTab(overrides: Partial<chrome.tabs.Tab> = {}): chrome.tabs.Tab {
 /** Default viewport bounds returned by CDP Runtime.evaluate for validateCoordinates */
 const defaultViewport = { width: 1280, height: 720 };
 
-/** Sets up chrome.debugger.sendCommand to return viewport bounds */
+/** Sets up the viewport size used by coordinate validation (now via the service). */
 function setupDebuggerViewport(
   viewport: { width: number; height: number } = defaultViewport
 ) {
@@ -93,6 +94,8 @@ function setupDebuggerViewport(
   c.debugger.sendCommand.mockResolvedValue({
     result: { value: viewport },
   });
+  // validateCoordinates routes through CoordinateActionService.getViewportSize().
+  mocks.coordinateActionServiceGetViewportSize.mockResolvedValue(viewport);
 }
 
 /** Sets up all mocks for a successful screenshot flow */
@@ -121,11 +124,13 @@ function setupCoordinateActionMocks() {
   mocks.coordinateActionServiceTypeAt.mockResolvedValue(undefined);
   mocks.coordinateActionServiceScrollTo.mockResolvedValue(undefined);
   mocks.coordinateActionServiceKeypressAt.mockResolvedValue(undefined);
+  mocks.coordinateActionServiceGetViewportSize.mockResolvedValue({ width: 1280, height: 720 });
   mocks.coordinateActionServiceForTab.mockResolvedValue({
     clickAt: mocks.coordinateActionServiceClickAt,
     typeAt: mocks.coordinateActionServiceTypeAt,
     scrollTo: mocks.coordinateActionServiceScrollTo,
     keypressAt: mocks.coordinateActionServiceKeypressAt,
+    getViewportSize: mocks.coordinateActionServiceGetViewportSize,
     release: vi.fn().mockResolvedValue(undefined),
   });
 }
@@ -598,18 +603,13 @@ describe('PageVisionTool', () => {
       );
     });
 
-    it('should validate coordinates via CDP before clicking', async () => {
+    it('should validate coordinates via the shared session before clicking', async () => {
       await tool.execute(
         { action: 'click', coordinates: { x: 100, y: 200 } },
         withTab(1)
       );
-      expect(chromeMock().debugger.sendCommand).toHaveBeenCalledWith(
-        { tabId: 1 },
-        'Runtime.evaluate',
-        expect.objectContaining({
-          expression: expect.stringContaining('window.innerWidth'),
-        })
-      );
+      // Routes through the acquired service handle, not a raw chrome.debugger call.
+      expect(mocks.coordinateActionServiceGetViewportSize).toHaveBeenCalled();
     });
 
     it('should fail when CoordinateActionService.forTab throws', async () => {
@@ -747,11 +747,7 @@ describe('PageVisionTool', () => {
         { action: 'type', coordinates: { x: 100, y: 200 }, text: 'test' },
         withTab(1)
       );
-      expect(chromeMock().debugger.sendCommand).toHaveBeenCalledWith(
-        { tabId: 1 },
-        'Runtime.evaluate',
-        expect.any(Object)
-      );
+      expect(mocks.coordinateActionServiceGetViewportSize).toHaveBeenCalled();
     });
 
     it('should handle empty string text', async () => {
@@ -1103,7 +1099,7 @@ describe('PageVisionTool', () => {
     });
 
     it('should fail when viewport bounds cannot be retrieved', async () => {
-      chromeMock().debugger.sendCommand.mockResolvedValueOnce({});
+      mocks.coordinateActionServiceGetViewportSize.mockResolvedValueOnce({} as any);
       const result = await tool.execute(
         { action: 'click', coordinates: { x: 100, y: 200 } },
         withTab(1)
@@ -1112,8 +1108,8 @@ describe('PageVisionTool', () => {
       expect(result.error).toContain('Failed to get viewport bounds');
     });
 
-    it('should fail when debugger.sendCommand returns null result', async () => {
-      chromeMock().debugger.sendCommand.mockResolvedValueOnce(null);
+    it('should fail when viewport bounds are null', async () => {
+      mocks.coordinateActionServiceGetViewportSize.mockResolvedValueOnce(null as any);
       const result = await tool.execute(
         { action: 'click', coordinates: { x: 100, y: 200 } },
         withTab(1)
@@ -1122,8 +1118,8 @@ describe('PageVisionTool', () => {
       expect(result.error).toContain('Failed to get viewport bounds');
     });
 
-    it('should fail when debugger.sendCommand throws', async () => {
-      chromeMock().debugger.sendCommand.mockRejectedValueOnce(
+    it('should fail when the viewport lookup throws', async () => {
+      mocks.coordinateActionServiceGetViewportSize.mockRejectedValueOnce(
         new Error('Debugger detached')
       );
       const result = await tool.execute(

--- a/src/extension/tools/__tests__/ViewportTool.test.ts
+++ b/src/extension/tools/__tests__/ViewportTool.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const acquire = vi.fn();
+vi.mock('@/extension/tools/browser/ChromeDebuggerSessionRegistry', () => ({
+  getDebuggerSessionRegistry: () => ({ acquire }),
+}));
+
+import { ViewportTool, __resetViewportOverridesForTests } from '@/extension/tools/ViewportTool';
+
+function fakeHandle() {
+  let detachCb: (() => void) | null = null;
+  const sendCommand = vi.fn(async (method: string) => {
+    if (method === 'Runtime.evaluate') return { result: { value: { width: 1000, height: 800 } } };
+    return {};
+  });
+  const release = vi.fn().mockResolvedValue(undefined);
+  return {
+    sendCommand,
+    release,
+    onDetach: (cb: () => void) => {
+      detachCb = cb;
+      return () => {
+        detachCb = null;
+      };
+    },
+    fireDetach: () => detachCb?.(),
+  };
+}
+
+describe('ViewportTool override lifecycle', () => {
+  beforeEach(() => {
+    __resetViewportOverridesForTests();
+    acquire.mockReset();
+  });
+
+  it('cleans up the held handle when the session detaches externally', async () => {
+    const h1 = fakeHandle();
+    acquire.mockResolvedValueOnce(h1 as any);
+    const tool = new ViewportTool();
+
+    await tool.execute({ action: 'set', width: 375, height: 667 }, { metadata: { tabId: 5 } });
+    expect(acquire).toHaveBeenCalledTimes(1);
+    expect(h1.sendCommand).toHaveBeenCalledWith(
+      'Emulation.setDeviceMetricsOverride',
+      expect.objectContaining({ deviceScaleFactor: 1 })
+    );
+
+    // External detach (tab closed / infobar) → entry cleaned up.
+    h1.fireDetach();
+
+    // A subsequent set must RE-ACQUIRE (entry removed), not reuse the dead handle.
+    const h2 = fakeHandle();
+    acquire.mockResolvedValueOnce(h2 as any);
+    await tool.execute({ action: 'set', width: 400, height: 700 }, { metadata: { tabId: 5 } });
+    expect(acquire).toHaveBeenCalledTimes(2);
+  });
+
+  it('reset clears the override and releases the handle', async () => {
+    const h = fakeHandle();
+    acquire.mockResolvedValueOnce(h as any);
+    const tool = new ViewportTool();
+
+    await tool.execute({ action: 'set' }, { metadata: { tabId: 9 } });
+    await tool.execute({ action: 'reset' }, { metadata: { tabId: 9 } });
+
+    expect(h.sendCommand).toHaveBeenCalledWith('Emulation.clearDeviceMetricsOverride', {});
+    expect(h.release).toHaveBeenCalled();
+
+    // After reset, set re-acquires.
+    const h2 = fakeHandle();
+    acquire.mockResolvedValueOnce(h2 as any);
+    await tool.execute({ action: 'set' }, { metadata: { tabId: 9 } });
+    expect(acquire).toHaveBeenCalledTimes(2);
+  });
+
+  it('reuses the held handle across repeated set calls (no double-acquire)', async () => {
+    const h = fakeHandle();
+    acquire.mockResolvedValueOnce(h as any);
+    const tool = new ViewportTool();
+
+    await tool.execute({ action: 'set', width: 375, height: 667 }, { metadata: { tabId: 7 } });
+    await tool.execute({ action: 'set', width: 414, height: 896 }, { metadata: { tabId: 7 } });
+    expect(acquire).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/extension/tools/browser/ChromeDebuggerClient.ts
+++ b/src/extension/tools/browser/ChromeDebuggerClient.ts
@@ -140,6 +140,41 @@ export class ChromeDebuggerClient implements DebuggerClient {
   }
 
   // ─────────────────────────────────────────────────────────────────────────
+  // OOPIF support (design §3.7) — address commands at a specific CDP target
+  // (cross-origin iframe / worker), not just the tab. Prerequisite for
+  // per-target snapshot reads; previously sendCommand hard-rejected any
+  // non-tabId target.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** Send a CDP command to a specific child target (e.g. an OOPIF). */
+  async sendCommandToTarget<T = unknown>(
+    targetId: string,
+    method: string,
+    params?: Record<string, unknown>
+  ): Promise<T> {
+    if (!this.attached) {
+      throw new Error('Debugger not attached');
+    }
+    const debuggee: chrome.debugger.Debuggee = { targetId };
+    return new Promise<T>((resolve, reject) => {
+      chrome.debugger.sendCommand(debuggee, method, params, (result) => {
+        if (chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message));
+          return;
+        }
+        resolve(result as T);
+      });
+    });
+  }
+
+  /** Enumerate debuggable targets (used to discover OOPIF iframe targets). */
+  async getTargets(): Promise<chrome.debugger.TargetInfo[]> {
+    return new Promise<chrome.debugger.TargetInfo[]>((resolve) => {
+      chrome.debugger.getTargets((targets) => resolve(targets));
+    });
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
   // Event Handling
   // ─────────────────────────────────────────────────────────────────────────
 

--- a/src/extension/tools/browser/ChromeDebuggerSessionRegistry.ts
+++ b/src/extension/tools/browser/ChromeDebuggerSessionRegistry.ts
@@ -10,11 +10,49 @@
 
 import { ChromeDebuggerClient } from './ChromeDebuggerClient';
 import type { CDPDomain, CDPEventCallback, DebuggerTarget } from '@/core/tools/browser/DebuggerClient';
-import type {
-  DebuggerHandle,
-  DebuggerSessionRegistry,
-  DebuggerDetachCallback,
+import {
+  CdpCommandTimeoutError,
+  type DebuggerHandle,
+  type DebuggerSessionRegistry,
+  type DebuggerDetachCallback,
+  type SendCommandOptions,
 } from '@/core/tools/browser/DebuggerSessionRegistry';
+
+/** Default per-command timeout for interactive commands. */
+const DEFAULT_CDP_TIMEOUT_MS = 10_000;
+/** Short timeout for input dispatch — a wedged Input.* is unambiguous. */
+const INPUT_CDP_TIMEOUT_MS = 5_000;
+/**
+ * Longer budget for snapshot-heavy commands that can legitimately take many
+ * seconds on large pages. Well under DomService's overall `snapshotTimeout`
+ * (120s) but enough to catch a genuinely wedged renderer.
+ */
+const SLOW_CDP_TIMEOUT_MS = 60_000;
+const SLOW_METHODS = new Set<string>([
+  'DOM.getDocument',
+  'Accessibility.getFullAXTree',
+  'DOMSnapshot.captureSnapshot',
+  'Page.captureScreenshot',
+]);
+
+function defaultTimeoutForMethod(method: string): number {
+  if (SLOW_METHODS.has(method)) return SLOW_CDP_TIMEOUT_MS;
+  if (method.startsWith('Input.')) return INPUT_CDP_TIMEOUT_MS;
+  return DEFAULT_CDP_TIMEOUT_MS;
+}
+
+/**
+ * Race a promise against a timeout that rejects with `onTimeout()`. The timer is
+ * always cleared so it can't fire after the command settled. A late underlying
+ * resolution is harmless — a JS promise can only settle once.
+ */
+function raceWithTimeout<T>(p: Promise<T>, ms: number, onTimeout: () => Error): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(onTimeout()), ms);
+  });
+  return Promise.race([p, timeout]).finally(() => clearTimeout(timer)) as Promise<T>;
+}
 
 /** Per-tab shared session state. */
 interface TabSession {
@@ -186,8 +224,30 @@ export class ChromeDebuggerSessionRegistry implements DebuggerSessionRegistry {
       isAttached: () => !released && registry.sessions.has(tabId),
 
       // ── DebuggerClient: commands ──
-      sendCommand: <T = unknown>(method: string, params?: Record<string, unknown>) =>
-        client.sendCommand<T>(method, params),
+      // Each command is raced against a per-method timeout. On timeout the tab
+      // is presumed wedged and force-detached so the next acquire re-attaches
+      // clean. NOTE (blast radius): force-detach abandons ALL in-flight commands
+      // on the shared tab, so one timed-out command fails its concurrent
+      // siblings too. Acceptable for a wedged renderer; see design §1.6 #2.
+      sendCommand: async <T = unknown>(
+        method: string,
+        params?: Record<string, unknown>,
+        opts?: SendCommandOptions
+      ): Promise<T> => {
+        const timeoutMs = opts?.timeoutMs ?? defaultTimeoutForMethod(method);
+        try {
+          return await raceWithTimeout(
+            client.sendCommand<T>(method, params),
+            timeoutMs,
+            () => new CdpCommandTimeoutError(method, timeoutMs)
+          );
+        } catch (error) {
+          if (error instanceof CdpCommandTimeoutError) {
+            await registry.forceDetach(tabId);
+          }
+          throw error;
+        }
+      },
 
       // ── DebuggerClient: events / domains ──
       onEvent: (cb: CDPEventCallback) => {

--- a/src/extension/tools/browser/ChromeDebuggerSessionRegistry.ts
+++ b/src/extension/tools/browser/ChromeDebuggerSessionRegistry.ts
@@ -124,11 +124,17 @@ export class ChromeDebuggerSessionRegistry implements DebuggerSessionRegistry {
   // Internal
   // ───────────────────────────────────────────────────────────────────────────
 
-  /** Release one reference; detach the shared session at refcount zero. */
-  private releaseTab(tabId: number): Promise<void> {
+  /**
+   * Release one reference held by `owned`; detach the shared session at
+   * refcount zero. The identity check (`session !== owned`) makes a release from
+   * a handle whose session was already force/externally detached (and possibly
+   * replaced by a re-acquire) a no-op — otherwise it would decrement/detach an
+   * unrelated session bound to the same tabId.
+   */
+  private releaseTab(tabId: number, owned: TabSession): Promise<void> {
     return this.withTabLock(tabId, async () => {
       const session = this.sessions.get(tabId);
-      if (!session) return;
+      if (!session || session !== owned) return;
       session.refs--;
       if (session.refs <= 0) {
         this.sessions.delete(tabId);
@@ -280,7 +286,9 @@ export class ChromeDebuggerSessionRegistry implements DebuggerSessionRegistry {
         // Remove this handle's subscriptions from the shared client/session.
         for (const cb of ownEventCallbacks) client.offEvent(cb);
         for (const cb of ownDetachCallbacks) session.detachCallbacks.delete(cb);
-        await registry.releaseTab(tabId);
+        // Pass the captured session so we only decrement OUR session, never a
+        // replacement bound to the same tabId after a force/external detach.
+        await registry.releaseTab(tabId, session);
       },
     };
 

--- a/src/extension/tools/browser/ChromeDebuggerSessionRegistry.ts
+++ b/src/extension/tools/browser/ChromeDebuggerSessionRegistry.ts
@@ -1,0 +1,262 @@
+/**
+ * Chrome Debugger Session Registry
+ *
+ * Extension-mode implementation of {@link DebuggerSessionRegistry}. Owns one
+ * shared {@link ChromeDebuggerClient} per tab, refcounted, with attach/detach
+ * serialized by a per-tab async mutex.
+ *
+ * @module extension/tools/browser/ChromeDebuggerSessionRegistry
+ */
+
+import { ChromeDebuggerClient } from './ChromeDebuggerClient';
+import type { CDPDomain, CDPEventCallback, DebuggerTarget } from '@/core/tools/browser/DebuggerClient';
+import type {
+  DebuggerHandle,
+  DebuggerSessionRegistry,
+  DebuggerDetachCallback,
+} from '@/core/tools/browser/DebuggerSessionRegistry';
+
+/** Per-tab shared session state. */
+interface TabSession {
+  client: ChromeDebuggerClient;
+  refs: number;
+  /** Detach subscribers across all live handles for this tab. */
+  detachCallbacks: Set<DebuggerDetachCallback>;
+}
+
+export class ChromeDebuggerSessionRegistry implements DebuggerSessionRegistry {
+  private sessions = new Map<number, TabSession>();
+  /** Per-tab promise-chain mutex. Tail never rejects (see {@link withTabLock}). */
+  private locks = new Map<number, Promise<unknown>>();
+  private detachListener:
+    | ((source: chrome.debugger.Debuggee, reason: string) => void)
+    | null = null;
+
+  constructor() {
+    this.installDetachListener();
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Public API
+  // ───────────────────────────────────────────────────────────────────────────
+
+  async acquire(tabId: number): Promise<DebuggerHandle> {
+    return this.withTabLock(tabId, async () => {
+      let session = this.sessions.get(tabId);
+      if (!session) {
+        const client = new ChromeDebuggerClient();
+        try {
+          await client.attach({ tabId } as DebuggerTarget);
+        } catch (error: any) {
+          const message = String(error?.message ?? error);
+          if (message.toLowerCase().includes('already attached')) {
+            throw new Error(
+              'ALREADY_ATTACHED: DevTools is open on this tab. Please close DevTools.'
+            );
+          }
+          throw new Error(`ATTACH_FAILED: ${message}`);
+        }
+        session = { client, refs: 0, detachCallbacks: new Set() };
+        this.sessions.set(tabId, session);
+      }
+      session.refs++;
+      return this.makeHandle(tabId, session);
+    });
+  }
+
+  async forceDetach(tabId: number): Promise<void> {
+    return this.withTabLock(tabId, async () => {
+      const session = this.sessions.get(tabId);
+      this.sessions.delete(tabId);
+      if (!session) return;
+      this.notifyDetach(session, 'force_detach');
+      try {
+        await session.client.detach();
+      } catch {
+        /* ignore — session is being torn down regardless */
+      }
+    });
+  }
+
+  isAttached(tabId: number): boolean {
+    return this.sessions.has(tabId);
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Internal
+  // ───────────────────────────────────────────────────────────────────────────
+
+  /** Release one reference; detach the shared session at refcount zero. */
+  private releaseTab(tabId: number): Promise<void> {
+    return this.withTabLock(tabId, async () => {
+      const session = this.sessions.get(tabId);
+      if (!session) return;
+      session.refs--;
+      if (session.refs <= 0) {
+        this.sessions.delete(tabId);
+        try {
+          await session.client.detach();
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+  }
+
+  /**
+   * Per-tab async mutex. Each call is chained after the previous one settles
+   * (success OR failure), so a rejected operation cannot poison the chain for
+   * later waiters. The stored "tail" is a non-rejecting promise; the returned
+   * promise preserves the operation's own result/rejection for the caller.
+   */
+  private withTabLock<T>(tabId: number, fn: () => Promise<T>): Promise<T> {
+    const prev = this.locks.get(tabId) ?? Promise.resolve();
+    const run = prev.then(() => fn());
+    const tail = run.then(
+      () => undefined,
+      () => undefined
+    );
+    this.locks.set(tabId, tail);
+    // Garbage-collect the lock entry once this tail settles, unless a newer
+    // operation has already superseded it.
+    void tail.then(() => {
+      if (this.locks.get(tabId) === tail) {
+        this.locks.delete(tabId);
+      }
+    });
+    return run;
+  }
+
+  private notifyDetach(session: TabSession, reason: string): void {
+    for (const cb of session.detachCallbacks) {
+      try {
+        cb(reason);
+      } catch (error) {
+        console.error('[DebuggerSessionRegistry] detach callback error:', error);
+      }
+    }
+    session.detachCallbacks.clear();
+  }
+
+  private installDetachListener(): void {
+    if (typeof chrome === 'undefined' || !chrome.debugger?.onDetach) {
+      return; // Non-extension context (e.g. tests, desktop) — nothing to reconcile.
+    }
+    this.detachListener = (source, reason) => {
+      const tabId = source.tabId;
+      if (tabId == null) return;
+      void this.handleExternalDetach(tabId, reason);
+    };
+    chrome.debugger.onDetach.addListener(this.detachListener);
+  }
+
+  /** Reconcile state when chrome reports a detach we did not initiate. */
+  private async handleExternalDetach(tabId: number, reason: string): Promise<void> {
+    await this.withTabLock(tabId, async () => {
+      const session = this.sessions.get(tabId);
+      if (!session) return;
+      this.sessions.delete(tabId);
+      this.notifyDetach(session, reason);
+      // The chrome-side session is already gone; best-effort cleanup of our
+      // client's listeners/state.
+      try {
+        await session.client.detach();
+      } catch {
+        /* ignore */
+      }
+    });
+  }
+
+  private makeHandle(tabId: number, session: TabSession): DebuggerHandle {
+    const registry = this;
+    const client = session.client;
+    let released = false;
+    // Track this handle's own subscriptions so release() can clean them up
+    // from the shared client without disturbing sibling handles.
+    const ownEventCallbacks: CDPEventCallback[] = [];
+    const ownDetachCallbacks: DebuggerDetachCallback[] = [];
+
+    const handle: DebuggerHandle = {
+      tabId,
+
+      // ── DebuggerClient: lifecycle ──
+      // attach is a no-op: the registry owns attachment.
+      attach: async () => {},
+      detach: () => handle.release(),
+      isAttached: () => !released && registry.sessions.has(tabId),
+
+      // ── DebuggerClient: commands ──
+      sendCommand: <T = unknown>(method: string, params?: Record<string, unknown>) =>
+        client.sendCommand<T>(method, params),
+
+      // ── DebuggerClient: events / domains ──
+      onEvent: (cb: CDPEventCallback) => {
+        ownEventCallbacks.push(cb);
+        client.onEvent(cb);
+      },
+      offEvent: (cb: CDPEventCallback) => {
+        const i = ownEventCallbacks.indexOf(cb);
+        if (i !== -1) ownEventCallbacks.splice(i, 1);
+        client.offEvent(cb);
+      },
+      enableDomain: (domain: CDPDomain) => client.enableDomain(domain),
+      disableDomain: (domain: CDPDomain) => client.disableDomain(domain),
+
+      // ── DebuggerClient: convenience ──
+      getTargetInfo: () => client.getTargetInfo(),
+      getTabId: () => tabId,
+
+      // ── DebuggerHandle extensions ──
+      onDetach: (cb: DebuggerDetachCallback) => {
+        session.detachCallbacks.add(cb);
+        ownDetachCallbacks.push(cb);
+        return () => {
+          session.detachCallbacks.delete(cb);
+        };
+      },
+      release: async () => {
+        if (released) return;
+        released = true;
+        // Remove this handle's subscriptions from the shared client/session.
+        for (const cb of ownEventCallbacks) client.offEvent(cb);
+        for (const cb of ownDetachCallbacks) session.detachCallbacks.delete(cb);
+        await registry.releaseTab(tabId);
+      },
+    };
+
+    return handle;
+  }
+
+  /** Test-only: detach the global onDetach listener (paired with reset). */
+  _dispose(): void {
+    if (this.detachListener && typeof chrome !== 'undefined' && chrome.debugger?.onDetach) {
+      chrome.debugger.onDetach.removeListener(this.detachListener);
+    }
+    this.detachListener = null;
+    this.sessions.clear();
+    this.locks.clear();
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Singleton — both DomService and the screenshot services import from here so
+// they coordinate through ONE registry instance.
+// ─────────────────────────────────────────────────────────────────────────────
+
+let registrySingleton: ChromeDebuggerSessionRegistry | null = null;
+
+export function getDebuggerSessionRegistry(): ChromeDebuggerSessionRegistry {
+  if (!registrySingleton) {
+    registrySingleton = new ChromeDebuggerSessionRegistry();
+  }
+  return registrySingleton;
+}
+
+/**
+ * Test-only: drop the singleton so each test starts with a clean registry.
+ * Wired into the global test setup's `beforeEach`.
+ */
+export function __resetDebuggerSessionRegistryForTests(): void {
+  registrySingleton?._dispose();
+  registrySingleton = null;
+}

--- a/src/extension/tools/browser/PageReadiness.ts
+++ b/src/extension/tools/browser/PageReadiness.ts
@@ -1,0 +1,161 @@
+/**
+ * PageReadiness — event-driven page-load waiting (replaces polling heuristics).
+ *
+ * Subscribes to CDP `Page.lifecycleEvent`s (enabled via
+ * `Page.setLifecycleEventsEnabled`) and resolves `waitFor(state)` when the named
+ * lifecycle fires. `networkAlmostIdle`/`networkIdle` come free with lifecycle
+ * events — no `Network.enable` needed. Waits are correlated by `loaderId` so a
+ * `load` from the *previous* document can't satisfy a wait for the new one.
+ *
+ * Also forwards `Page.javascriptDialogOpening` so a `confirm()` no longer
+ * deadlocks pending CDP evaluates.
+ *
+ * Design: `.ai_design/improve_webtool_from_codex/design.md` §3.8 / §7.3.
+ *
+ * @module extension/tools/browser/PageReadiness
+ */
+
+import type { DebuggerHandle } from '@/core/tools/browser/DebuggerSessionRegistry';
+
+export type ReadinessState = 'DOMContentLoaded' | 'load' | 'networkAlmostIdle' | 'networkIdle';
+
+export interface WaitForOptions {
+  timeoutMs?: number;
+  /** When the timeout elapses, resolve instead of reject (default true). */
+  failOpen?: boolean;
+  /** Only count lifecycle events for this loaderId (set by navigate()). */
+  loaderId?: string;
+}
+
+export interface DialogInfo {
+  type: string;
+  message: string;
+}
+
+interface Waiter {
+  state: ReadinessState;
+  loaderId?: string;
+  resolve: () => void;
+  reject: (e: Error) => void;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+export class PageReadiness {
+  private readonly boundListener: (method: string, params: unknown) => void;
+  private readonly ready: Promise<void>;
+  /** loaderId → lifecycle names already seen (so a wait registered late still resolves). */
+  private readonly seen = new Map<string, Set<string>>();
+  private readonly waiters = new Set<Waiter>();
+  private readonly dialogCallbacks = new Set<(info: DialogInfo) => void>();
+  private latestLoaderId: string | undefined;
+
+  constructor(private readonly handle: DebuggerHandle) {
+    this.boundListener = (method, params) => this.onCdpEvent(method, params as any);
+    handle.onEvent(this.boundListener);
+    this.ready = this.enable();
+  }
+
+  private async enable(): Promise<void> {
+    await this.handle.enableDomain('Page');
+    await this.handle.sendCommand('Page.setLifecycleEventsEnabled', { enabled: true });
+  }
+
+  /**
+   * Navigate and return correlation ids. Wait against the returned loaderId so
+   * only this document's lifecycle events satisfy a subsequent waitFor.
+   */
+  async navigate(url: string, waitUntil?: ReadinessState, opts?: WaitForOptions): Promise<{ frameId: string; loaderId?: string }> {
+    await this.ready;
+    const result = await this.handle.sendCommand<{ frameId: string; loaderId?: string; errorText?: string }>(
+      'Page.navigate',
+      { url }
+    );
+    if (result.errorText) {
+      throw new Error(`NAVIGATION_FAILED: ${result.errorText}`);
+    }
+    if (waitUntil) {
+      await this.waitFor(waitUntil, { ...opts, loaderId: result.loaderId });
+    }
+    return { frameId: result.frameId, loaderId: result.loaderId };
+  }
+
+  /** Resolve when `state` is reached (optionally for a specific loaderId). */
+  async waitFor(state: ReadinessState, opts?: WaitForOptions): Promise<void> {
+    await this.ready;
+    const loaderId = opts?.loaderId ?? this.latestLoaderId;
+
+    // Already seen for this loader? resolve immediately.
+    if (loaderId && this.seen.get(loaderId)?.has(state)) return;
+
+    const timeoutMs = opts?.timeoutMs ?? 30_000;
+    const failOpen = opts?.failOpen ?? true;
+
+    await new Promise<void>((resolve, reject) => {
+      const waiter: Waiter = {
+        state,
+        loaderId,
+        resolve,
+        reject,
+        timer: setTimeout(() => {
+          this.waiters.delete(waiter);
+          if (failOpen) resolve();
+          else reject(new Error(`PAGE_READINESS_TIMEOUT: '${state}' not reached within ${timeoutMs}ms`));
+        }, timeoutMs),
+      };
+      this.waiters.add(waiter);
+    });
+  }
+
+  /** Subscribe to javascript dialogs (alert/confirm/prompt/beforeunload). */
+  onDialog(cb: (info: DialogInfo) => void): () => void {
+    this.dialogCallbacks.add(cb);
+    return () => this.dialogCallbacks.delete(cb);
+  }
+
+  /** Respond to an open javascript dialog. */
+  async handleDialog(accept: boolean, promptText?: string): Promise<void> {
+    await this.handle.sendCommand('Page.handleJavaScriptDialog', { accept, promptText });
+  }
+
+  dispose(): void {
+    this.handle.offEvent(this.boundListener);
+    for (const w of this.waiters) {
+      if (w.timer) clearTimeout(w.timer);
+    }
+    this.waiters.clear();
+    this.dialogCallbacks.clear();
+    this.seen.clear();
+  }
+
+  private onCdpEvent(method: string, params: any): void {
+    if (method === 'Page.lifecycleEvent') {
+      const loaderId: string = params.loaderId;
+      const name: string = params.name;
+      if (loaderId) {
+        this.latestLoaderId = loaderId;
+        let set = this.seen.get(loaderId);
+        if (!set) {
+          set = new Set();
+          this.seen.set(loaderId, set);
+        }
+        set.add(name);
+      }
+      for (const waiter of [...this.waiters]) {
+        if (waiter.state === name && (!waiter.loaderId || waiter.loaderId === loaderId)) {
+          if (waiter.timer) clearTimeout(waiter.timer);
+          this.waiters.delete(waiter);
+          waiter.resolve();
+        }
+      }
+    } else if (method === 'Page.javascriptDialogOpening') {
+      const info: DialogInfo = { type: params.type, message: params.message };
+      for (const cb of this.dialogCallbacks) {
+        try {
+          cb(info);
+        } catch (error) {
+          console.error('[PageReadiness] dialog callback error:', error);
+        }
+      }
+    }
+  }
+}

--- a/src/extension/tools/browser/PageReadiness.ts
+++ b/src/extension/tools/browser/PageReadiness.ts
@@ -137,6 +137,13 @@ export class PageReadiness {
         if (!set) {
           set = new Set();
           this.seen.set(loaderId, set);
+          // Bound memory across many navigations (Map preserves insertion
+          // order — evict the oldest loaderId).
+          while (this.seen.size > 8) {
+            const oldest = this.seen.keys().next().value;
+            if (oldest === undefined || oldest === loaderId) break;
+            this.seen.delete(oldest);
+          }
         }
         set.add(name);
       }

--- a/src/extension/tools/browser/ViewportOverrideService.ts
+++ b/src/extension/tools/browser/ViewportOverrideService.ts
@@ -1,0 +1,68 @@
+/**
+ * ViewportOverrideService — deterministic viewport via CDP Emulation.
+ *
+ * Applies `Emulation.setDeviceMetricsOverride` with `deviceScaleFactor: 1` so
+ * screenshot pixels == CSS pixels == input coordinates, eliminating all DPR
+ * math downstream (the structural fix behind the T08 DPR hotfix). Also lets the
+ * agent test responsive/breakpoint layouts via an explicit size.
+ *
+ * Scope (design §3.3 / §1.6): the override is user-visible (it resizes the live
+ * tab), so it is applied ONLY during page_vision flows and explicit
+ * `browser_viewport set`, defaults to the tab's CURRENT CSS viewport (not a
+ * fixed 1280×720) to avoid visibly resizing the user's page, and is always
+ * cleared on release / turn end.
+ *
+ * @module extension/tools/browser/ViewportOverrideService
+ */
+
+export type CdpSend = <T = any>(method: string, params?: any) => Promise<T>;
+
+export interface ViewportSize {
+  width: number;
+  height: number;
+}
+
+export class ViewportOverrideService {
+  constructor(private readonly send: CdpSend) {}
+
+  /**
+   * Apply a deterministic viewport. Width/height default to the tab's current
+   * CSS viewport so the page isn't visibly resized. Returns the size applied.
+   */
+  async setOverride(size?: Partial<ViewportSize>): Promise<ViewportSize> {
+    let width = size?.width;
+    let height = size?.height;
+
+    if (width === undefined || height === undefined) {
+      const current = await this.getCurrentViewport();
+      width = width ?? current.width;
+      height = height ?? current.height;
+    }
+
+    await this.send('Emulation.setDeviceMetricsOverride', {
+      width,
+      height,
+      deviceScaleFactor: 1,
+      mobile: false,
+    });
+
+    return { width, height };
+  }
+
+  /** Clear any active device-metrics override. Never throws. */
+  async clearOverride(): Promise<void> {
+    try {
+      await this.send('Emulation.clearDeviceMetricsOverride', {});
+    } catch (error) {
+      console.warn('[ViewportOverrideService] clearDeviceMetricsOverride failed:', error);
+    }
+  }
+
+  private async getCurrentViewport(): Promise<ViewportSize> {
+    const result = await this.send<any>('Runtime.evaluate', {
+      expression: '({ width: window.innerWidth, height: window.innerHeight })',
+      returnByValue: true,
+    });
+    return result.result.value;
+  }
+}

--- a/src/extension/tools/browser/__tests__/ChromeDebuggerClient.oopif.test.ts
+++ b/src/extension/tools/browser/__tests__/ChromeDebuggerClient.oopif.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ChromeDebuggerClient } from '../ChromeDebuggerClient';
+
+/** OOPIF prerequisite (design §3.7): target-addressed commands + enumeration. */
+describe('ChromeDebuggerClient OOPIF support', () => {
+  let sendCommand: ReturnType<typeof vi.fn>;
+  let getTargets: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sendCommand = vi.fn((_debuggee: any, _method: string, _params: any, cb: (r: unknown) => void) => cb({ ok: true }));
+    getTargets = vi.fn((cb: (t: unknown[]) => void) => cb([{ id: 'T1', type: 'iframe', tabId: 5 }]));
+    (globalThis as any).chrome = {
+      ...(globalThis as any).chrome,
+      runtime: { lastError: undefined },
+      debugger: {
+        attach: vi.fn((_d: any, _v: string, cb: () => void) => cb()),
+        detach: vi.fn((_d: any, cb: () => void) => cb()),
+        sendCommand,
+        getTargets,
+        onEvent: { addListener: vi.fn(), removeListener: vi.fn() },
+      },
+    };
+  });
+
+  it('addresses sendCommandToTarget at {targetId}', async () => {
+    const client = new ChromeDebuggerClient();
+    await client.attach({ tabId: 5 });
+
+    const result = await client.sendCommandToTarget('TARGET-1', 'DOM.getDocument', { depth: -1 });
+
+    expect(result).toEqual({ ok: true });
+    expect(sendCommand).toHaveBeenCalledWith(
+      { targetId: 'TARGET-1' },
+      'DOM.getDocument',
+      { depth: -1 },
+      expect.any(Function)
+    );
+  });
+
+  it('rejects target commands when not attached', async () => {
+    const client = new ChromeDebuggerClient();
+    await expect(client.sendCommandToTarget('T1', 'DOM.getDocument')).rejects.toThrow('Debugger not attached');
+  });
+
+  it('enumerates debuggable targets', async () => {
+    const client = new ChromeDebuggerClient();
+    const targets = await client.getTargets();
+    expect(targets).toEqual([{ id: 'T1', type: 'iframe', tabId: 5 }]);
+  });
+});

--- a/src/extension/tools/browser/__tests__/ChromeDebuggerSessionRegistry.test.ts
+++ b/src/extension/tools/browser/__tests__/ChromeDebuggerSessionRegistry.test.ts
@@ -148,4 +148,19 @@ describe('ChromeDebuggerSessionRegistry', () => {
       vi.useRealTimers();
     }
   });
+
+  it('a stale handle release after force-detach does not detach the re-acquired session', async () => {
+    const staleHandle = await registry.acquire(1); // session A
+    await registry.forceDetach(1); // A torn down (detach #1)
+    const fresh = await registry.acquire(1); // session B (attach #2), refs=1
+    expect(env.attach).toHaveBeenCalledTimes(2);
+
+    // Releasing the stale handle from session A must NOT decrement/detach B.
+    await staleHandle.release();
+    expect(env.detach).toHaveBeenCalledTimes(1); // only A's force-detach
+    expect(registry.isAttached(1)).toBe(true); // B is still live
+
+    await fresh.release();
+    expect(env.detach).toHaveBeenCalledTimes(2); // now B detaches at refcount 0
+  });
 });

--- a/src/extension/tools/browser/__tests__/ChromeDebuggerSessionRegistry.test.ts
+++ b/src/extension/tools/browser/__tests__/ChromeDebuggerSessionRegistry.test.ts
@@ -116,4 +116,36 @@ describe('ChromeDebuggerSessionRegistry', () => {
   it('installs exactly one chrome.debugger.onDetach listener', () => {
     expect(env.detachListeners.length).toBe(1);
   });
+
+  it('does not time out a command that resolves promptly', async () => {
+    const h = await registry.acquire(1);
+    const res = await h.sendCommand('Runtime.evaluate', { expression: '1' });
+    expect(res).toEqual({});
+    expect(env.detach).not.toHaveBeenCalled();
+    expect(registry.isAttached(1)).toBe(true);
+  });
+
+  it('times out a wedged command, force-detaches, and re-attaches on next acquire', async () => {
+    vi.useFakeTimers();
+    try {
+      const h = await registry.acquire(1);
+      // Make the next command hang: never invoke the chrome callback.
+      env.sendCommand.mockImplementationOnce(() => {});
+
+      const pending = h.sendCommand('Page.navigate', { url: 'x' }, { timeoutMs: 1000 });
+      const rejects = expect(pending).rejects.toThrow(/CDP_COMMAND_TIMEOUT/);
+      await vi.advanceTimersByTimeAsync(1000);
+      await rejects;
+
+      // Force-detached the wedged tab.
+      expect(env.detach).toHaveBeenCalledTimes(1);
+      expect(registry.isAttached(1)).toBe(false);
+
+      // Next acquire re-attaches cleanly.
+      await registry.acquire(1);
+      expect(env.attach).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/extension/tools/browser/__tests__/ChromeDebuggerSessionRegistry.test.ts
+++ b/src/extension/tools/browser/__tests__/ChromeDebuggerSessionRegistry.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ChromeDebuggerSessionRegistry } from '../ChromeDebuggerSessionRegistry';
+
+/**
+ * Build a chrome.debugger mock and let the REAL ChromeDebuggerClient run against
+ * it, so we exercise the registry end-to-end and can assert on attach/detach.
+ */
+function makeChromeEnv() {
+  const detachListeners: Array<(source: any, reason: string) => void> = [];
+  const runtime = { lastError: undefined as { message: string } | undefined };
+  const attach = vi.fn((_debuggee: any, _version: string, cb: () => void) => cb());
+  const detach = vi.fn((_debuggee: any, cb: () => void) => cb());
+  const sendCommand = vi.fn((_debuggee: any, _method: string, _params: any, cb: (r: unknown) => void) =>
+    cb({})
+  );
+  const chrome = {
+    runtime,
+    debugger: {
+      attach,
+      detach,
+      sendCommand,
+      onEvent: { addListener: vi.fn(), removeListener: vi.fn() },
+      onDetach: {
+        addListener: (cb: any) => detachListeners.push(cb),
+        removeListener: (cb: any) => {
+          const i = detachListeners.indexOf(cb);
+          if (i !== -1) detachListeners.splice(i, 1);
+        },
+      },
+    },
+  };
+  return { chrome, runtime, attach, detach, sendCommand, detachListeners };
+}
+
+describe('ChromeDebuggerSessionRegistry', () => {
+  let registry: ChromeDebuggerSessionRegistry;
+  let env: ReturnType<typeof makeChromeEnv>;
+
+  beforeEach(() => {
+    env = makeChromeEnv();
+    (globalThis as any).chrome = env.chrome;
+    registry = new ChromeDebuggerSessionRegistry();
+  });
+
+  afterEach(() => {
+    registry._dispose();
+  });
+
+  it('attaches once for concurrent acquires on the same tab and detaches only at refcount 0', async () => {
+    const [h1, h2] = await Promise.all([registry.acquire(1), registry.acquire(1)]);
+
+    expect(env.attach).toHaveBeenCalledTimes(1);
+    expect(registry.isAttached(1)).toBe(true);
+
+    await h1.release();
+    expect(env.detach).not.toHaveBeenCalled(); // h2 still holds a ref
+
+    await h2.release();
+    expect(env.detach).toHaveBeenCalledTimes(1);
+    expect(registry.isAttached(1)).toBe(false);
+  });
+
+  it('attaches separately per tab', async () => {
+    await registry.acquire(1);
+    await registry.acquire(2);
+    expect(env.attach).toHaveBeenCalledTimes(2);
+    expect(registry.isAttached(1)).toBe(true);
+    expect(registry.isAttached(2)).toBe(true);
+  });
+
+  it('release() is idempotent and never throws', async () => {
+    const h = await registry.acquire(1);
+    await h.release();
+    await expect(h.release()).resolves.toBeUndefined();
+    expect(env.detach).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces ALREADY_ATTACHED when a foreign debugger holds the tab', async () => {
+    env.attach.mockImplementationOnce((_d: any, _v: string, cb: () => void) => {
+      env.runtime.lastError = { message: 'Another debugger is already attached to the tab with id: 1' };
+      cb();
+      env.runtime.lastError = undefined;
+    });
+    await expect(registry.acquire(1)).rejects.toThrow(/ALREADY_ATTACHED/);
+    expect(registry.isAttached(1)).toBe(false);
+  });
+
+  it('forceDetach clears state under lock; the next acquire re-attaches cleanly', async () => {
+    const stale = await registry.acquire(1);
+
+    await registry.forceDetach(1);
+    expect(env.detach).toHaveBeenCalledTimes(1);
+    expect(registry.isAttached(1)).toBe(false);
+
+    // A handle from the force-detached session no-ops on release.
+    await expect(stale.release()).resolves.toBeUndefined();
+
+    await registry.acquire(1);
+    expect(env.attach).toHaveBeenCalledTimes(2);
+    expect(registry.isAttached(1)).toBe(true);
+  });
+
+  it('notifies onDetach subscribers and reconciles on external detach', async () => {
+    const h = await registry.acquire(1);
+    const onDetach = vi.fn();
+    h.onDetach(onDetach);
+
+    // Simulate chrome firing onDetach for this tab.
+    for (const l of env.detachListeners) l({ tabId: 1 }, 'target_closed');
+    await new Promise((r) => setTimeout(r, 0)); // let the locked reconcile settle
+
+    expect(onDetach).toHaveBeenCalledWith('target_closed');
+    expect(registry.isAttached(1)).toBe(false);
+  });
+
+  it('installs exactly one chrome.debugger.onDetach listener', () => {
+    expect(env.detachListeners.length).toBe(1);
+  });
+});

--- a/src/extension/tools/browser/__tests__/PageReadiness.test.ts
+++ b/src/extension/tools/browser/__tests__/PageReadiness.test.ts
@@ -94,4 +94,15 @@ describe('PageReadiness', () => {
     const result = await navPromise;
     expect(result).toEqual({ frameId: 'F1', loaderId: 'L1' });
   });
+
+  it('caps the seen loaderId map across many navigations', async () => {
+    const { handle, fire, tick } = fakeHandle();
+    const pr = new PageReadiness(handle);
+    await tick();
+    for (let i = 0; i < 20; i++) {
+      fire('Page.lifecycleEvent', { loaderId: `L${i}`, name: 'load' });
+    }
+    expect((pr as any).seen.size).toBeLessThanOrEqual(8);
+    pr.dispose();
+  });
 });

--- a/src/extension/tools/browser/__tests__/PageReadiness.test.ts
+++ b/src/extension/tools/browser/__tests__/PageReadiness.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PageReadiness } from '../PageReadiness';
+
+function fakeHandle() {
+  let listener: ((m: string, p: unknown) => void) | null = null;
+  const sendCommand = vi.fn(async (method: string) => {
+    if (method === 'Page.navigate') return { frameId: 'F1', loaderId: 'L1' };
+    return {};
+  });
+  const handle = {
+    tabId: 1,
+    sendCommand,
+    enableDomain: vi.fn().mockResolvedValue(undefined),
+    onEvent: (cb: (m: string, p: unknown) => void) => {
+      listener = cb;
+    },
+    offEvent: () => {
+      listener = null;
+    },
+  } as any;
+  const fire = (method: string, params: any) => listener?.(method, params);
+  const tick = () => new Promise((r) => setTimeout(r, 0));
+  return { handle, fire, sendCommand, tick };
+}
+
+describe('PageReadiness', () => {
+  it('enables Page domain and lifecycle events on construction', async () => {
+    const { handle, sendCommand, tick } = fakeHandle();
+    const pr = new PageReadiness(handle);
+    await pr.waitFor('load', { timeoutMs: 10 }); // also forces `ready` to settle
+    expect(handle.enableDomain).toHaveBeenCalledWith('Page');
+    expect(sendCommand).toHaveBeenCalledWith('Page.setLifecycleEventsEnabled', { enabled: true });
+    pr.dispose();
+    await tick();
+  });
+
+  it('resolves waitFor when the named lifecycle event fires for the loader', async () => {
+    const { handle, fire, tick } = fakeHandle();
+    const pr = new PageReadiness(handle);
+    await tick();
+    const p = pr.waitFor('load', { loaderId: 'L1' });
+    await tick();
+    fire('Page.lifecycleEvent', { loaderId: 'L1', name: 'load' });
+    await expect(p).resolves.toBeUndefined();
+    pr.dispose();
+  });
+
+  it('does not resolve on a load for a different loaderId (correlation)', async () => {
+    const { handle, fire, tick } = fakeHandle();
+    const pr = new PageReadiness(handle);
+    await tick();
+    const p = pr.waitFor('load', { loaderId: 'L1', timeoutMs: 50, failOpen: false });
+    await tick();
+    fire('Page.lifecycleEvent', { loaderId: 'L2', name: 'load' }); // wrong document
+    await expect(p).rejects.toThrow('PAGE_READINESS_TIMEOUT');
+    pr.dispose();
+  });
+
+  it('resolves immediately if the state was already seen', async () => {
+    const { handle, fire, tick } = fakeHandle();
+    const pr = new PageReadiness(handle);
+    await tick();
+    fire('Page.lifecycleEvent', { loaderId: 'L1', name: 'networkAlmostIdle' });
+    await expect(pr.waitFor('networkAlmostIdle', { loaderId: 'L1' })).resolves.toBeUndefined();
+    pr.dispose();
+  });
+
+  it('fails open on timeout by default', async () => {
+    const { handle, tick } = fakeHandle();
+    const pr = new PageReadiness(handle);
+    await tick();
+    await expect(pr.waitFor('load', { loaderId: 'never', timeoutMs: 10 })).resolves.toBeUndefined();
+    pr.dispose();
+  });
+
+  it('forwards javascript dialogs', async () => {
+    const { handle, fire, tick } = fakeHandle();
+    const pr = new PageReadiness(handle);
+    await tick();
+    const onDialog = vi.fn();
+    pr.onDialog(onDialog);
+    fire('Page.javascriptDialogOpening', { type: 'confirm', message: 'Sure?' });
+    expect(onDialog).toHaveBeenCalledWith({ type: 'confirm', message: 'Sure?' });
+    pr.dispose();
+  });
+
+  it('navigate returns correlation ids and waits on the new loader', async () => {
+    const { handle, fire, tick } = fakeHandle();
+    const pr = new PageReadiness(handle);
+    await tick();
+    const navPromise = pr.navigate('https://example.com', 'load');
+    await tick();
+    fire('Page.lifecycleEvent', { loaderId: 'L1', name: 'load' });
+    const result = await navPromise;
+    expect(result).toEqual({ frameId: 'F1', loaderId: 'L1' });
+  });
+});

--- a/src/extension/tools/browser/__tests__/ViewportOverrideService.test.ts
+++ b/src/extension/tools/browser/__tests__/ViewportOverrideService.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ViewportOverrideService } from '../ViewportOverrideService';
+
+describe('ViewportOverrideService', () => {
+  it('applies an explicit size with deviceScaleFactor 1', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const service = new ViewportOverrideService(send);
+
+    const applied = await service.setOverride({ width: 375, height: 667 });
+
+    expect(applied).toEqual({ width: 375, height: 667 });
+    expect(send).toHaveBeenCalledWith('Emulation.setDeviceMetricsOverride', {
+      width: 375,
+      height: 667,
+      deviceScaleFactor: 1,
+      mobile: false,
+    });
+  });
+
+  it('defaults to the current CSS viewport when size omitted', async () => {
+    const send = vi.fn().mockImplementation(async (method: string) => {
+      if (method === 'Runtime.evaluate') return { result: { value: { width: 1280, height: 720 } } };
+      return undefined;
+    });
+    const service = new ViewportOverrideService(send);
+
+    const applied = await service.setOverride();
+
+    expect(applied).toEqual({ width: 1280, height: 720 });
+    expect(send).toHaveBeenCalledWith('Emulation.setDeviceMetricsOverride', {
+      width: 1280,
+      height: 720,
+      deviceScaleFactor: 1,
+      mobile: false,
+    });
+  });
+
+  it('clears the override', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const service = new ViewportOverrideService(send);
+    await service.clearOverride();
+    expect(send).toHaveBeenCalledWith('Emulation.clearDeviceMetricsOverride', {});
+  });
+
+  it('clearOverride never throws', async () => {
+    const send = vi.fn().mockRejectedValue(new Error('detached'));
+    const service = new ViewportOverrideService(send);
+    await expect(service.clearOverride()).resolves.toBeUndefined();
+  });
+});

--- a/src/extension/tools/browser/tabLeaseStore.ts
+++ b/src/extension/tools/browser/tabLeaseStore.ts
@@ -33,6 +33,14 @@ async function tabExists(tabId: number): Promise<boolean> {
   }
 }
 
+/**
+ * Single queue key for ALL lease mutations. The lease store is one global blob
+ * in chrome.storage.session, so claim/release/GC must be serialized globally —
+ * keying the queue per-session would let two sessions' read-modify-write of the
+ * shared blob interleave and lose an update.
+ */
+export const LEASE_QUEUE_KEY = '__workx_leases__';
+
 let storeSingleton: TabLeaseStore | null = null;
 let queueSingleton: LeaseLifecycleQueue | null = null;
 
@@ -57,7 +65,7 @@ export function getLeaseLifecycleQueue(): LeaseLifecycleQueue {
  */
 export async function gcStaleTabLeases(): Promise<number> {
   try {
-    return await getLeaseLifecycleQueue().run('__gc__', () => getTabLeaseStore().gcStale());
+    return await getLeaseLifecycleQueue().run(LEASE_QUEUE_KEY, () => getTabLeaseStore().gcStale());
   } catch (error) {
     console.warn('[tabLeaseStore] stale-lease GC failed:', error);
     return 0;

--- a/src/extension/tools/browser/tabLeaseStore.ts
+++ b/src/extension/tools/browser/tabLeaseStore.ts
@@ -1,0 +1,71 @@
+/**
+ * Extension-mode TabLeaseStore singleton.
+ *
+ * Wires {@link TabLeaseStore} to `chrome.storage.session` (survives SW restarts,
+ * cleared on browser close) and `chrome.tabs.get` for liveness. Exposes a shared
+ * {@link LeaseLifecycleQueue} so callers serialize lease mutations per session,
+ * and a startup GC that drops leases whose tab is gone.
+ *
+ * @module extension/tools/browser/tabLeaseStore
+ */
+
+import {
+  TabLeaseStore,
+  LeaseLifecycleQueue,
+  type LeaseStorage,
+} from '@/core/TabLeaseStore';
+
+const chromeSessionStorage: LeaseStorage = {
+  async get(key: string) {
+    return (await chrome.storage.session.get(key)) as Record<string, unknown>;
+  },
+  async set(key: string, value: unknown) {
+    await chrome.storage.session.set({ [key]: value });
+  },
+};
+
+async function tabExists(tabId: number): Promise<boolean> {
+  try {
+    await chrome.tabs.get(tabId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+let storeSingleton: TabLeaseStore | null = null;
+let queueSingleton: LeaseLifecycleQueue | null = null;
+
+export function getTabLeaseStore(): TabLeaseStore {
+  if (!storeSingleton) {
+    storeSingleton = new TabLeaseStore(chromeSessionStorage, tabExists);
+  }
+  return storeSingleton;
+}
+
+export function getLeaseLifecycleQueue(): LeaseLifecycleQueue {
+  if (!queueSingleton) {
+    queueSingleton = new LeaseLifecycleQueue();
+  }
+  return queueSingleton;
+}
+
+/**
+ * Drop stale leases at service-worker / session start, serialized through the
+ * lifecycle queue (under a reserved key) so it can't race a concurrent claim.
+ * Best-effort: never throws.
+ */
+export async function gcStaleTabLeases(): Promise<number> {
+  try {
+    return await getLeaseLifecycleQueue().run('__gc__', () => getTabLeaseStore().gcStale());
+  } catch (error) {
+    console.warn('[tabLeaseStore] stale-lease GC failed:', error);
+    return 0;
+  }
+}
+
+/** Test-only: reset singletons. */
+export function __resetTabLeaseSingletonsForTests(): void {
+  storeSingleton = null;
+  queueSingleton = null;
+}

--- a/src/extension/tools/dom/DomService.ts
+++ b/src/extension/tools/dom/DomService.ts
@@ -733,7 +733,9 @@ export class DomService {
       // Nothing visible. If the element is also zero-area (collapsed/hidden),
       // refuse — matching the box-model path's ELEMENT_NOT_VISIBLE rather than
       // silently clicking a degenerate element.
-      const maxArea = Math.max(0, ...quads.map((q) => this.quadArea(q)));
+      // reduce() (not Math.max(...spread)) to avoid a call-stack overflow on a
+      // pathologically large quad array.
+      const maxArea = quads.reduce((m, q) => Math.max(m, this.quadArea(q)), 0);
       if (maxArea <= 0) {
         throw new Error('ELEMENT_NOT_VISIBLE: Element has zero width or height. It may be hidden or display:none.');
       }

--- a/src/extension/tools/dom/DomService.ts
+++ b/src/extension/tools/dom/DomService.ts
@@ -15,6 +15,7 @@ import { computeHeuristics, classifyNode, determineInteractionType, detectFramew
 import type { TypeOptions } from '../../../types/domTool';
 import { DomAddon, type DomAddonContext } from './addons/DomAddon';
 import { googleDocAddon } from './addons/GoogleDocAddon';
+import { dispatchKey } from '../input/InputDispatcher';
 import type { DebuggerClient, CDPEventCallback } from '../../../core/tools/browser/DebuggerClient';
 // Static import — forTab() is only used in extension builds where DOMTool is registered.
 // Dynamic import() is banned in Chrome extension service workers.
@@ -2676,18 +2677,10 @@ export class DomService {
         if (modifiers.includes('Meta')) modifierBits |= 4;
       }
 
-      await this.sendCommand('Input.dispatchKeyEvent', {
-        type: 'keyDown',
-        key,
-        code: `Key${key.toUpperCase()}`,
-        modifiers: modifierBits
-      });
-
-      await this.sendCommand('Input.dispatchKeyEvent', {
-        type: 'keyUp',
-        key,
-        code: `Key${key.toUpperCase()}`,
-        modifiers: modifierBits
+      // Correct key synthesis: real `code`/`windowsVirtualKeyCode`/`text` so
+      // pages (and legacy keyCode handlers) actually receive the keypress.
+      await dispatchKey((method, params) => this.sendCommand(method, params), key, {
+        modifiers: modifierBits,
       });
 
       // Invalidate snapshot - let getSerializedDom() rebuild when needed

--- a/src/extension/tools/dom/DomService.ts
+++ b/src/extension/tools/dom/DomService.ts
@@ -730,11 +730,31 @@ export class DomService {
     }
 
     if (!point) {
+      // Nothing visible. If the element is also zero-area (collapsed/hidden),
+      // refuse — matching the box-model path's ELEMENT_NOT_VISIBLE rather than
+      // silently clicking a degenerate element.
+      const maxArea = Math.max(0, ...quads.map((q) => this.quadArea(q)));
+      if (maxArea <= 0) {
+        throw new Error('ELEMENT_NOT_VISIBLE: Element has zero width or height. It may be hidden or display:none.');
+      }
       // Best effort: center of the first quad (may be partially off-screen).
       const q = quads[0];
       point = { x: (q[0] + q[4]) / 2, y: (q[1] + q[5]) / 2 };
     }
     return point;
+  }
+
+  /** Polygon area of a CDP content quad [x1,y1,x2,y2,x3,y3,x4,y4] (shoelace). */
+  private quadArea(q: number[]): number {
+    if (!q || q.length < 8) return 0;
+    return (
+      Math.abs(
+        q[0] * q[3] - q[2] * q[1] +
+        q[2] * q[5] - q[4] * q[3] +
+        q[4] * q[7] - q[6] * q[5] +
+        q[6] * q[1] - q[0] * q[7]
+      ) / 2
+    );
   }
 
   /**
@@ -770,7 +790,11 @@ export class DomService {
       expression: '({ width: window.innerWidth, height: window.innerHeight })',
       returnByValue: true
     });
-    return result.result.value;
+    const value = result?.result?.value;
+    if (!value || typeof value.width !== 'number' || typeof value.height !== 'number') {
+      throw new Error('ELEMENT_NOT_VISIBLE: Failed to read viewport size for click targeting.');
+    }
+    return value;
   }
 
   /**

--- a/src/extension/tools/dom/DomService.ts
+++ b/src/extension/tools/dom/DomService.ts
@@ -15,7 +15,14 @@ import { computeHeuristics, classifyNode, determineInteractionType, detectFramew
 import type { TypeOptions } from '../../../types/domTool';
 import { DomAddon, type DomAddonContext } from './addons/DomAddon';
 import { googleDocAddon } from './addons/GoogleDocAddon';
-import { dispatchKey } from '../input/InputDispatcher';
+import { dispatchKey, click as dispatchClick, type MouseButton } from '../input/InputDispatcher';
+
+/** Options for {@link DomService.click}. */
+export interface ClickActionOptions {
+  button?: MouseButton;
+  clickCount?: number;
+  modifiers?: number;
+}
 import type { DebuggerClient, CDPEventCallback } from '../../../core/tools/browser/DebuggerClient';
 // Static import — forTab() is only used in extension builds where DOMTool is registered.
 // Dynamic import() is banned in Chrome extension service workers.
@@ -1009,7 +1016,7 @@ export class DomService {
   }
 
   // Action methods (T037-T045 will implement these)
-  async click(nodeId: number | string): Promise<ActionResult> {
+  async click(nodeId: number | string, options?: ClickActionOptions): Promise<ActionResult> {
     const start = Date.now();
 
     // Parse frame-scoped node ID
@@ -1125,20 +1132,13 @@ export class DomService {
       // CDP MIGRATION: Trigger ripple visual effect BEFORE click (with correct coordinates)
       await this.triggerVisualEffect('ripple', centerX, centerY);
 
-      // Dispatch click at the correct position
-      await this.sendCommand('Input.dispatchMouseEvent', {
-        type: 'mousePressed',
-        x: centerX,
-        y: centerY,
-        button: 'left',
-        clickCount: 1
-      });
-
-      await this.sendCommand('Input.dispatchMouseEvent', {
-        type: 'mouseReleased',
-        x: centerX,
-        y: centerY,
-        button: 'left'
+      // Dispatch click at the correct position. Routes through the shared
+      // dispatcher: mouseMoved -> mousePressed -> mouseReleased with correct
+      // `buttons` bookkeeping, honoring the requested button/clickCount.
+      await dispatchClick((method, params) => this.sendCommand(method, params), centerX, centerY, {
+        button: options?.button,
+        clickCount: options?.clickCount,
+        modifiers: options?.modifiers,
       });
 
       // Invalidate snapshot - let getSerializedDom() rebuild when needed

--- a/src/extension/tools/dom/DomService.ts
+++ b/src/extension/tools/dom/DomService.ts
@@ -16,14 +16,19 @@ import type { TypeOptions } from '../../../types/domTool';
 import { DomAddon, type DomAddonContext } from './addons/DomAddon';
 import { googleDocAddon } from './addons/GoogleDocAddon';
 import type { DebuggerClient, CDPEventCallback } from '../../../core/tools/browser/DebuggerClient';
+import type { DebuggerHandle } from '../../../core/tools/browser/DebuggerSessionRegistry';
 // Static import — forTab() is only used in extension builds where DOMTool is registered.
 // Dynamic import() is banned in Chrome extension service workers.
-import { ChromeDebuggerClient } from '../browser/ChromeDebuggerClient';
+import { getDebuggerSessionRegistry } from '../browser/ChromeDebuggerSessionRegistry';
 
 export class DomService {
   private static instances = new Map<string, DomService>();
 
   private client: DebuggerClient;
+  /** Set on the extension forTab() path; null on the desktop forClient() path. */
+  private handle: DebuggerHandle | null = null;
+  /** Unsubscribe from the shared session's detach notifications. */
+  private detachUnsubscribe: (() => void) | null = null;
   private instanceKey: string;
   private tabId: number;
   private isAttached: boolean = false;
@@ -74,20 +79,21 @@ export class DomService {
   static async forTab(tabId: number, config?: Partial<ServiceConfig>): Promise<DomService> {
     const key = `tab:${tabId}`;
     if (!this.instances.has(key)) {
-      const client = new ChromeDebuggerClient();
+      // Acquire a shared, refcounted debugger session for this tab. The registry
+      // throws `ALREADY_ATTACHED:` / `ATTACH_FAILED:` on conflict.
+      const handle = await getDebuggerSessionRegistry().acquire(tabId);
       try {
-        await client.attach({ tabId });
-      } catch (error: any) {
-        if (error.message?.toLowerCase().includes('already attached')) {
-          throw new Error('ALREADY_ATTACHED: DevTools is open on this tab. Please close DevTools.');
-        }
-        throw new Error(`ATTACH_FAILED: ${error.message}`);
+        const service = new DomService(handle, key, config);
+        service.tabId = tabId;
+        service.handle = handle;
+        await service.enableDomains();
+        service.setupEventListeners();
+        this.instances.set(key, service);
+      } catch (error) {
+        // Don't leak the reference if setup fails after a successful acquire.
+        await handle.release();
+        throw error;
       }
-      const service = new DomService(client, key, config);
-      service.tabId = tabId;
-      await service.enableDomains();
-      service.setupEventListeners();
-      this.instances.set(key, service);
     }
     return this.instances.get(key)!;
   }
@@ -130,16 +136,17 @@ export class DomService {
     this.boundHandleCdpEvent = this.handleCdpEvent.bind(this);
     this.client.onEvent(this.boundHandleCdpEvent);
 
-    // Listen for debugger detach (extension-only, chrome.debugger.onDetach)
-    if (typeof chrome !== 'undefined' && chrome.debugger?.onDetach) {
-      this.boundHandleDebuggerDetach = this.handleDebuggerDetach.bind(this);
-      chrome.debugger.onDetach.addListener(this.boundHandleDebuggerDetach);
+    // Reconcile on external/forced detach via the shared session handle. The
+    // registry owns the single chrome.debugger.onDetach listener and fans it
+    // out, so DomService no longer registers its own (extension/forTab path
+    // only; the desktop forClient path has no handle).
+    if (this.handle) {
+      this.detachUnsubscribe = this.handle.onDetach((reason) => this.handleDebuggerDetach(reason));
     }
   }
 
-  // Bound event handler references for cleanup
+  // Bound event handler reference for cleanup
   private boundHandleCdpEvent: CDPEventCallback | null = null;
-  private boundHandleDebuggerDetach: ((source: chrome.debugger.Debuggee, reason: string) => void) | null = null;
 
   async detach(): Promise<void> {
     if (!this.isAttached) return;
@@ -150,12 +157,19 @@ export class DomService {
         this.client.offEvent(this.boundHandleCdpEvent);
         this.boundHandleCdpEvent = null;
       }
-      if (this.boundHandleDebuggerDetach && typeof chrome !== 'undefined' && chrome.debugger?.onDetach) {
-        chrome.debugger.onDetach.removeListener(this.boundHandleDebuggerDetach);
-        this.boundHandleDebuggerDetach = null;
+      if (this.detachUnsubscribe) {
+        this.detachUnsubscribe();
+        this.detachUnsubscribe = null;
       }
 
-      await this.client.detach();
+      // forTab: release our refcount (detaches the shared session at zero).
+      // forClient (desktop): detach the pre-attached client directly.
+      if (this.handle) {
+        await this.handle.release();
+        this.handle = null;
+      } else {
+        await this.client.detach();
+      }
       this.isAttached = false;
       this.currentSnapshot = null;
       DomService.instances.delete(this.instanceKey);
@@ -738,13 +752,16 @@ export class DomService {
     }
   }
 
-  // Handle CDP connection loss (extension-only, chrome.debugger.onDetach)
-  private handleDebuggerDetach(source: chrome.debugger.Debuggee, reason: string): void {
-    if (source.tabId !== this.tabId) return;
-
+  // Handle CDP connection loss, fanned out from the registry's single
+  // chrome.debugger.onDetach listener (already filtered to this tab).
+  private handleDebuggerDetach(reason: string): void {
     console.error(`[DomService] CDP_CONNECTION_LOST: Debugger detached from tab ${this.tabId}. Reason: ${reason}`);
     this.isAttached = false;
     this.currentSnapshot = null;
+    // The shared session is already gone; drop our handle (release() would
+    // no-op) and our subscription (the registry already cleared subscribers).
+    this.handle = null;
+    this.detachUnsubscribe = null;
     DomService.instances.delete(this.instanceKey);
 
     // If detach was unexpected (not user-initiated), log for debugging

--- a/src/extension/tools/dom/DomService.ts
+++ b/src/extension/tools/dom/DomService.ts
@@ -42,6 +42,7 @@ export class DomService {
       snapshotTimeout: 120000,
       retryAttempts: 2,
       enableMetrics: true,
+      useContentQuads: false,
       ...config
     };
 
@@ -701,6 +702,78 @@ export class DomService {
   }
 
   /**
+   * Resolve a click point using DOM.getContentQuads (viewport-relative CSS
+   * pixels). Picks the center of the largest quad∩viewport intersection so
+   * partially-scrolled elements still click a visible point; scrolls into view
+   * and retries once when nothing is visible.
+   */
+  private async resolveClickPointViaContentQuads(backendNodeId: number): Promise<{ x: number; y: number }> {
+    const viewport = await this.getViewportSizeCss();
+
+    const fetchQuads = async (): Promise<number[][]> => {
+      const result = await this.sendCommand<any>('DOM.getContentQuads', { backendNodeId });
+      return (result?.quads ?? []) as number[][];
+    };
+
+    let quads = await fetchQuads();
+    if (quads.length === 0) {
+      throw new Error('ELEMENT_NOT_VISIBLE: Element has no content quads. It may be hidden or display:none.');
+    }
+
+    let point = this.pickVisibleQuadCenter(quads, viewport);
+    if (!point) {
+      // Off-screen: scroll into view and retry once.
+      await this.sendCommand('DOM.scrollIntoViewIfNeeded', { backendNodeId }).catch(() => { });
+      await new Promise(resolve => setTimeout(resolve, 100));
+      quads = await fetchQuads();
+      point = this.pickVisibleQuadCenter(quads, viewport);
+    }
+
+    if (!point) {
+      // Best effort: center of the first quad (may be partially off-screen).
+      const q = quads[0];
+      point = { x: (q[0] + q[4]) / 2, y: (q[1] + q[5]) / 2 };
+    }
+    return point;
+  }
+
+  /**
+   * Choose the center of the largest quad clipped to the viewport rect
+   * {0,0,width,height}. Returns null when no quad intersects the viewport.
+   */
+  private pickVisibleQuadCenter(
+    quads: number[][],
+    viewport: { width: number; height: number }
+  ): { x: number; y: number } | null {
+    let best: { area: number; x: number; y: number } | null = null;
+    for (const q of quads) {
+      if (!q || q.length < 8) continue;
+      const xs = [q[0], q[2], q[4], q[6]];
+      const ys = [q[1], q[3], q[5], q[7]];
+      const ixMin = Math.max(Math.min(...xs), 0);
+      const ixMax = Math.min(Math.max(...xs), viewport.width);
+      const iyMin = Math.max(Math.min(...ys), 0);
+      const iyMax = Math.min(Math.max(...ys), viewport.height);
+      const iw = ixMax - ixMin;
+      const ih = iyMax - iyMin;
+      if (iw <= 0 || ih <= 0) continue; // no visible intersection
+      const area = iw * ih;
+      if (!best || area > best.area) {
+        best = { area, x: (ixMin + ixMax) / 2, y: (iyMin + iyMax) / 2 };
+      }
+    }
+    return best ? { x: best.x, y: best.y } : null;
+  }
+
+  private async getViewportSizeCss(): Promise<{ width: number; height: number }> {
+    const result = await this.sendCommand<any>('Runtime.evaluate', {
+      expression: '({ width: window.innerWidth, height: window.innerHeight })',
+      returnByValue: true
+    });
+    return result.result.value;
+  }
+
+  /**
    * Get page metadata via CDP Runtime.evaluate (platform-agnostic).
    * Replaces chrome.tabs.get() which is only available in extension mode.
    */
@@ -1055,70 +1128,84 @@ export class DomService {
       // (in case we found the node in a different frame than specified)
       const resolvedBackendNodeId = node.backendNodeId;
 
-      // Get box model for coordinates
-      let boxModel;
-      try {
-        boxModel = await this.sendCommand<any>('DOM.getBoxModel', { backendNodeId: resolvedBackendNodeId });
-      } catch (error: any) {
-        // SVG elements don't have box models - try getting content quads instead
-        if (error.message?.includes('Could not compute box model')) {
-          if (node?.nodeName?.toLowerCase() === 'svg' || node?.nodeName?.toLowerCase().includes('svg')) {
-            console.warn('[DomService] SVG element detected - using alternative click method');
-            // For SVG, try to get bounding rect via JavaScript
-            throw new Error('SVG_CLICK_NOT_SUPPORTED: Direct SVG element clicking not yet fully implemented. Consider clicking parent element.');
-          }
-        }
-        throw error;
-      }
+      // Resolve the click point in viewport-relative CSS pixels.
+      let centerX: number;
+      let centerY: number;
 
-      let { content } = boxModel.model;
-
-      // Element visibility verification
-      const width = Math.abs(content[2] - content[0]);
-      const height = Math.abs(content[5] - content[1]);
-      if (width === 0 || height === 0) {
-        throw new Error('ELEMENT_NOT_VISIBLE: Element has zero width or height. It may be hidden or display:none.');
-      }
-
-      // Calculate initial center coordinates
-      let centerX = (content[0] + content[2]) / 2;
-      let centerY = (content[1] + content[5]) / 2;
-
-      // Check if element is within viewport and scroll if needed
-      // Only check viewport if visual effects are enabled (optimization)
-      if (this.config.enableVisualEffects) {
-        const viewportResult = await this.sendCommand<any>('Runtime.evaluate', {
-          expression: '({ width: window.innerWidth, height: window.innerHeight, scrollX: window.scrollX, scrollY: window.scrollY })',
-          returnByValue: true
-        });
-        const viewport = viewportResult.result.value;
-
-        // Element is in viewport if its center is visible on screen
-        // Note: content coordinates are absolute (relative to document), not viewport
-        const isInViewport =
-          centerX >= viewport.scrollX &&
-          centerX <= viewport.scrollX + viewport.width &&
-          centerY >= viewport.scrollY &&
-          centerY <= viewport.scrollY + viewport.height;
-
-        if (!isInViewport) {
-          // Scroll element into view
-          await this.sendCommand('DOM.scrollIntoViewIfNeeded', { backendNodeId: resolvedBackendNodeId });
-
-          // Wait for scroll animation to complete
-          await new Promise(resolve => setTimeout(resolve, 100));
-
-          // Get box model AGAIN after scrolling (element position has changed)
-          const updatedBoxModel = await this.sendCommand<any>('DOM.getBoxModel', { backendNodeId: resolvedBackendNodeId });
-          content = updatedBoxModel.model.content;
-
-          // Recalculate center coordinates with new position
-          centerX = (content[0] + content[2]) / 2;
-          centerY = (content[1] + content[5]) / 2;
-        }
+      if (this.config.useContentQuads) {
+        // getContentQuads returns viewport-relative quads and handles
+        // inline/SVG/transformed elements (no box model required). We click the
+        // center of the quad∩viewport intersection — no document-scroll offsets
+        // (see design §3.4 / §1.6 #6).
+        const point = await this.resolveClickPointViaContentQuads(resolvedBackendNodeId);
+        centerX = point.x;
+        centerY = point.y;
       } else {
-        // Visual effects disabled - still scroll into view if needed, but don't wait
-        await this.sendCommand('DOM.scrollIntoViewIfNeeded', { backendNodeId: resolvedBackendNodeId }).catch(() => { });
+        // Get box model for coordinates
+        let boxModel;
+        try {
+          boxModel = await this.sendCommand<any>('DOM.getBoxModel', { backendNodeId: resolvedBackendNodeId });
+        } catch (error: any) {
+          // SVG elements don't have box models - try getting content quads instead
+          if (error.message?.includes('Could not compute box model')) {
+            if (node?.nodeName?.toLowerCase() === 'svg' || node?.nodeName?.toLowerCase().includes('svg')) {
+              console.warn('[DomService] SVG element detected - using alternative click method');
+              // For SVG, try to get bounding rect via JavaScript
+              throw new Error('SVG_CLICK_NOT_SUPPORTED: Direct SVG element clicking not yet fully implemented. Consider clicking parent element.');
+            }
+          }
+          throw error;
+        }
+
+        let { content } = boxModel.model;
+
+        // Element visibility verification
+        const width = Math.abs(content[2] - content[0]);
+        const height = Math.abs(content[5] - content[1]);
+        if (width === 0 || height === 0) {
+          throw new Error('ELEMENT_NOT_VISIBLE: Element has zero width or height. It may be hidden or display:none.');
+        }
+
+        // Calculate initial center coordinates
+        centerX = (content[0] + content[2]) / 2;
+        centerY = (content[1] + content[5]) / 2;
+
+        // Check if element is within viewport and scroll if needed
+        // Only check viewport if visual effects are enabled (optimization)
+        if (this.config.enableVisualEffects) {
+          const viewportResult = await this.sendCommand<any>('Runtime.evaluate', {
+            expression: '({ width: window.innerWidth, height: window.innerHeight, scrollX: window.scrollX, scrollY: window.scrollY })',
+            returnByValue: true
+          });
+          const viewport = viewportResult.result.value;
+
+          // Element is in viewport if its center is visible on screen
+          // Note: content coordinates are absolute (relative to document), not viewport
+          const isInViewport =
+            centerX >= viewport.scrollX &&
+            centerX <= viewport.scrollX + viewport.width &&
+            centerY >= viewport.scrollY &&
+            centerY <= viewport.scrollY + viewport.height;
+
+          if (!isInViewport) {
+            // Scroll element into view
+            await this.sendCommand('DOM.scrollIntoViewIfNeeded', { backendNodeId: resolvedBackendNodeId });
+
+            // Wait for scroll animation to complete
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            // Get box model AGAIN after scrolling (element position has changed)
+            const updatedBoxModel = await this.sendCommand<any>('DOM.getBoxModel', { backendNodeId: resolvedBackendNodeId });
+            content = updatedBoxModel.model.content;
+
+            // Recalculate center coordinates with new position
+            centerX = (content[0] + content[2]) / 2;
+            centerY = (content[1] + content[5]) / 2;
+          }
+        } else {
+          // Visual effects disabled - still scroll into view if needed, but don't wait
+          await this.sendCommand('DOM.scrollIntoViewIfNeeded', { backendNodeId: resolvedBackendNodeId }).catch(() => { });
+        }
       }
 
       // CDP MIGRATION: Trigger ripple visual effect BEFORE click (with correct coordinates)

--- a/src/extension/tools/dom/__tests__/DomService.contentQuads.test.ts
+++ b/src/extension/tools/dom/__tests__/DomService.contentQuads.test.ts
@@ -105,5 +105,24 @@ describe('DomService getContentQuads targeting', () => {
       });
       await expect(service.resolveClickPointViaContentQuads(42)).rejects.toThrow('ELEMENT_NOT_VISIBLE');
     });
+
+    it('throws ELEMENT_NOT_VISIBLE for a zero-area (collapsed) element instead of clicking it', async () => {
+      // Degenerate quad (all points equal) → no visible intersection, zero area.
+      const service = await makeService('cq-8', (method) => {
+        if (method === 'Runtime.evaluate') return { result: { value: { width: 800, height: 600 } } };
+        if (method === 'DOM.getContentQuads') return { quads: [[100, 100, 100, 100, 100, 100, 100, 100]] };
+        return {};
+      });
+      await expect(service.resolveClickPointViaContentQuads(42)).rejects.toThrow('ELEMENT_NOT_VISIBLE');
+    });
+
+    it('throws when the viewport size cannot be read', async () => {
+      const service = await makeService('cq-9', (method) => {
+        if (method === 'Runtime.evaluate') return { result: { value: undefined } };
+        if (method === 'DOM.getContentQuads') return { quads: [[10, 10, 20, 10, 20, 20, 10, 20]] };
+        return {};
+      });
+      await expect(service.resolveClickPointViaContentQuads(42)).rejects.toThrow('ELEMENT_NOT_VISIBLE');
+    });
   });
 });

--- a/src/extension/tools/dom/__tests__/DomService.contentQuads.test.ts
+++ b/src/extension/tools/dom/__tests__/DomService.contentQuads.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DomService } from '../DomService';
+import type { DebuggerClient } from '../../../../core/tools/browser/DebuggerClient';
+
+/**
+ * Unit tests for the `useContentQuads` click-targeting path (design §3.4 / T07):
+ * viewport-relative quads, click the center of the quad∩viewport intersection,
+ * scroll-and-retry when off-screen. The helpers are exercised directly to avoid
+ * standing up a full snapshot.
+ */
+
+function mockClient(sendImpl: (method: string, params?: any) => any): DebuggerClient {
+  return {
+    attach: vi.fn().mockResolvedValue(undefined),
+    detach: vi.fn().mockResolvedValue(undefined),
+    isAttached: vi.fn().mockReturnValue(true),
+    sendCommand: vi.fn(sendImpl),
+    onEvent: vi.fn(),
+    offEvent: vi.fn(),
+    enableDomain: vi.fn().mockResolvedValue(undefined),
+    disableDomain: vi.fn().mockResolvedValue(undefined),
+    getTargetInfo: vi.fn().mockReturnValue(null),
+    getTabId: vi.fn().mockReturnValue(null),
+  } as unknown as DebuggerClient;
+}
+
+async function makeService(key: string, send: (method: string, params?: any) => any): Promise<any> {
+  const client = mockClient(send);
+  return DomService.forClient(client, key, { useContentQuads: true });
+}
+
+describe('DomService getContentQuads targeting', () => {
+  describe('pickVisibleQuadCenter', () => {
+    it('returns the center of a fully-visible quad', async () => {
+      const service = await makeService('cq-1', () => ({}));
+      const point = service.pickVisibleQuadCenter(
+        [[10, 20, 110, 20, 110, 70, 10, 70]],
+        { width: 1000, height: 1000 }
+      );
+      expect(point).toEqual({ x: 60, y: 45 });
+    });
+
+    it('clips to the viewport center for a partially-scrolled element', async () => {
+      const service = await makeService('cq-2', () => ({}));
+      // Quad spans y = -40..60; viewport height 100 → visible band 0..60 → center y 30.
+      const point = service.pickVisibleQuadCenter(
+        [[0, -40, 100, -40, 100, 60, 0, 60]],
+        { width: 1000, height: 100 }
+      );
+      expect(point).toEqual({ x: 50, y: 30 });
+    });
+
+    it('returns null when no quad intersects the viewport', async () => {
+      const service = await makeService('cq-3', () => ({}));
+      const point = service.pickVisibleQuadCenter(
+        [[2000, 2000, 2100, 2000, 2100, 2100, 2000, 2100]],
+        { width: 1000, height: 1000 }
+      );
+      expect(point).toBeNull();
+    });
+
+    it('picks the largest visible quad', async () => {
+      const service = await makeService('cq-4', () => ({}));
+      const small = [0, 0, 10, 0, 10, 10, 0, 10]; // area 100
+      const large = [0, 0, 100, 0, 100, 100, 0, 100]; // area 10000
+      const point = service.pickVisibleQuadCenter([small, large], { width: 1000, height: 1000 });
+      expect(point).toEqual({ x: 50, y: 50 });
+    });
+  });
+
+  describe('resolveClickPointViaContentQuads', () => {
+    it('uses getContentQuads + viewport intersection (no scroll offsets)', async () => {
+      const service = await makeService('cq-5', (method) => {
+        if (method === 'Runtime.evaluate') return { result: { value: { width: 800, height: 600 } } };
+        if (method === 'DOM.getContentQuads') return { quads: [[100, 100, 200, 100, 200, 150, 100, 150]] };
+        return {};
+      });
+      const point = await service.resolveClickPointViaContentQuads(42);
+      expect(point).toEqual({ x: 150, y: 125 });
+    });
+
+    it('scrolls into view and retries when the element is off-screen', async () => {
+      let quadCall = 0;
+      const send = vi.fn(async (method: string) => {
+        if (method === 'Runtime.evaluate') return { result: { value: { width: 800, height: 600 } } };
+        if (method === 'DOM.getContentQuads') {
+          quadCall++;
+          return quadCall === 1
+            ? { quads: [[100, 2000, 200, 2000, 200, 2050, 100, 2050]] } // off-screen
+            : { quads: [[100, 100, 200, 100, 200, 150, 100, 150]] }; // after scroll
+        }
+        return {};
+      });
+      const service = await makeService('cq-6', send as any);
+      const point = await service.resolveClickPointViaContentQuads(42);
+      expect(send).toHaveBeenCalledWith('DOM.scrollIntoViewIfNeeded', { backendNodeId: 42 });
+      expect(point).toEqual({ x: 150, y: 125 });
+    });
+
+    it('throws ELEMENT_NOT_VISIBLE when there are no quads', async () => {
+      const service = await makeService('cq-7', (method) => {
+        if (method === 'Runtime.evaluate') return { result: { value: { width: 800, height: 600 } } };
+        if (method === 'DOM.getContentQuads') return { quads: [] };
+        return {};
+      });
+      await expect(service.resolveClickPointViaContentQuads(42)).rejects.toThrow('ELEMENT_NOT_VISIBLE');
+    });
+  });
+});

--- a/src/extension/tools/dom/__tests__/DomService.test.ts
+++ b/src/extension/tools/dom/__tests__/DomService.test.ts
@@ -233,24 +233,16 @@ describe('DomService', () => {
       await service.detach();
     });
 
-    it('should remove chrome.debugger.onDetach listener if set', async () => {
-      // Setup chrome.debugger.onDetach mock
-      const removeListenerFn = vi.fn();
-      (globalThis as any).chrome = {
-        ...(globalThis as any).chrome,
-        debugger: {
-          onDetach: {
-            addListener: vi.fn(),
-            removeListener: removeListenerFn,
-          }
-        }
-      };
+    it('does not touch chrome.debugger.onDetach on the desktop forClient path', async () => {
+      // The registry owns the single chrome.debugger.onDetach listener for the
+      // forTab path; the desktop forClient path has no handle and must not
+      // register/remove chrome.debugger listeners directly.
       const client = createMockClient({ attached: true });
       const service = await DomService.forClient(client, 'detach-key-4');
-      // The setupEventListeners should have registered a listener
-      expect((service as any).boundHandleDebuggerDetach).not.toBeNull();
+      expect((service as any).handle).toBeNull();
+      expect((service as any).detachUnsubscribe).toBeNull();
       await service.detach();
-      expect(removeListenerFn).toHaveBeenCalled();
+      expect(client.detach).toHaveBeenCalled();
     });
   });
 
@@ -701,25 +693,17 @@ describe('DomService', () => {
   // handleDebuggerDetach
   // ==========================================================================
   describe('handleDebuggerDetach', () => {
-    it('should clean up on detach for matching tabId', async () => {
+    // The registry fans out detach already filtered to this tab, so the handler
+    // now takes only a reason (no source/tabId filtering of its own).
+    it('should clean up on detach', async () => {
       const client = createMockClient({ attached: true });
       const service = await DomService.forClient(client, 'dbg-detach-1');
       (service as any).tabId = 42;
       (service as any).currentSnapshot = { some: 'data' };
       const handler = (service as any).handleDebuggerDetach.bind(service);
-      handler({ tabId: 42 }, 'target_closed');
+      handler('target_closed');
       expect((service as any).isAttached).toBe(false);
       expect(service.getCurrentSnapshot()).toBeNull();
-    });
-
-    it('should ignore detach for non-matching tabId', async () => {
-      const client = createMockClient({ attached: true });
-      const service = await DomService.forClient(client, 'dbg-detach-2');
-      (service as any).tabId = 42;
-      (service as any).isAttached = true;
-      const handler = (service as any).handleDebuggerDetach.bind(service);
-      handler({ tabId: 99 }, 'target_closed');
-      expect((service as any).isAttached).toBe(true);
     });
 
     it('should log extra warning for unexpected detach reasons', async () => {
@@ -728,7 +712,7 @@ describe('DomService', () => {
       (service as any).tabId = 42;
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const handler = (service as any).handleDebuggerDetach.bind(service);
-      handler({ tabId: 42 }, 'crashed');
+      handler('crashed');
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Unexpected debugger detach'));
       warnSpy.mockRestore();
     });
@@ -739,7 +723,7 @@ describe('DomService', () => {
       (service as any).tabId = 42;
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const handler = (service as any).handleDebuggerDetach.bind(service);
-      handler({ tabId: 42 }, 'canceled_by_user');
+      handler('canceled_by_user');
       expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('Unexpected debugger detach'));
       warnSpy.mockRestore();
     });

--- a/src/extension/tools/dom/types.ts
+++ b/src/extension/tools/dom/types.ts
@@ -247,6 +247,13 @@ export interface ServiceConfig {
   snapshotTimeout: number;
   retryAttempts: number;
   enableMetrics?: boolean; // Enable performance metrics collection
+  /**
+   * Use DOM.getContentQuads (viewport-relative) for click targeting instead of
+   * DOM.getBoxModel. Fixes the scrolled-page in-viewport misclassification and
+   * supports inline/SVG/transformed elements. Default off pending dogfood;
+   * falls back to getBoxModel when off.
+   */
+  useContentQuads?: boolean;
 }
 
 // Performance metrics interface

--- a/src/extension/tools/input/InputDispatcher.ts
+++ b/src/extension/tools/input/InputDispatcher.ts
@@ -1,0 +1,140 @@
+/**
+ * InputDispatcher — correct CDP input synthesis.
+ *
+ * Stateless helpers that emit `Input.*` CDP events with the fields real
+ * browsers expect: proper `code`/`windowsVirtualKeyCode`/`text` for keys, and a
+ * `mouseMoved → mousePressed → mouseReleased` sequence with correct `buttons`
+ * bookkeeping for clicks. Takes a `send` function so it works against any
+ * target (tab or, later, an OOPIF).
+ *
+ * @module extension/tools/input/InputDispatcher
+ */
+
+import { getKeyDefinition } from './keyDefinitions';
+
+/** Sends a CDP command; satisfied by DomService/CoordinateActionService senders. */
+export type CdpSend = <T = unknown>(method: string, params: Record<string, unknown>) => Promise<T>;
+
+/** CDP modifier bitmask. */
+export const MODIFIER_BITS = { alt: 1, ctrl: 2, meta: 4, shift: 8 } as const;
+
+/** CDP mouse `buttons` bitmask (held buttons). */
+const BUTTON_MASK: Record<MouseButton, number> = { left: 1, right: 2, middle: 4 };
+
+export type MouseButton = 'left' | 'right' | 'middle';
+
+export interface ModifierFlags {
+  alt?: boolean;
+  ctrl?: boolean;
+  meta?: boolean;
+  shift?: boolean;
+}
+
+export interface DispatchKeyOptions {
+  /** CDP modifier bitmask (see {@link encodeModifiers}). */
+  modifiers?: number;
+}
+
+export interface ClickOptions {
+  button?: MouseButton;
+  clickCount?: number;
+  /** CDP modifier bitmask. */
+  modifiers?: number;
+}
+
+/** Encode modifier flags to the CDP bitmask (Alt=1, Ctrl=2, Meta=4, Shift=8). */
+export function encodeModifiers(flags?: ModifierFlags): number {
+  if (!flags) return 0;
+  let bits = 0;
+  if (flags.alt) bits |= MODIFIER_BITS.alt;
+  if (flags.ctrl) bits |= MODIFIER_BITS.ctrl;
+  if (flags.meta) bits |= MODIFIER_BITS.meta;
+  if (flags.shift) bits |= MODIFIER_BITS.shift;
+  return bits;
+}
+
+/**
+ * Dispatch a single key press (keyDown/rawKeyDown + keyUp) with correct
+ * `code`, `windowsVirtualKeyCode`, and `text` for printable keys.
+ */
+export async function dispatchKey(
+  send: CdpSend,
+  key: string,
+  options?: DispatchKeyOptions
+): Promise<void> {
+  const def = getKeyDefinition(key);
+  const modifiers = options?.modifiers ?? 0;
+
+  let text = def.text;
+  // With Shift held, a letter produces its uppercase character.
+  if (text && modifiers & MODIFIER_BITS.shift && /^[a-z]$/.test(text)) {
+    text = text.toUpperCase();
+  }
+  const isPrintable = text !== undefined;
+
+  const base: Record<string, unknown> = {
+    key: def.key,
+    code: def.code,
+    windowsVirtualKeyCode: def.keyCode,
+    nativeVirtualKeyCode: def.keyCode,
+    modifiers,
+  };
+  if (def.location !== undefined) base.location = def.location;
+
+  await send('Input.dispatchKeyEvent', {
+    // Printable keys produce a character event; non-text keys (navigation,
+    // modifiers) use rawKeyDown so no spurious text is inserted.
+    type: isPrintable ? 'keyDown' : 'rawKeyDown',
+    ...base,
+    ...(isPrintable ? { text } : {}),
+  });
+  await send('Input.dispatchKeyEvent', { type: 'keyUp', ...base });
+}
+
+/**
+ * Dispatch a mouse click as `mouseMoved → mousePressed → mouseReleased`. The
+ * leading move lets hover-gated controls (menus, row actions) react, and some
+ * frameworks gate `click` on a prior `mousemove`. `buttons` reflects currently
+ * held buttons: set on press, cleared on release.
+ */
+export async function click(send: CdpSend, x: number, y: number, options?: ClickOptions): Promise<void> {
+  const button = options?.button ?? 'left';
+  const clickCount = options?.clickCount ?? 1;
+  const modifiers = options?.modifiers ?? 0;
+  const heldButtons = BUTTON_MASK[button];
+
+  await send('Input.dispatchMouseEvent', {
+    type: 'mouseMoved',
+    x,
+    y,
+    button: 'none',
+    buttons: 0,
+    modifiers,
+    pointerType: 'mouse',
+  });
+  await send('Input.dispatchMouseEvent', {
+    type: 'mousePressed',
+    x,
+    y,
+    button,
+    buttons: heldButtons,
+    clickCount,
+    modifiers,
+    pointerType: 'mouse',
+  });
+  await send('Input.dispatchMouseEvent', {
+    type: 'mouseReleased',
+    x,
+    y,
+    button,
+    buttons: 0,
+    clickCount,
+    modifiers,
+    pointerType: 'mouse',
+  });
+}
+
+/** Insert text directly (fast path for bulk typing; not per-key synthesis). */
+export async function insertText(send: CdpSend, text: string): Promise<void> {
+  await send('Input.insertText', { text });
+}

--- a/src/extension/tools/input/InputDispatcher.ts
+++ b/src/extension/tools/input/InputDispatcher.ts
@@ -63,12 +63,18 @@ export async function dispatchKey(
   options?: DispatchKeyOptions
 ): Promise<void> {
   const def = getKeyDefinition(key);
-  const modifiers = options?.modifiers ?? 0;
+  let modifiers = options?.modifiers ?? 0;
 
   let text = def.text;
   // With Shift held, a letter produces its uppercase character.
   if (text && modifiers & MODIFIER_BITS.shift && /^[a-z]$/.test(text)) {
     text = text.toUpperCase();
+  }
+  // An already-uppercase letter implies Shift — encode it so the synthesized
+  // KeyboardEvent (event.shiftKey, code+shiftKey reconstruction) matches a real
+  // keystroke rather than reporting shiftKey:false for 'A'.
+  if (text && /^[A-Z]$/.test(text)) {
+    modifiers |= MODIFIER_BITS.shift;
   }
   const isPrintable = text !== undefined;
 
@@ -99,7 +105,7 @@ export async function dispatchKey(
  */
 export async function click(send: CdpSend, x: number, y: number, options?: ClickOptions): Promise<void> {
   const button = options?.button ?? 'left';
-  const clickCount = options?.clickCount ?? 1;
+  const clickCount = Math.max(1, options?.clickCount ?? 1);
   const modifiers = options?.modifiers ?? 0;
   const heldButtons = BUTTON_MASK[button];
 
@@ -112,26 +118,33 @@ export async function click(send: CdpSend, x: number, y: number, options?: Click
     modifiers,
     pointerType: 'mouse',
   });
-  await send('Input.dispatchMouseEvent', {
-    type: 'mousePressed',
-    x,
-    y,
-    button,
-    buttons: heldButtons,
-    clickCount,
-    modifiers,
-    pointerType: 'mouse',
-  });
-  await send('Input.dispatchMouseEvent', {
-    type: 'mouseReleased',
-    x,
-    y,
-    button,
-    buttons: 0,
-    clickCount,
-    modifiers,
-    pointerType: 'mouse',
-  });
+
+  // A double-click is NOT one press/release with clickCount:2 — the renderer
+  // derives `dblclick` only after observing successive click cycles with an
+  // incrementing clickCount. So emit `clickCount` full press/release cycles
+  // (count 1, then 2, …), matching Puppeteer/Playwright.
+  for (let n = 1; n <= clickCount; n++) {
+    await send('Input.dispatchMouseEvent', {
+      type: 'mousePressed',
+      x,
+      y,
+      button,
+      buttons: heldButtons,
+      clickCount: n,
+      modifiers,
+      pointerType: 'mouse',
+    });
+    await send('Input.dispatchMouseEvent', {
+      type: 'mouseReleased',
+      x,
+      y,
+      button,
+      buttons: 0,
+      clickCount: n,
+      modifiers,
+      pointerType: 'mouse',
+    });
+  }
 }
 
 /** Insert text directly (fast path for bulk typing; not per-key synthesis). */

--- a/src/extension/tools/input/InputDispatcher.ts
+++ b/src/extension/tools/input/InputDispatcher.ts
@@ -10,7 +10,7 @@
  * @module extension/tools/input/InputDispatcher
  */
 
-import { getKeyDefinition } from './keyDefinitions';
+import { getKeyDefinition, SHIFTED_CHARS } from './keyDefinitions';
 
 /** Sends a CDP command; satisfied by DomService/CoordinateActionService senders. */
 export type CdpSend = <T = unknown>(method: string, params: Record<string, unknown>) => Promise<T>;
@@ -70,10 +70,11 @@ export async function dispatchKey(
   if (text && modifiers & MODIFIER_BITS.shift && /^[a-z]$/.test(text)) {
     text = text.toUpperCase();
   }
-  // An already-uppercase letter implies Shift — encode it so the synthesized
-  // KeyboardEvent (event.shiftKey, code+shiftKey reconstruction) matches a real
-  // keystroke rather than reporting shiftKey:false for 'A'.
-  if (text && /^[A-Z]$/.test(text)) {
+  // A character that requires Shift on a US layout (uppercase letter, or a
+  // shifted symbol like '?', '!', '~') implies Shift — encode it so the
+  // synthesized KeyboardEvent (event.shiftKey, code+shiftKey reconstruction)
+  // matches a real keystroke rather than reporting shiftKey:false.
+  if (text && (/^[A-Z]$/.test(text) || SHIFTED_CHARS.has(text))) {
     modifiers |= MODIFIER_BITS.shift;
   }
   const isPrintable = text !== undefined;

--- a/src/extension/tools/input/__tests__/InputDispatcher.test.ts
+++ b/src/extension/tools/input/__tests__/InputDispatcher.test.ts
@@ -99,10 +99,37 @@ describe('click', () => {
     }));
   });
 
-  it('supports right-click and double-click', async () => {
+  it('supports right-click', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
-    await click(send, 1, 2, { button: 'right', clickCount: 2 });
-    expect(send.mock.calls[1][1]).toMatchObject({ button: 'right', buttons: 2, clickCount: 2 });
-    expect(send.mock.calls[2][1]).toMatchObject({ button: 'right', buttons: 0, clickCount: 2 });
+    await click(send, 1, 2, { button: 'right' });
+    expect(send.mock.calls[1][1]).toMatchObject({ type: 'mousePressed', button: 'right', buttons: 2, clickCount: 1 });
+    expect(send.mock.calls[2][1]).toMatchObject({ type: 'mouseReleased', button: 'right', buttons: 0, clickCount: 1 });
+  });
+
+  it('double-click emits two full press/release cycles with incrementing clickCount', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await click(send, 1, 2, { clickCount: 2 });
+    // mouseMoved, press(1), release(1), press(2), release(2)
+    expect(send).toHaveBeenCalledTimes(5);
+    expect(send.mock.calls[0][1]).toMatchObject({ type: 'mouseMoved' });
+    expect(send.mock.calls[1][1]).toMatchObject({ type: 'mousePressed', clickCount: 1 });
+    expect(send.mock.calls[2][1]).toMatchObject({ type: 'mouseReleased', clickCount: 1 });
+    expect(send.mock.calls[3][1]).toMatchObject({ type: 'mousePressed', clickCount: 2 });
+    expect(send.mock.calls[4][1]).toMatchObject({ type: 'mouseReleased', clickCount: 2 });
+  });
+});
+
+describe('keyDefinitions punctuation + dispatchKey shift', () => {
+  it('maps punctuation to a real code + virtual key code (not ASCII)', () => {
+    expect(getKeyDefinition('.')).toMatchObject({ code: 'Period', keyCode: 190, text: '.' });
+    expect(getKeyDefinition('/')).toMatchObject({ code: 'Slash', keyCode: 191, text: '/' });
+    // No bogus ASCII-derived keyCode (e.g. '.' must not be 46 = VK_DELETE).
+    expect(getKeyDefinition('.').keyCode).not.toBe(46);
+  });
+
+  it('encodes the Shift modifier for an already-uppercase letter', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await dispatchKey(send, 'A');
+    expect(send.mock.calls[0][1]).toMatchObject({ type: 'keyDown', text: 'A', modifiers: MODIFIER_BITS.shift });
   });
 });

--- a/src/extension/tools/input/__tests__/InputDispatcher.test.ts
+++ b/src/extension/tools/input/__tests__/InputDispatcher.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getKeyDefinition } from '../keyDefinitions';
+import { dispatchKey, click, encodeModifiers, MODIFIER_BITS } from '../InputDispatcher';
+
+describe('getKeyDefinition', () => {
+  it('maps Enter with text and keyCode 13', () => {
+    expect(getKeyDefinition('Enter')).toMatchObject({ code: 'Enter', keyCode: 13, text: '\r' });
+  });
+
+  it('maps Tab with keyCode 9 and no text', () => {
+    const def = getKeyDefinition('Tab');
+    expect(def).toMatchObject({ code: 'Tab', keyCode: 9 });
+    expect(def.text).toBeUndefined();
+  });
+
+  it('maps lowercase and uppercase letters to KeyA / keyCode 65', () => {
+    expect(getKeyDefinition('a')).toMatchObject({ code: 'KeyA', keyCode: 65, text: 'a' });
+    expect(getKeyDefinition('A')).toMatchObject({ code: 'KeyA', keyCode: 65, text: 'A' });
+  });
+
+  it('maps digits to DigitN', () => {
+    expect(getKeyDefinition('1')).toMatchObject({ code: 'Digit1', keyCode: 49, text: '1' });
+  });
+
+  it('maps navigation keys without text', () => {
+    expect(getKeyDefinition('ArrowDown')).toMatchObject({ code: 'ArrowDown', keyCode: 40 });
+    expect(getKeyDefinition('ArrowDown').text).toBeUndefined();
+  });
+
+  it('resolves aliases', () => {
+    expect(getKeyDefinition('Esc').code).toBe('Escape');
+    expect(getKeyDefinition('Up').code).toBe('ArrowUp');
+    expect(getKeyDefinition('Return').code).toBe('Enter');
+  });
+
+  it('maps function keys', () => {
+    expect(getKeyDefinition('F5')).toMatchObject({ code: 'F5', keyCode: 116 });
+    expect(getKeyDefinition('F12')).toMatchObject({ code: 'F12', keyCode: 123 });
+  });
+
+  it('never produces the legacy KeyENTER-style code', () => {
+    expect(getKeyDefinition('Enter').code).not.toBe('KeyENTER');
+    expect(getKeyDefinition('Tab').code).not.toBe('KeyTAB');
+  });
+});
+
+describe('encodeModifiers', () => {
+  it('encodes the CDP bitmask', () => {
+    expect(encodeModifiers()).toBe(0);
+    expect(encodeModifiers({ ctrl: true })).toBe(MODIFIER_BITS.ctrl);
+    expect(encodeModifiers({ alt: true, shift: true })).toBe(MODIFIER_BITS.alt | MODIFIER_BITS.shift);
+  });
+});
+
+describe('dispatchKey', () => {
+  it('sends keyDown with text + windowsVirtualKeyCode then keyUp for a printable key', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await dispatchKey(send, 'Enter');
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', expect.objectContaining({
+      type: 'keyDown', key: 'Enter', code: 'Enter', windowsVirtualKeyCode: 13, text: '\r',
+    }));
+    expect(send).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', expect.objectContaining({
+      type: 'keyUp', code: 'Enter', windowsVirtualKeyCode: 13,
+    }));
+  });
+
+  it('uses rawKeyDown with no text for navigation keys', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await dispatchKey(send, 'ArrowDown');
+    const first = send.mock.calls[0][1];
+    expect(first.type).toBe('rawKeyDown');
+    expect(first.text).toBeUndefined();
+    expect(first.windowsVirtualKeyCode).toBe(40);
+  });
+
+  it('uppercases a letter when Shift is held', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await dispatchKey(send, 'a', { modifiers: MODIFIER_BITS.shift });
+    expect(send.mock.calls[0][1]).toMatchObject({ type: 'keyDown', text: 'A' });
+  });
+});
+
+describe('click', () => {
+  it('emits mouseMoved → mousePressed → mouseReleased with correct buttons', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await click(send, 10, 20);
+
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(send).toHaveBeenNthCalledWith(1, 'Input.dispatchMouseEvent', expect.objectContaining({
+      type: 'mouseMoved', x: 10, y: 20, button: 'none', buttons: 0,
+    }));
+    expect(send).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', expect.objectContaining({
+      type: 'mousePressed', button: 'left', buttons: 1, clickCount: 1,
+    }));
+    expect(send).toHaveBeenNthCalledWith(3, 'Input.dispatchMouseEvent', expect.objectContaining({
+      type: 'mouseReleased', button: 'left', buttons: 0, clickCount: 1,
+    }));
+  });
+
+  it('supports right-click and double-click', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await click(send, 1, 2, { button: 'right', clickCount: 2 });
+    expect(send.mock.calls[1][1]).toMatchObject({ button: 'right', buttons: 2, clickCount: 2 });
+    expect(send.mock.calls[2][1]).toMatchObject({ button: 'right', buttons: 0, clickCount: 2 });
+  });
+});

--- a/src/extension/tools/input/__tests__/InputDispatcher.test.ts
+++ b/src/extension/tools/input/__tests__/InputDispatcher.test.ts
@@ -132,4 +132,23 @@ describe('keyDefinitions punctuation + dispatchKey shift', () => {
     await dispatchKey(send, 'A');
     expect(send.mock.calls[0][1]).toMatchObject({ type: 'keyDown', text: 'A', modifiers: MODIFIER_BITS.shift });
   });
+
+  it('maps shifted number-row symbols to the digit code and encodes Shift', async () => {
+    expect(getKeyDefinition('!')).toMatchObject({ code: 'Digit1', keyCode: 49, text: '!' });
+    const send = vi.fn().mockResolvedValue(undefined);
+    await dispatchKey(send, '!');
+    expect(send.mock.calls[0][1]).toMatchObject({ type: 'keyDown', code: 'Digit1', modifiers: MODIFIER_BITS.shift });
+  });
+
+  it('encodes Shift for a shifted punctuation symbol', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await dispatchKey(send, '?');
+    expect(send.mock.calls[0][1]).toMatchObject({ type: 'keyDown', code: 'Slash', modifiers: MODIFIER_BITS.shift });
+  });
+
+  it('does not encode Shift for an unshifted symbol', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await dispatchKey(send, '/');
+    expect(send.mock.calls[0][1]).toMatchObject({ type: 'keyDown', code: 'Slash', modifiers: 0 });
+  });
 });

--- a/src/extension/tools/input/keyDefinitions.ts
+++ b/src/extension/tools/input/keyDefinitions.ts
@@ -73,6 +73,21 @@ const ALIASES: Record<string, string> = {
 const A_CODE = 'a'.charCodeAt(0);
 const Z_CODE = 'z'.charCodeAt(0);
 
+/** US punctuation → physical `code` + Windows virtual key code. */
+const PUNCTUATION: Record<string, { code: string; keyCode: number }> = {
+  '`': { code: 'Backquote', keyCode: 192 }, '~': { code: 'Backquote', keyCode: 192 },
+  '-': { code: 'Minus', keyCode: 189 }, '_': { code: 'Minus', keyCode: 189 },
+  '=': { code: 'Equal', keyCode: 187 }, '+': { code: 'Equal', keyCode: 187 },
+  '[': { code: 'BracketLeft', keyCode: 219 }, '{': { code: 'BracketLeft', keyCode: 219 },
+  ']': { code: 'BracketRight', keyCode: 221 }, '}': { code: 'BracketRight', keyCode: 221 },
+  '\\': { code: 'Backslash', keyCode: 220 }, '|': { code: 'Backslash', keyCode: 220 },
+  ';': { code: 'Semicolon', keyCode: 186 }, ':': { code: 'Semicolon', keyCode: 186 },
+  "'": { code: 'Quote', keyCode: 222 }, '"': { code: 'Quote', keyCode: 222 },
+  ',': { code: 'Comma', keyCode: 188 }, '<': { code: 'Comma', keyCode: 188 },
+  '.': { code: 'Period', keyCode: 190 }, '>': { code: 'Period', keyCode: 190 },
+  '/': { code: 'Slash', keyCode: 191 }, '?': { code: 'Slash', keyCode: 191 },
+};
+
 /**
  * Resolve a key string to its CDP definition. Handles named keys, aliases,
  * function keys (F1–F24), single letters/digits, and falls back to treating an
@@ -101,9 +116,14 @@ export function getKeyDefinition(key: string): KeyDefinition {
     if (ch >= '0' && ch <= '9') {
       return { key: ch, code: `Digit${ch}`, keyCode: ch.charCodeAt(0), text: ch };
     }
-    // Other printable single character (punctuation/symbols): provide text so
-    // it inserts; we don't model a precise physical code for every symbol.
-    return { key: ch, code: '', keyCode: ch.toUpperCase().charCodeAt(0), text: ch };
+    const punct = PUNCTUATION[ch];
+    if (punct) {
+      return { key: ch, code: punct.code, keyCode: punct.keyCode, text: ch };
+    }
+    // Other printable single character: provide text so it inserts. We don't
+    // model a physical code for it, and we deliberately emit keyCode:0 rather
+    // than a wrong virtual key code derived from the character's ASCII value.
+    return { key: ch, code: '', keyCode: 0, text: ch };
   }
 
   // Unknown multi-char key: pass through with no virtual code.

--- a/src/extension/tools/input/keyDefinitions.ts
+++ b/src/extension/tools/input/keyDefinitions.ts
@@ -86,7 +86,24 @@ const PUNCTUATION: Record<string, { code: string; keyCode: number }> = {
   ',': { code: 'Comma', keyCode: 188 }, '<': { code: 'Comma', keyCode: 188 },
   '.': { code: 'Period', keyCode: 190 }, '>': { code: 'Period', keyCode: 190 },
   '/': { code: 'Slash', keyCode: 191 }, '?': { code: 'Slash', keyCode: 191 },
+  // Shifted number-row symbols share the digit's physical code.
+  '!': { code: 'Digit1', keyCode: 49 }, '@': { code: 'Digit2', keyCode: 50 },
+  '#': { code: 'Digit3', keyCode: 51 }, '$': { code: 'Digit4', keyCode: 52 },
+  '%': { code: 'Digit5', keyCode: 53 }, '^': { code: 'Digit6', keyCode: 54 },
+  '&': { code: 'Digit7', keyCode: 55 }, '*': { code: 'Digit8', keyCode: 56 },
+  '(': { code: 'Digit9', keyCode: 57 }, ')': { code: 'Digit0', keyCode: 48 },
 };
+
+/**
+ * Characters that require Shift on a US layout. Dispatching these should encode
+ * the Shift modifier so the synthesized KeyboardEvent matches a real keystroke
+ * (event.shiftKey true), like the uppercase-letter path. Uppercase A–Z are
+ * handled separately by a regex.
+ */
+export const SHIFTED_CHARS = new Set([
+  '~', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+',
+  '{', '}', '|', ':', '"', '<', '>', '?',
+]);
 
 /**
  * Resolve a key string to its CDP definition. Handles named keys, aliases,

--- a/src/extension/tools/input/keyDefinitions.ts
+++ b/src/extension/tools/input/keyDefinitions.ts
@@ -1,0 +1,111 @@
+/**
+ * US-keyboard key-definition table.
+ *
+ * Maps a `key` value (as supplied by the agent — e.g. "Enter", "ArrowDown",
+ * "a", "1") to the fields CDP's `Input.dispatchKeyEvent` needs: a correct
+ * `code`, a `windowsVirtualKeyCode` (so `KeyboardEvent.keyCode`/`which` is
+ * populated for legacy handlers), and `text` for printable keys.
+ *
+ * This replaces the previous `code: \`Key${key.toUpperCase()}\`` defect, which
+ * produced invalid codes like `KeyENTER`/`KeyTAB` and sent no virtual key code
+ * or text — so many pages ignored synthesized keypresses entirely.
+ *
+ * Shape ported from Puppeteer's USKeyboardLayout (Apache-2.0).
+ *
+ * @module extension/tools/input/keyDefinitions
+ */
+
+export interface KeyDefinition {
+  /** `KeyboardEvent.key` value. */
+  key: string;
+  /** `KeyboardEvent.code` value (physical key). */
+  code: string;
+  /** Windows virtual key code → CDP `windowsVirtualKeyCode`. */
+  keyCode: number;
+  /** Character produced, when printable. Presence marks the key as text-producing. */
+  text?: string;
+  /** `KeyboardEvent.location` (1 = left modifier, 3 = numpad). */
+  location?: number;
+}
+
+/** Named / non-printable keys and aliases the agent commonly supplies. */
+const NAMED_KEYS: Record<string, KeyDefinition> = {
+  Enter: { key: 'Enter', code: 'Enter', keyCode: 13, text: '\r' },
+  NumpadEnter: { key: 'Enter', code: 'NumpadEnter', keyCode: 13, text: '\r', location: 3 },
+  Tab: { key: 'Tab', code: 'Tab', keyCode: 9 },
+  Backspace: { key: 'Backspace', code: 'Backspace', keyCode: 8 },
+  Delete: { key: 'Delete', code: 'Delete', keyCode: 46 },
+  Escape: { key: 'Escape', code: 'Escape', keyCode: 27 },
+  ArrowUp: { key: 'ArrowUp', code: 'ArrowUp', keyCode: 38 },
+  ArrowDown: { key: 'ArrowDown', code: 'ArrowDown', keyCode: 40 },
+  ArrowLeft: { key: 'ArrowLeft', code: 'ArrowLeft', keyCode: 37 },
+  ArrowRight: { key: 'ArrowRight', code: 'ArrowRight', keyCode: 39 },
+  Home: { key: 'Home', code: 'Home', keyCode: 36 },
+  End: { key: 'End', code: 'End', keyCode: 35 },
+  PageUp: { key: 'PageUp', code: 'PageUp', keyCode: 33 },
+  PageDown: { key: 'PageDown', code: 'PageDown', keyCode: 34 },
+  Insert: { key: 'Insert', code: 'Insert', keyCode: 45 },
+  ' ': { key: ' ', code: 'Space', keyCode: 32, text: ' ' },
+  // Modifiers (left variants).
+  Shift: { key: 'Shift', code: 'ShiftLeft', keyCode: 16, location: 1 },
+  Control: { key: 'Control', code: 'ControlLeft', keyCode: 17, location: 1 },
+  Alt: { key: 'Alt', code: 'AltLeft', keyCode: 18, location: 1 },
+  Meta: { key: 'Meta', code: 'MetaLeft', keyCode: 91, location: 1 },
+};
+
+/** Friendly aliases → canonical key names. */
+const ALIASES: Record<string, string> = {
+  Esc: 'Escape',
+  Del: 'Delete',
+  Space: ' ',
+  Spacebar: ' ',
+  Up: 'ArrowUp',
+  Down: 'ArrowDown',
+  Left: 'ArrowLeft',
+  Right: 'ArrowRight',
+  Ctrl: 'Control',
+  Command: 'Meta',
+  Cmd: 'Meta',
+  Win: 'Meta',
+  Return: 'Enter',
+};
+
+const A_CODE = 'a'.charCodeAt(0);
+const Z_CODE = 'z'.charCodeAt(0);
+
+/**
+ * Resolve a key string to its CDP definition. Handles named keys, aliases,
+ * function keys (F1–F24), single letters/digits, and falls back to treating an
+ * unknown single character as printable text.
+ */
+export function getKeyDefinition(key: string): KeyDefinition {
+  const canonical = ALIASES[key] ?? key;
+  const named = NAMED_KEYS[canonical];
+  if (named) return named;
+
+  // Function keys F1–F24 → keyCode 112–135.
+  const fnMatch = /^F([1-9]|1[0-9]|2[0-4])$/.exec(canonical);
+  if (fnMatch) {
+    const n = Number(fnMatch[1]);
+    return { key: canonical, code: canonical, keyCode: 111 + n };
+  }
+
+  if (canonical.length === 1) {
+    const ch = canonical;
+    const lower = ch.toLowerCase();
+    const lc = lower.charCodeAt(0);
+    if (lc >= A_CODE && lc <= Z_CODE) {
+      const letter = lower.toUpperCase();
+      return { key: ch, code: `Key${letter}`, keyCode: lower.toUpperCase().charCodeAt(0), text: ch };
+    }
+    if (ch >= '0' && ch <= '9') {
+      return { key: ch, code: `Digit${ch}`, keyCode: ch.charCodeAt(0), text: ch };
+    }
+    // Other printable single character (punctuation/symbols): provide text so
+    // it inserts; we don't model a precise physical code for every symbol.
+    return { key: ch, code: '', keyCode: ch.toUpperCase().charCodeAt(0), text: ch };
+  }
+
+  // Unknown multi-char key: pass through with no virtual code.
+  return { key: canonical, code: canonical, keyCode: 0 };
+}

--- a/src/extension/tools/registerExtensionTools.ts
+++ b/src/extension/tools/registerExtensionTools.ts
@@ -21,6 +21,7 @@ import { DOMTool } from './DOMTool';
 import { NavigationTool } from './NavigationTool';
 import { StorageTool } from './StorageTool';
 import { PageVisionTool } from './PageVisionTool';
+import { ViewportTool } from './ViewportTool';
 
 // Cross-platform tools (also used in extension)
 import { PlanningTool } from '../../tools/PlanningTool';
@@ -328,6 +329,23 @@ export async function registerExtensionTools(
         console.log(`PageVisionTool disabled: Model "${modelConfig.name}" does not support image input`);
       }
     }
+
+    // ── browser_viewport ────────────────────────────────────────────────
+    await registerTool('viewport_tool', new ViewportTool(), {
+      riskAssessor: staticRiskAssessor,
+      runtime: {
+        concurrency: {
+          // set/reset mutate emulation state — not concurrency-safe.
+          isConcurrencySafe: () => false,
+          isReadOnly: () => false,
+          isDestructive: () => false,
+        },
+        ui: {
+          getActivityDescription: (input) =>
+            input.action === 'reset' ? 'Resetting viewport' : 'Setting viewport',
+        },
+      },
+    });
 
     // ── planning_tool ───────────────────────────────────────────────────
     try {

--- a/src/extension/tools/screenshot/CoordinateActionService.ts
+++ b/src/extension/tools/screenshot/CoordinateActionService.ts
@@ -196,6 +196,16 @@ export class CoordinateActionService {
   }
 
   /**
+   * Public viewport size via the shared debugger session (CSS pixels). Used by
+   * page_vision coordinate validation so it routes through the acquired handle
+   * instead of a separate raw chrome.debugger call.
+   */
+  async getViewportSize(): Promise<{ width: number; height: number }> {
+    const { width, height } = await this.getViewportBounds();
+    return { width, height };
+  }
+
+  /**
    * Get current viewport bounds
    */
   private async getViewportBounds(): Promise<{

--- a/src/extension/tools/screenshot/CoordinateActionService.ts
+++ b/src/extension/tools/screenshot/CoordinateActionService.ts
@@ -6,10 +6,14 @@
  */
 
 import type { Coordinates, KeyModifiers, CoordinateActionOptions } from './types';
+import { getDebuggerSessionRegistry } from '../browser/ChromeDebuggerSessionRegistry';
+import type { DebuggerHandle } from '@/core/tools/browser/DebuggerSessionRegistry';
 
 export class CoordinateActionService {
   private tabId: number;
   private sendCommand: <T = any>(method: string, params?: any) => Promise<T>;
+  /** Shared debugger session reference, when created via forTab(). */
+  private handle: DebuggerHandle | null = null;
 
   constructor(
     tabId: number,
@@ -209,46 +213,28 @@ export class CoordinateActionService {
   }
 
   /**
-   * Create CoordinateActionService for a specific tab
-   * Uses chrome.debugger to send CDP commands
+   * Create CoordinateActionService for a specific tab.
+   *
+   * Acquires a shared, refcounted debugger session from the registry instead of
+   * attaching independently (the old `Runtime.evaluate('1+1')` probe raced with
+   * other services and never detached). Callers MUST {@link release} the service
+   * when done; page_vision acquires once per action.
    */
   static async forTab(tabId: number): Promise<CoordinateActionService> {
-    // Check if debugger is already attached
-    let isAttached = false;
-    try {
-      await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
-        expression: '1+1',
-        returnByValue: true
-      });
-      isAttached = true;
-    } catch (error: any) {
-      // Debugger not attached - will attach below
-      isAttached = false;
-    }
+    const handle = await getDebuggerSessionRegistry().acquire(tabId);
 
-    // Attach debugger if not already attached
-    if (!isAttached) {
-      try {
-        await chrome.debugger.attach({ tabId }, '1.3');
-      } catch (error: any) {
-        console.error(`[CoordinateActionService] Failed to attach debugger to tab ${tabId}:`, error);
+    const sendCommand = <T = any>(method: string, params?: any): Promise<T> =>
+      handle.sendCommand<T>(method, params);
 
-        // Check for common errors
-        if (error.message?.includes('Another debugger is already attached')) {
-          // Debugger is attached by another process (DevTools, DomService, etc.) - this is OK
-        } else if (error.message?.includes('Cannot access')) {
-          throw new Error(`CDP_CONNECTION_LOST: Cannot attach debugger to tab ${tabId}. Tab may be a protected page (chrome://, chrome-extension://, etc.)`);
-        } else {
-          throw new Error(`CDP_CONNECTION_LOST: Failed to attach debugger to tab ${tabId}: ${error.message}`);
-        }
-      }
-    }
+    const service = new CoordinateActionService(tabId, sendCommand);
+    service.handle = handle;
+    return service;
+  }
 
-    // Create send command wrapper
-    const sendCommand = async <T = any>(method: string, params?: any): Promise<T> => {
-      return await chrome.debugger.sendCommand({ tabId }, method, params) as T;
-    };
-
-    return new CoordinateActionService(tabId, sendCommand);
+  /** Release this service's reference to the shared debugger session. */
+  async release(): Promise<void> {
+    const handle = this.handle;
+    this.handle = null;
+    await handle?.release();
   }
 }

--- a/src/extension/tools/screenshot/CoordinateActionService.ts
+++ b/src/extension/tools/screenshot/CoordinateActionService.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Coordinates, KeyModifiers, CoordinateActionOptions } from './types';
-import { dispatchKey } from '../input/InputDispatcher';
+import { dispatchKey, click as dispatchClick } from '../input/InputDispatcher';
 
 export class CoordinateActionService {
   private tabId: number;
@@ -35,24 +35,12 @@ export class CoordinateActionService {
       const clickCount = options?.clickCount || 1;
       const modifiers = this.encodeModifiers(options?.modifiers);
 
-      // Dispatch mouse pressed event
-      await this.sendCommand('Input.dispatchMouseEvent', {
-        type: 'mousePressed',
-        x: coordinates.x,
-        y: coordinates.y,
+      // Route through the shared dispatcher: mouseMoved -> mousePressed ->
+      // mouseReleased with correct `buttons` bookkeeping.
+      await dispatchClick((method, params) => this.sendCommand(method, params), coordinates.x, coordinates.y, {
         button,
         clickCount,
-        modifiers
-      });
-
-      // Dispatch mouse released event
-      await this.sendCommand('Input.dispatchMouseEvent', {
-        type: 'mouseReleased',
-        x: coordinates.x,
-        y: coordinates.y,
-        button,
-        clickCount,
-        modifiers
+        modifiers,
       });
 
       // Wait after action if specified

--- a/src/extension/tools/screenshot/CoordinateActionService.ts
+++ b/src/extension/tools/screenshot/CoordinateActionService.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Coordinates, KeyModifiers, CoordinateActionOptions } from './types';
+import { dispatchKey } from '../input/InputDispatcher';
 
 export class CoordinateActionService {
   private tabId: number;
@@ -150,21 +151,8 @@ export class CoordinateActionService {
     try {
       const modifiers = this.encodeModifiers(options?.modifiers);
 
-      // Dispatch key down event
-      await this.sendCommand('Input.dispatchKeyEvent', {
-        type: 'keyDown',
-        key,
-        code: `Key${key.toUpperCase()}`,
-        modifiers
-      });
-
-      // Dispatch key up event
-      await this.sendCommand('Input.dispatchKeyEvent', {
-        type: 'keyUp',
-        key,
-        code: `Key${key.toUpperCase()}`,
-        modifiers
-      });
+      // Correct key synthesis via the shared dispatcher (real code/keyCode/text).
+      await dispatchKey((method, params) => this.sendCommand(method, params), key, { modifiers });
 
       // Wait after action if specified
       if (options?.waitAfter) {

--- a/src/extension/tools/screenshot/ScreenshotService.ts
+++ b/src/extension/tools/screenshot/ScreenshotService.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ScreenshotCaptureOptions, ViewportBounds, ScrollOffset } from './types';
+import { downscalePngToCssPixels } from './downscale';
 
 export class ScreenshotService {
   private tabId: number;
@@ -30,18 +31,22 @@ export class ScreenshotService {
     viewport: ViewportBounds;
   }> {
     try {
-      // Get viewport bounds before capture
-      const viewport = await this.getViewportBounds();
+      // Get viewport bounds (+ DPR) before capture
+      const { devicePixelRatio, ...viewport } = await this.getViewportBounds();
 
-      // Capture screenshot using CDP
+      // Capture screenshot using CDP (device pixels)
       const screenshot = await this.sendCommand<{ data: string }>('Page.captureScreenshot', {
         format: options?.format || 'png',
         quality: options?.quality,
         captureBeyondViewport: false // Only capture visible viewport
       });
 
+      // Downscale to CSS pixels so the image the model sees matches the
+      // coordinate space clicks are dispatched in (no-op when DPR == 1).
+      const base64Data = await downscalePngToCssPixels(screenshot.data, devicePixelRatio);
+
       return {
-        base64Data: screenshot.data,
+        base64Data,
         viewport
       };
     } catch (error: any) {
@@ -101,19 +106,20 @@ export class ScreenshotService {
   /**
    * Get current viewport bounds
    */
-  private async getViewportBounds(): Promise<ViewportBounds> {
+  private async getViewportBounds(): Promise<ViewportBounds & { devicePixelRatio: number }> {
     const result = await this.sendCommand<any>('Runtime.evaluate', {
-      expression: '({ width: window.innerWidth, height: window.innerHeight, scroll_x: window.scrollX, scroll_y: window.scrollY })',
+      expression: '({ width: window.innerWidth, height: window.innerHeight, scroll_x: window.scrollX, scroll_y: window.scrollY, device_pixel_ratio: window.devicePixelRatio })',
       returnByValue: true
     });
 
-    const { width, height, scroll_x, scroll_y } = result.result.value;
+    const { width, height, scroll_x, scroll_y, device_pixel_ratio } = result.result.value;
 
     return {
       width,
       height,
       scroll_x,
-      scroll_y
+      scroll_y,
+      devicePixelRatio: device_pixel_ratio ?? 1
     };
   }
 

--- a/src/extension/tools/screenshot/ScreenshotService.ts
+++ b/src/extension/tools/screenshot/ScreenshotService.ts
@@ -35,15 +35,20 @@ export class ScreenshotService {
       const { devicePixelRatio, ...viewport } = await this.getViewportBounds();
 
       // Capture screenshot using CDP (device pixels)
+      const format = options?.format || 'png';
       const screenshot = await this.sendCommand<{ data: string }>('Page.captureScreenshot', {
-        format: options?.format || 'png',
+        format,
         quality: options?.quality,
         captureBeyondViewport: false // Only capture visible viewport
       });
 
       // Downscale to CSS pixels so the image the model sees matches the
       // coordinate space clicks are dispatched in (no-op when DPR == 1).
-      const base64Data = await downscalePngToCssPixels(screenshot.data, devicePixelRatio);
+      // Preserve the requested image format when re-encoding.
+      const base64Data = await downscalePngToCssPixels(screenshot.data, devicePixelRatio, {
+        mimeType: `image/${format}`,
+        quality: options?.quality != null ? options.quality / 100 : undefined,
+      });
 
       return {
         base64Data,

--- a/src/extension/tools/screenshot/ScreenshotService.ts
+++ b/src/extension/tools/screenshot/ScreenshotService.ts
@@ -5,10 +5,14 @@
  */
 
 import type { ScreenshotCaptureOptions, ViewportBounds, ScrollOffset } from './types';
+import { getDebuggerSessionRegistry } from '../browser/ChromeDebuggerSessionRegistry';
+import type { DebuggerHandle } from '@/core/tools/browser/DebuggerSessionRegistry';
 
 export class ScreenshotService {
   private tabId: number;
   private sendCommand: <T = any>(method: string, params?: any) => Promise<T>;
+  /** Shared debugger session reference, when created via forTab(). */
+  private handle: DebuggerHandle | null = null;
 
   constructor(
     tabId: number,
@@ -118,54 +122,37 @@ export class ScreenshotService {
   }
 
   /**
-   * Create ScreenshotService for a specific tab
-   * Uses chrome.debugger to send CDP commands
+   * Create ScreenshotService for a specific tab.
+   *
+   * Acquires a shared, refcounted debugger session from the registry instead of
+   * attaching independently (which previously raced with DomService/page_vision
+   * via a `Runtime.evaluate('1+1')` probe and never detached). Callers MUST
+   * {@link release} the service when done; page_vision acquires once per action.
    */
   static async forTab(tabId: number): Promise<ScreenshotService> {
-    // Check if debugger is already attached
-    let isAttached = false;
+    const handle = await getDebuggerSessionRegistry().acquire(tabId);
+
+    // Enable Page domain (required for screenshots; deduped across the session).
     try {
-      await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
-        expression: '1+1',
-        returnByValue: true
-      });
-      isAttached = true;
+      await handle.enableDomain('Page');
     } catch (error: any) {
-      // Debugger not attached - will attach below
-      isAttached = false;
-    }
-
-    // Attach debugger if not already attached
-    if (!isAttached) {
-      try {
-        await chrome.debugger.attach({ tabId }, '1.3');
-      } catch (error: any) {
-        console.error(`[ScreenshotService] Failed to attach debugger to tab ${tabId}:`, error);
-
-        // Check for common errors
-        if (error.message?.includes('Another debugger is already attached')) {
-          // Debugger is attached by another process (DevTools, DomService, etc.) - this is OK
-        } else if (error.message?.includes('Cannot access')) {
-          throw new Error(`CDP_CONNECTION_LOST: Cannot attach debugger to tab ${tabId}. Tab may be a protected page (chrome://, chrome-extension://, etc.)`);
-        } else {
-          throw new Error(`CDP_CONNECTION_LOST: Failed to attach debugger to tab ${tabId}: ${error.message}`);
-        }
-      }
-    }
-
-    // Enable Page domain (required for screenshots)
-    try {
-      await chrome.debugger.sendCommand({ tabId }, 'Page.enable', {});
-    } catch (error: any) {
+      await handle.release();
       console.error(`[ScreenshotService] Failed to enable Page domain:`, error);
       throw new Error(`SCREENSHOT_FAILED: Failed to enable Page domain: ${error.message}`);
     }
 
-    // Create send command wrapper
-    const sendCommand = async <T = any>(method: string, params?: any): Promise<T> => {
-      return await chrome.debugger.sendCommand({ tabId }, method, params) as T;
-    };
+    const sendCommand = <T = any>(method: string, params?: any): Promise<T> =>
+      handle.sendCommand<T>(method, params);
 
-    return new ScreenshotService(tabId, sendCommand);
+    const service = new ScreenshotService(tabId, sendCommand);
+    service.handle = handle;
+    return service;
+  }
+
+  /** Release this service's reference to the shared debugger session. */
+  async release(): Promise<void> {
+    const handle = this.handle;
+    this.handle = null;
+    await handle?.release();
   }
 }

--- a/src/extension/tools/screenshot/__tests__/CoordinateActionService.test.ts
+++ b/src/extension/tools/screenshot/__tests__/CoordinateActionService.test.ts
@@ -412,33 +412,36 @@ describe('CoordinateActionService', () => {
   // keypressAt
   // ==========================================================================
   describe('keypressAt', () => {
-    it('sends keyDown then keyUp with correct key and code', async () => {
+    it('sends keyDown then keyUp with correct key, code, virtual key code, and text', async () => {
       await service.keypressAt('Enter');
 
       expect(mockSendCommand).toHaveBeenCalledTimes(2);
 
-      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', {
+      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', expect.objectContaining({
         type: 'keyDown',
         key: 'Enter',
-        code: 'KeyENTER',
+        code: 'Enter',
+        windowsVirtualKeyCode: 13,
+        text: '\r',
         modifiers: 0,
-      });
+      }));
 
-      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', {
+      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', expect.objectContaining({
         type: 'keyUp',
         key: 'Enter',
-        code: 'KeyENTER',
+        code: 'Enter',
+        windowsVirtualKeyCode: 13,
         modifiers: 0,
-      });
+      }));
     });
 
-    it('generates uppercase code from the key name', async () => {
+    it('uses the correct physical code for a letter', async () => {
       await service.keypressAt('a');
 
       expect(mockSendCommand).toHaveBeenNthCalledWith(
         1,
         'Input.dispatchKeyEvent',
-        expect.objectContaining({ key: 'a', code: 'KeyA' })
+        expect.objectContaining({ key: 'a', code: 'KeyA', windowsVirtualKeyCode: 65, text: 'a' })
       );
     });
 
@@ -447,19 +450,19 @@ describe('CoordinateActionService', () => {
         modifiers: { ctrl: true },
       });
 
-      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', {
+      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', expect.objectContaining({
         type: 'keyDown',
         key: 'c',
         code: 'KeyC',
         modifiers: 2,
-      });
+      }));
 
-      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', {
+      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', expect.objectContaining({
         type: 'keyUp',
         key: 'c',
         code: 'KeyC',
         modifiers: 2,
-      });
+      }));
     });
 
     it('encodes combined modifiers on keypress events', async () => {
@@ -487,7 +490,7 @@ describe('CoordinateActionService', () => {
       expect(mockSendCommand).toHaveBeenNthCalledWith(
         1,
         'Input.dispatchKeyEvent',
-        expect.objectContaining({ key: 'Tab', code: 'KeyTAB' })
+        expect.objectContaining({ key: 'Tab', code: 'Tab', windowsVirtualKeyCode: 9 })
       );
     });
 
@@ -497,7 +500,7 @@ describe('CoordinateActionService', () => {
       expect(mockSendCommand).toHaveBeenNthCalledWith(
         1,
         'Input.dispatchKeyEvent',
-        expect.objectContaining({ key: 'Escape', code: 'KeyESCAPE' })
+        expect.objectContaining({ key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 })
       );
     });
 

--- a/src/extension/tools/screenshot/__tests__/CoordinateActionService.test.ts
+++ b/src/extension/tools/screenshot/__tests__/CoordinateActionService.test.ts
@@ -32,19 +32,30 @@ describe('CoordinateActionService', () => {
       }));
     });
 
-    it('uses custom button, clickCount, and modifiers from options', async () => {
+    it('uses custom button and modifiers from options', async () => {
       await service.clickAt(
         { x: 50, y: 75 },
-        { button: 'right', clickCount: 2, modifiers: { shift: true } }
+        { button: 'right', modifiers: { shift: true } }
       );
 
       expect(mockSendCommand).toHaveBeenCalledTimes(3);
 
       expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', expect.objectContaining({
-        type: 'mousePressed', x: 50, y: 75, button: 'right', buttons: 2, clickCount: 2, modifiers: 8,
+        type: 'mousePressed', x: 50, y: 75, button: 'right', buttons: 2, clickCount: 1, modifiers: 8,
       }));
       expect(mockSendCommand).toHaveBeenNthCalledWith(3, 'Input.dispatchMouseEvent', expect.objectContaining({
-        type: 'mouseReleased', x: 50, y: 75, button: 'right', buttons: 0, clickCount: 2, modifiers: 8,
+        type: 'mouseReleased', x: 50, y: 75, button: 'right', buttons: 0, clickCount: 1, modifiers: 8,
+      }));
+    });
+
+    it('double-click emits two press/release cycles (5 events)', async () => {
+      await service.clickAt({ x: 1, y: 2 }, { clickCount: 2 });
+      expect(mockSendCommand).toHaveBeenCalledTimes(5);
+      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mousePressed', clickCount: 1,
+      }));
+      expect(mockSendCommand).toHaveBeenNthCalledWith(4, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mousePressed', clickCount: 2,
       }));
     });
 

--- a/src/extension/tools/screenshot/__tests__/CoordinateActionService.test.ts
+++ b/src/extension/tools/screenshot/__tests__/CoordinateActionService.test.ts
@@ -16,28 +16,20 @@ describe('CoordinateActionService', () => {
   // clickAt
   // ==========================================================================
   describe('clickAt', () => {
-    it('sends mousePressed then mouseReleased with correct coordinates', async () => {
+    it('sends mouseMoved, mousePressed, then mouseReleased with correct coordinates', async () => {
       await service.clickAt({ x: 100, y: 200 });
 
-      expect(mockSendCommand).toHaveBeenCalledTimes(2);
+      expect(mockSendCommand).toHaveBeenCalledTimes(3);
 
-      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchMouseEvent', {
-        type: 'mousePressed',
-        x: 100,
-        y: 200,
-        button: 'left',
-        clickCount: 1,
-        modifiers: 0,
-      });
-
-      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', {
-        type: 'mouseReleased',
-        x: 100,
-        y: 200,
-        button: 'left',
-        clickCount: 1,
-        modifiers: 0,
-      });
+      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mouseMoved', x: 100, y: 200, button: 'none', buttons: 0,
+      }));
+      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mousePressed', x: 100, y: 200, button: 'left', buttons: 1, clickCount: 1, modifiers: 0,
+      }));
+      expect(mockSendCommand).toHaveBeenNthCalledWith(3, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mouseReleased', x: 100, y: 200, button: 'left', buttons: 0, clickCount: 1, modifiers: 0,
+      }));
     });
 
     it('uses custom button, clickCount, and modifiers from options', async () => {
@@ -46,38 +38,22 @@ describe('CoordinateActionService', () => {
         { button: 'right', clickCount: 2, modifiers: { shift: true } }
       );
 
-      expect(mockSendCommand).toHaveBeenCalledTimes(2);
+      expect(mockSendCommand).toHaveBeenCalledTimes(3);
 
-      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchMouseEvent', {
-        type: 'mousePressed',
-        x: 50,
-        y: 75,
-        button: 'right',
-        clickCount: 2,
-        modifiers: 8,
-      });
-
-      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', {
-        type: 'mouseReleased',
-        x: 50,
-        y: 75,
-        button: 'right',
-        clickCount: 2,
-        modifiers: 8,
-      });
+      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mousePressed', x: 50, y: 75, button: 'right', buttons: 2, clickCount: 2, modifiers: 8,
+      }));
+      expect(mockSendCommand).toHaveBeenNthCalledWith(3, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mouseReleased', x: 50, y: 75, button: 'right', buttons: 0, clickCount: 2, modifiers: 8,
+      }));
     });
 
     it('defaults button to left, clickCount to 1, modifiers to 0 when options is undefined', async () => {
       await service.clickAt({ x: 0, y: 0 });
 
-      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchMouseEvent', {
-        type: 'mousePressed',
-        x: 0,
-        y: 0,
-        button: 'left',
-        clickCount: 1,
-        modifiers: 0,
-      });
+      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mousePressed', x: 0, y: 0, button: 'left', buttons: 1, clickCount: 1, modifiers: 0,
+      }));
     });
 
     it('wraps sendCommand errors with COORDINATE_CLICK_FAILED', async () => {
@@ -200,30 +176,21 @@ describe('CoordinateActionService', () => {
       await vi.advanceTimersByTimeAsync(100);
       await promise;
 
-      // clickAt produces 2 calls (mousePressed + mouseReleased), then insertText = 3 total
-      expect(mockSendCommand).toHaveBeenCalledTimes(3);
+      // clickAt produces 3 calls (mouseMoved, mousePressed, mouseReleased), then insertText = 4 total
+      expect(mockSendCommand).toHaveBeenCalledTimes(4);
 
-      // First two calls are the click (mousePressed, mouseReleased)
-      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchMouseEvent', {
-        type: 'mousePressed',
-        x: 300,
-        y: 400,
-        button: 'left',
-        clickCount: 1,
-        modifiers: 0,
-      });
+      expect(mockSendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mouseMoved', x: 300, y: 400,
+      }));
+      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mousePressed', x: 300, y: 400, button: 'left', clickCount: 1,
+      }));
+      expect(mockSendCommand).toHaveBeenNthCalledWith(3, 'Input.dispatchMouseEvent', expect.objectContaining({
+        type: 'mouseReleased', x: 300, y: 400, button: 'left', clickCount: 1,
+      }));
 
-      expect(mockSendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchMouseEvent', {
-        type: 'mouseReleased',
-        x: 300,
-        y: 400,
-        button: 'left',
-        clickCount: 1,
-        modifiers: 0,
-      });
-
-      // Third call is the text insertion
-      expect(mockSendCommand).toHaveBeenNthCalledWith(3, 'Input.insertText', {
+      // Last call is the text insertion
+      expect(mockSendCommand).toHaveBeenNthCalledWith(4, 'Input.insertText', {
         text: 'Hello World',
       });
     });
@@ -237,11 +204,11 @@ describe('CoordinateActionService', () => {
       await vi.advanceTimersByTimeAsync(100);
       await promise;
 
-      // Internal click should always use clickCount: 1
+      // Internal click (mousePressed = 2nd call) should always use clickCount: 1
       expect(mockSendCommand).toHaveBeenNthCalledWith(
-        1,
+        2,
         'Input.dispatchMouseEvent',
-        expect.objectContaining({ clickCount: 1 })
+        expect.objectContaining({ type: 'mousePressed', clickCount: 1 })
       );
     });
 
@@ -256,8 +223,9 @@ describe('CoordinateActionService', () => {
     });
 
     it('wraps errors from insertText with COORDINATE_TYPE_FAILED', async () => {
-      // Click succeeds, but insertText fails
+      // Click succeeds (mouseMoved, mousePressed, mouseReleased), but insertText fails
       mockSendCommand
+        .mockResolvedValueOnce(undefined) // mouseMoved
         .mockResolvedValueOnce(undefined) // mousePressed
         .mockResolvedValueOnce(undefined) // mouseReleased
         .mockRejectedValueOnce(new Error('Input domain error'));

--- a/src/extension/tools/screenshot/__tests__/ScreenshotService.test.ts
+++ b/src/extension/tools/screenshot/__tests__/ScreenshotService.test.ts
@@ -70,7 +70,7 @@ describe('ScreenshotService', () => {
       await service.captureViewport();
 
       expect(mockSendCommand).toHaveBeenCalledWith('Runtime.evaluate', {
-        expression: '({ width: window.innerWidth, height: window.innerHeight, scroll_x: window.scrollX, scroll_y: window.scrollY })',
+        expression: '({ width: window.innerWidth, height: window.innerHeight, scroll_x: window.scrollX, scroll_y: window.scrollY, device_pixel_ratio: window.devicePixelRatio })',
         returnByValue: true,
       });
     });

--- a/src/extension/tools/screenshot/__tests__/ScreenshotService.test.ts
+++ b/src/extension/tools/screenshot/__tests__/ScreenshotService.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ScreenshotService } from '../ScreenshotService';
+import { __resetDebuggerSessionRegistryForTests } from '../../browser/ChromeDebuggerSessionRegistry';
 
 describe('ScreenshotService', () => {
   const TAB_ID = 1;
@@ -344,137 +345,100 @@ describe('ScreenshotService', () => {
   // forTab — static factory
   // ==========================================================================
   describe('forTab', () => {
-    let mockDebuggerSendCommand: ReturnType<typeof vi.fn>;
-    let mockDebuggerAttach: ReturnType<typeof vi.fn>;
+    // forTab now acquires a shared, refcounted debugger session from the
+    // registry (which uses the real ChromeDebuggerClient over chrome.debugger),
+    // instead of the old `Runtime.evaluate('1+1')` probe + raw attach.
+    let runtime: { lastError: { message: string } | undefined };
 
     beforeEach(() => {
-      mockDebuggerSendCommand = vi.fn();
-      mockDebuggerAttach = vi.fn().mockResolvedValue(undefined);
-
-      // Set up chrome.debugger mock
-      (globalThis as any).chrome.debugger = {
-        sendCommand: mockDebuggerSendCommand,
-        attach: mockDebuggerAttach,
+      runtime = { lastError: undefined };
+      (globalThis as any).chrome = {
+        ...(globalThis as any).chrome,
+        runtime,
+        debugger: {
+          attach: vi.fn((_d: any, _v: string, cb: () => void) => cb()),
+          detach: vi.fn((_d: any, cb: () => void) => cb()),
+          sendCommand: vi.fn((_d: any, method: string, _p: any, cb: (r: unknown) => void) => {
+            if (method === 'Runtime.evaluate') {
+              return cb({ result: { value: { width: 800, height: 600, scroll_x: 0, scroll_y: 0 } } });
+            }
+            if (method === 'Page.captureScreenshot') return cb({ data: 'screenshotFromTab' });
+            return cb({});
+          }),
+          onEvent: { addListener: vi.fn(), removeListener: vi.fn() },
+          onDetach: { addListener: vi.fn(), removeListener: vi.fn() },
+        },
       };
+      __resetDebuggerSessionRegistryForTests();
     });
 
-    it('returns a ScreenshotService instance', async () => {
-      // Debugger not attached yet (sendCommand throws), then attach + Page.enable succeeds
-      mockDebuggerSendCommand
-        .mockRejectedValueOnce(new Error('Not attached'))
-        .mockResolvedValueOnce(undefined); // Page.enable
-
+    it('returns a ScreenshotService instance and attaches once', async () => {
       const svc = await ScreenshotService.forTab(42);
-
       expect(svc).toBeInstanceOf(ScreenshotService);
+      expect((globalThis as any).chrome.debugger.attach).toHaveBeenCalledTimes(1);
     });
 
-    it('attaches debugger when not already attached', async () => {
-      mockDebuggerSendCommand
-        .mockRejectedValueOnce(new Error('Not attached'))
-        .mockResolvedValueOnce(undefined); // Page.enable
-
-      await ScreenshotService.forTab(10);
-
-      expect(mockDebuggerAttach).toHaveBeenCalledWith({ tabId: 10 }, '1.3');
-    });
-
-    it('skips attach when debugger is already attached', async () => {
-      // First sendCommand (check) succeeds = already attached
-      mockDebuggerSendCommand
-        .mockResolvedValueOnce({ result: { value: 2 } }) // runtime check
-        .mockResolvedValueOnce(undefined); // Page.enable
-
-      await ScreenshotService.forTab(5);
-
-      expect(mockDebuggerAttach).not.toHaveBeenCalled();
-    });
-
-    it('enables Page domain after attaching', async () => {
-      mockDebuggerSendCommand
-        .mockRejectedValueOnce(new Error('Not attached'))
-        .mockResolvedValueOnce(undefined); // Page.enable
-
+    it('enables the Page domain', async () => {
       await ScreenshotService.forTab(7);
-
-      expect(mockDebuggerSendCommand).toHaveBeenCalledWith(
+      expect((globalThis as any).chrome.debugger.sendCommand).toHaveBeenCalledWith(
         { tabId: 7 },
         'Page.enable',
-        {}
+        undefined,
+        expect.any(Function)
       );
     });
 
-    it('throws CDP_CONNECTION_LOST for "Cannot access" error', async () => {
-      mockDebuggerSendCommand.mockRejectedValueOnce(new Error('Not attached'));
-      mockDebuggerAttach.mockRejectedValueOnce(new Error('Cannot access this tab'));
-
-      await expect(ScreenshotService.forTab(1)).rejects.toThrow(
-        'CDP_CONNECTION_LOST: Cannot attach debugger to tab 1'
-      );
+    it('reuses a single attach for the shared session', async () => {
+      await ScreenshotService.forTab(9);
+      await ScreenshotService.forTab(9);
+      expect((globalThis as any).chrome.debugger.attach).toHaveBeenCalledTimes(1);
     });
 
-    it('throws CDP_CONNECTION_LOST for unknown attach errors', async () => {
-      mockDebuggerSendCommand.mockRejectedValueOnce(new Error('Not attached'));
-      mockDebuggerAttach.mockRejectedValueOnce(new Error('Some unknown error'));
-
-      await expect(ScreenshotService.forTab(3)).rejects.toThrow(
-        'CDP_CONNECTION_LOST: Failed to attach debugger to tab 3: Some unknown error'
+    it('surfaces ALREADY_ATTACHED when a foreign debugger holds the tab', async () => {
+      (globalThis as any).chrome.debugger.attach.mockImplementationOnce(
+        (_d: any, _v: string, cb: () => void) => {
+          runtime.lastError = { message: 'Another debugger is already attached' };
+          cb();
+          runtime.lastError = undefined;
+        }
       );
-    });
-
-    it('ignores "Another debugger is already attached" error', async () => {
-      mockDebuggerSendCommand
-        .mockRejectedValueOnce(new Error('Not attached'))
-        .mockResolvedValueOnce(undefined); // Page.enable
-      mockDebuggerAttach.mockRejectedValueOnce(
-        new Error('Another debugger is already attached')
-      );
-
-      const svc = await ScreenshotService.forTab(4);
-      expect(svc).toBeInstanceOf(ScreenshotService);
+      await expect(ScreenshotService.forTab(1)).rejects.toThrow(/ALREADY_ATTACHED/);
     });
 
     it('throws SCREENSHOT_FAILED when Page.enable fails', async () => {
-      mockDebuggerSendCommand
-        .mockRejectedValueOnce(new Error('Not attached')) // check
-        .mockRejectedValueOnce(new Error('Page domain not supported')); // Page.enable
-
+      (globalThis as any).chrome.debugger.sendCommand.mockImplementation(
+        (_d: any, method: string, _p: any, cb: (r: unknown) => void) => {
+          if (method === 'Page.enable') {
+            runtime.lastError = { message: 'Page domain not supported' };
+            cb(undefined);
+            runtime.lastError = undefined;
+            return;
+          }
+          cb({});
+        }
+      );
       await expect(ScreenshotService.forTab(8)).rejects.toThrow(
-        'SCREENSHOT_FAILED: Failed to enable Page domain: Page domain not supported'
+        /SCREENSHOT_FAILED: Failed to enable Page domain/
       );
     });
 
-    it('created service uses chrome.debugger.sendCommand wrapper', async () => {
-      mockDebuggerSendCommand
-        .mockResolvedValueOnce({ result: { value: 2 } }) // check attached
-        .mockResolvedValueOnce(undefined) // Page.enable
-        .mockResolvedValueOnce({ result: { value: { width: 800, height: 600, scroll_x: 0, scroll_y: 0 } } }) // getViewportBounds
-        .mockResolvedValueOnce({ data: 'screenshotFromTab' }); // captureScreenshot
-
+    it('created service routes captures through the shared session', async () => {
       const svc = await ScreenshotService.forTab(55);
       const result = await svc.captureViewport();
 
       expect(result.base64Data).toBe('screenshotFromTab');
-      // Verify the wrapper passes tabId correctly
-      expect(mockDebuggerSendCommand).toHaveBeenCalledWith(
+      expect((globalThis as any).chrome.debugger.sendCommand).toHaveBeenCalledWith(
         { tabId: 55 },
         'Page.captureScreenshot',
-        expect.any(Object)
+        expect.any(Object),
+        expect.any(Function)
       );
     });
 
-    it('checks debugger attachment with Runtime.evaluate expression 1+1', async () => {
-      mockDebuggerSendCommand
-        .mockResolvedValueOnce({ result: { value: 2 } })
-        .mockResolvedValueOnce(undefined);
-
-      await ScreenshotService.forTab(11);
-
-      expect(mockDebuggerSendCommand).toHaveBeenCalledWith(
-        { tabId: 11 },
-        'Runtime.evaluate',
-        { expression: '1+1', returnByValue: true }
-      );
+    it('release() detaches the shared session at refcount zero', async () => {
+      const svc = await ScreenshotService.forTab(12);
+      await svc.release();
+      expect((globalThis as any).chrome.debugger.detach).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/extension/tools/screenshot/__tests__/downscale.test.ts
+++ b/src/extension/tools/screenshot/__tests__/downscale.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { downscalePngToCssPixels } from '../downscale';
+
+describe('downscalePngToCssPixels', () => {
+  const sample = btoa('PNGDATA');
+  let origBitmap: any;
+  let origCanvas: any;
+
+  beforeEach(() => {
+    origBitmap = (globalThis as any).createImageBitmap;
+    origCanvas = (globalThis as any).OffscreenCanvas;
+  });
+
+  afterEach(() => {
+    (globalThis as any).createImageBitmap = origBitmap;
+    (globalThis as any).OffscreenCanvas = origCanvas;
+  });
+
+  it('returns the input unchanged when dpr <= 1', async () => {
+    expect(await downscalePngToCssPixels(sample, 1)).toBe(sample);
+  });
+
+  it('returns the input unchanged when image APIs are unavailable', async () => {
+    (globalThis as any).createImageBitmap = undefined;
+    (globalThis as any).OffscreenCanvas = undefined;
+    expect(await downscalePngToCssPixels(sample, 2)).toBe(sample);
+  });
+
+  it('downscales by dpr using OffscreenCanvas when dpr > 1', async () => {
+    const drawImage = vi.fn();
+    const closed = vi.fn();
+    (globalThis as any).createImageBitmap = vi.fn(async () => ({ width: 200, height: 100, close: closed }));
+
+    let canvasW = 0;
+    let canvasH = 0;
+    (globalThis as any).OffscreenCanvas = class {
+      width: number;
+      height: number;
+      constructor(w: number, h: number) {
+        this.width = w;
+        this.height = h;
+        canvasW = w;
+        canvasH = h;
+      }
+      getContext() {
+        return { drawImage };
+      }
+      convertToBlob() {
+        return Promise.resolve({ arrayBuffer: async () => new Uint8Array([9, 9, 9]).buffer });
+      }
+    };
+
+    const out = await downscalePngToCssPixels(sample, 2);
+
+    // Canvas sized to CSS pixels (device / dpr).
+    expect(canvasW).toBe(100);
+    expect(canvasH).toBe(50);
+    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 100, 50);
+    expect(closed).toHaveBeenCalled();
+    // Output is the re-encoded bytes, not the original device-pixel image.
+    expect(out).toBe(btoa(String.fromCharCode(9, 9, 9)));
+    expect(out).not.toBe(sample);
+  });
+
+  it('falls back to the original image if the pipeline throws', async () => {
+    (globalThis as any).createImageBitmap = vi.fn(async () => {
+      throw new Error('decode failed');
+    });
+    (globalThis as any).OffscreenCanvas = class {};
+    expect(await downscalePngToCssPixels(sample, 2)).toBe(sample);
+  });
+});

--- a/src/extension/tools/screenshot/__tests__/downscale.test.ts
+++ b/src/extension/tools/screenshot/__tests__/downscale.test.ts
@@ -62,6 +62,24 @@ describe('downscalePngToCssPixels', () => {
     expect(out).not.toBe(sample);
   });
 
+  it('preserves the requested image format when re-encoding', async () => {
+    const convertArgs: any[] = [];
+    (globalThis as any).createImageBitmap = vi.fn(async () => ({ width: 200, height: 100, close: vi.fn() }));
+    (globalThis as any).OffscreenCanvas = class {
+      constructor(public width: number, public height: number) {}
+      getContext() {
+        return { drawImage: vi.fn() };
+      }
+      convertToBlob(opts: any) {
+        convertArgs.push(opts);
+        return Promise.resolve({ arrayBuffer: async () => new Uint8Array([1]).buffer });
+      }
+    };
+
+    await downscalePngToCssPixels(sample, 2, { mimeType: 'image/jpeg', quality: 0.8 });
+    expect(convertArgs[0]).toEqual({ type: 'image/jpeg', quality: 0.8 });
+  });
+
   it('falls back to the original image if the pipeline throws', async () => {
     (globalThis as any).createImageBitmap = vi.fn(async () => {
       throw new Error('decode failed');

--- a/src/extension/tools/screenshot/downscale.ts
+++ b/src/extension/tools/screenshot/downscale.ts
@@ -1,0 +1,63 @@
+/**
+ * Downscale a device-pixel PNG to CSS pixels.
+ *
+ * `page_vision` captures at device resolution (`Page.captureScreenshot` applies
+ * no scale), yet the model is told to report image-pixel coordinates and those
+ * are dispatched as CSS-pixel `Input` events. On DPR>1 displays that mismatch
+ * made every vision click land at DPR× the intended position (then silently
+ * clamped to the viewport edge). Downscaling the captured PNG to
+ * `innerWidth × innerHeight` makes image pixels == CSS pixels == input
+ * coordinates, with no DPR math downstream.
+ *
+ * Uses `OffscreenCanvas` / `createImageBitmap`, both available in MV3 service
+ * workers. No-ops when `devicePixelRatio <= 1` or the image APIs are
+ * unavailable (e.g. `chrome://`, PDF viewer, or a non-worker context), falling
+ * back to the original image rather than failing the capture.
+ *
+ * @module extension/tools/screenshot/downscale
+ */
+
+export async function downscalePngToCssPixels(
+  base64Data: string,
+  devicePixelRatio: number
+): Promise<string> {
+  if (!(devicePixelRatio > 1)) return base64Data;
+  if (typeof createImageBitmap !== 'function' || typeof OffscreenCanvas === 'undefined') {
+    return base64Data;
+  }
+
+  try {
+    const bytes = base64ToBytes(base64Data);
+    const bitmap = await createImageBitmap(new Blob([bytes], { type: 'image/png' }));
+    const targetWidth = Math.max(1, Math.round(bitmap.width / devicePixelRatio));
+    const targetHeight = Math.max(1, Math.round(bitmap.height / devicePixelRatio));
+
+    const canvas = new OffscreenCanvas(targetWidth, targetHeight);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      bitmap.close?.();
+      return base64Data;
+    }
+    ctx.drawImage(bitmap, 0, 0, targetWidth, targetHeight);
+    bitmap.close?.();
+
+    const blob = await canvas.convertToBlob({ type: 'image/png' });
+    return bytesToBase64(new Uint8Array(await blob.arrayBuffer()));
+  } catch (error) {
+    console.warn('[ScreenshotService] DPR downscale failed; using device-pixel image:', error);
+    return base64Data;
+  }
+}
+
+function base64ToBytes(base64: string): Uint8Array<ArrayBuffer> {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(new ArrayBuffer(binary.length));
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+}

--- a/src/extension/tools/screenshot/downscale.ts
+++ b/src/extension/tools/screenshot/downscale.ts
@@ -17,18 +17,28 @@
  * @module extension/tools/screenshot/downscale
  */
 
+export interface DownscaleOptions {
+  /** Image MIME type to decode and re-encode as (default 'image/png'). */
+  mimeType?: string;
+  /** Encoder quality for lossy formats (jpeg/webp), 0–1. */
+  quality?: number;
+}
+
 export async function downscalePngToCssPixels(
   base64Data: string,
-  devicePixelRatio: number
+  devicePixelRatio: number,
+  options?: DownscaleOptions
 ): Promise<string> {
   if (!(devicePixelRatio > 1)) return base64Data;
   if (typeof createImageBitmap !== 'function' || typeof OffscreenCanvas === 'undefined') {
     return base64Data;
   }
 
+  const mimeType = options?.mimeType ?? 'image/png';
+
   try {
     const bytes = base64ToBytes(base64Data);
-    const bitmap = await createImageBitmap(new Blob([bytes], { type: 'image/png' }));
+    const bitmap = await createImageBitmap(new Blob([bytes], { type: mimeType }));
     const targetWidth = Math.max(1, Math.round(bitmap.width / devicePixelRatio));
     const targetHeight = Math.max(1, Math.round(bitmap.height / devicePixelRatio));
 
@@ -41,7 +51,9 @@ export async function downscalePngToCssPixels(
     ctx.drawImage(bitmap, 0, 0, targetWidth, targetHeight);
     bitmap.close?.();
 
-    const blob = await canvas.convertToBlob({ type: 'image/png' });
+    // Preserve the requested format so a jpeg/webp capture isn't silently
+    // turned into PNG bytes.
+    const blob = await canvas.convertToBlob({ type: mimeType, quality: options?.quality });
     return bytesToBase64(new Uint8Array(await blob.arrayBuffer()));
   } catch (error) {
     console.warn('[ScreenshotService] DPR downscale failed; using device-pixel image:', error);


### PR DESCRIPTION
## Summary

Complete implementation of the web-operation hardening plan (`.ai_design/improve_webtool_from_codex`). This integration branch contains **all of PR-1 plus the new PR-2 / PR-3 / PR-4 / hardening work** so the whole effort can be reviewed together. PR-1 is also available as the focused standalone PRs #280, #282, #283, #285.

**Full suite: 9466 passing, type-check clean.** The only failures are 6 pre-existing files rooted in the missing `@vscode/ripgrep` optional dep — identical on clean `main` (zero new regressions).

## What's implemented

### PR-1 — fully merged (T01–T08)
- **T01–T03** Debugger session registry (refcounted, per-tab lock, single onDetach reconciler, lock-scoped forceDetach) + per-command CDP timeouts + migration; page_vision acquire-once.
- **T04–T06** Key-definition table + InputDispatcher (correct `code`/`windowsVirtualKeyCode`/`text`; `mouseMoved → mousePressed → mouseReleased` with correct `buttons`) + click-option plumbing.
- **T07** `getContentQuads` click targeting behind `useContentQuads` (default off).
- **T08** Vision DPR hotfix (PNG downscale to CSS pixels).

### PR-2 — viewport / leases / readiness
- **T09, T11** `ViewportOverrideService` (`deviceScaleFactor:1`) + `browser_viewport` tool (holds a registry handle while active; reset releases). *T10 is a no-op under an active override.*
- **T12–T14** `TabLeaseStore` + `LeaseLifecycleQueue` + GC; best-effort claim/release wired into `RepublicAgent.handleTabBinding` via optional `IPlatformAdapter` hooks (non-throwing), startup GC at SW `onStartup`.
- **T15, T18** `PageReadiness` — loaderId-correlated lifecycle waiting + `Page.javascriptDialogOpening` forwarding. *T16/T17 wiring deferred (see Deferred).*

### PR-3 — downloads / overlay
- **T19** `DownloadWatcher` (started/completed/interrupted via an injected emit → `Session.emitEvent`).
- **T20** `ensureContentScript` ping-or-inject (deduped, isolated-world).
- **T21** Overlay `MutationObserver` self-heal (re-mounts on `document.body`, re-entrancy guarded).

### Hardening
- **T27** `DeferredReload`, **T28** `getExtensionInstanceId`, **T30** `withTimeout` util.

### PR-4 — OOPIF foundation
- **T22** `ChromeDebuggerClient.sendCommandToTarget` + `getTargets()` — the concrete prerequisite (previously sendCommand hard-rejected non-tabId targets).

## Deferred (documented in commits, intentionally not done blind)

| Item | Why |
|---|---|
| **T16/T17** NavigationTool/`waitForPageLoad` wiring | Needs a *persistent* PageReadiness + already-idle detection to avoid an 8s fail-open regression; `Page.navigate` adds a debugger infobar to un-debugged tabs. Helper is ready. |
| **T23/T24/T25** OOPIF snapshot grafting + input routing + byte budget | Substantial rewrite (FrameRegistry `targetId` column, cross-target backendNodeId collisions, target-aware call sites). Design says read-only-first, dogfood-gated. Foundation (T22) shipped. |
| **T29** typed error codes at DOMTool throw sites | Cross-cutting refactor that would churn error-classification tests. |
| `src/tools/` duplicate (server/desktop) tree | Deliberate per §1.5. |

## Tests added

Registry, InputDispatcher, getContentQuads, downscale, ViewportOverrideService, TabLeaseStore + LeaseLifecycleQueue, PageReadiness, DownloadWatcher, ensureContentScript, withTimeout, extensionLifecycle, ChromeDebuggerClient OOPIF — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)