### PR TITLE
Add BYOK custom endpoints + DeepSeek; slim default model catalog

### DIFF
--- a/src/config/__tests__/customEndpoints.persistence.test.ts
+++ b/src/config/__tests__/customEndpoints.persistence.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Custom endpoint (BYOK) persistence round-trip.
+ *
+ * Built-in provider metadata is reloaded from default.json each boot and is
+ * intentionally NOT persisted. User-defined custom providers have no
+ * default.json entry, so their full definition must survive the
+ * extractStoredConfig → buildRuntimeConfig round-trip, and a selected custom
+ * model must not be treated as "missing" and reset to the default.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getDefaultAgentConfig, extractStoredConfig, buildRuntimeConfig } from '@/config/defaults';
+import type { IProviderConfig } from '@/config/types';
+
+function makeCustomProvider(): IProviderConfig {
+  return {
+    id: 'custom-abc',
+    name: 'My LLM',
+    apiKey: '[SECURED]',
+    baseUrl: 'https://api.example.com/v1',
+    timeout: 30000,
+    retryConfig: { maxRetries: 3, initialDelay: 1000, maxDelay: 10000, backoffMultiplier: 2 },
+    isCustom: true,
+    apiFormat: 'chat_completions',
+    models: [
+      {
+        name: 'My LLM',
+        modelKey: 'my-model',
+        creator: 'Custom',
+        contextWindow: 128000,
+        maxOutputTokens: 16384,
+        supportsReasoning: false,
+        supportsImage: false,
+        supportBackendMode: 0,
+      },
+    ],
+  };
+}
+
+describe('custom endpoint persistence', () => {
+  it('extractStoredConfig moves custom providers into customProviders (not providerKeys)', () => {
+    const config = getDefaultAgentConfig();
+    config.providers['custom-abc'] = makeCustomProvider();
+
+    const stored = extractStoredConfig(config);
+
+    expect(stored.customProviders).toBeDefined();
+    expect(stored.customProviders).toHaveLength(1);
+    expect(stored.customProviders![0].id).toBe('custom-abc');
+    expect(stored.customProviders![0].apiFormat).toBe('chat_completions');
+    // Custom providers must NOT leak into providerKeys (which is for built-ins).
+    expect(stored.providerKeys['custom-abc']).toBeUndefined();
+  });
+
+  it('omits customProviders entirely when there are none', () => {
+    const stored = extractStoredConfig(getDefaultAgentConfig());
+    expect(stored.customProviders).toBeUndefined();
+  });
+
+  it('buildRuntimeConfig re-injects persisted custom providers with isCustom set', () => {
+    const config = getDefaultAgentConfig();
+    config.providers['custom-abc'] = makeCustomProvider();
+
+    const stored = extractStoredConfig(config);
+    const rebuilt = buildRuntimeConfig(stored);
+
+    const restored = rebuilt.providers['custom-abc'];
+    expect(restored).toBeDefined();
+    expect(restored.isCustom).toBe(true);
+    expect(restored.baseUrl).toBe('https://api.example.com/v1');
+    expect(restored.models[0].modelKey).toBe('my-model');
+  });
+
+  it('does not reset a selected custom model on reload', () => {
+    const config = getDefaultAgentConfig();
+    config.providers['custom-abc'] = makeCustomProvider();
+    config.selectedModelKey = 'custom-abc:my-model';
+
+    const rebuilt = buildRuntimeConfig(extractStoredConfig(config));
+
+    expect(rebuilt.selectedModelKey).toBe('custom-abc:my-model');
+  });
+
+  it('survives a second round-trip (build → extract → build)', () => {
+    const config = getDefaultAgentConfig();
+    config.providers['custom-abc'] = makeCustomProvider();
+    config.selectedModelKey = 'custom-abc:my-model';
+
+    const once = buildRuntimeConfig(extractStoredConfig(config));
+    const twice = buildRuntimeConfig(extractStoredConfig(once));
+
+    expect(twice.providers['custom-abc']?.isCustom).toBe(true);
+    expect(twice.providers['custom-abc']?.models[0].modelKey).toBe('my-model');
+    expect(twice.selectedModelKey).toBe('custom-abc:my-model');
+  });
+});

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -179,7 +179,7 @@ export const DEFAULT_APP_SERVER_CONFIG: IAppServerConfig = {
 export function getDefaultAgentConfig(): IAgentConfig {
   return {
     version: '2.1.0',
-    selectedModelKey: 'fireworks:accounts/fireworks/models/kimi-k2p6', // Default to Kimi K2.6 on Fireworks for fresh install
+    selectedModelKey: 'deepseek:deepseek-v4-flash', // Default to DeepSeek V4 Flash (free-tier) for fresh install
     providers: getDefaultProviders(),
     profiles: {},
     activeProfile: null,
@@ -363,7 +363,7 @@ export function getDefaultProviders(): Record<string, IProviderConfig> {
 export function getDefaultStoredConfig(): IStoredConfig {
   return {
     version: '2.1.0',
-    selectedModelKey: 'fireworks:accounts/fireworks/models/kimi-k2p6', // Default to Kimi K2.6 on Fireworks for fresh install
+    selectedModelKey: 'deepseek:deepseek-v4-flash', // Default to DeepSeek V4 Flash (free-tier) for fresh install
     providerKeys: {}, // Empty - no API keys configured by default
     preferences: { ...DEFAULT_USER_PREFERENCES },
     cache: { ...DEFAULT_CACHE_SETTINGS },
@@ -392,6 +392,19 @@ export function buildRuntimeConfig(stored: IStoredConfig | null): IAgentConfig {
 
   // Get fresh providers from default.json
   const providers = getDefaultProviders();
+
+  // Re-inject user-defined custom providers (BYOK). These have no default.json
+  // entry, so their full definition is persisted in stored.customProviders and
+  // restored here BEFORE selectedModelKey validation so a selected custom model
+  // is not treated as missing. The persisted apiKey is the secured marker; the
+  // real key is fetched from the CredentialStore at request time by provider id.
+  if (stored.customProviders) {
+    for (const custom of stored.customProviders) {
+      if (custom?.id) {
+        providers[custom.id] = { ...custom, isCustom: true };
+      }
+    }
+  }
 
   // Apply stored API keys and auth method to providers
   for (const [providerId, storedProvider] of Object.entries(stored.providerKeys)) {
@@ -494,8 +507,16 @@ export function buildRuntimeConfig(stored: IStoredConfig | null): IAgentConfig {
 export function extractStoredConfig(config: IAgentConfig): IStoredConfig {
   // Extract only id, API keys and organization from providers
   const providerKeys: Record<string, { id: string; apiKey: string; organization?: string | null }> = {};
+  // User-defined custom providers are persisted in full (default.json has no
+  // entry to rehydrate them from). Their secret lives in the CredentialStore;
+  // the persisted apiKey field is just the secured marker.
+  const customProviders: IProviderConfig[] = [];
 
   for (const [providerId, provider] of Object.entries(config.providers)) {
+    if (provider.isCustom) {
+      customProviders.push(provider);
+      continue;
+    }
     // Only store if there's an API key configured or an auth method set
     if (provider.apiKey || provider.authMethod) {
       providerKeys[providerId] = {
@@ -511,6 +532,7 @@ export function extractStoredConfig(config: IAgentConfig): IStoredConfig {
     version: config.version,
     selectedModelKey: config.selectedModelKey,
     providerKeys,
+    ...(customProviders.length > 0 ? { customProviders } : {}),
     preferences: config.preferences,
     cache: config.cache,
     extension: config.extension,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -321,6 +321,27 @@ export interface IProviderConfig {
   authMethod?: 'api_key' | 'chatgpt_oauth';
 
   /**
+   * Whether this is a user-defined custom provider (optional).
+   * Custom providers are added at runtime via the "Add Custom Endpoint" UI
+   * (BYOK). Unlike built-in providers — whose metadata is reloaded from
+   * default.json on every boot — custom providers are persisted in full
+   * (see IStoredConfig.customProviders) and re-injected into the runtime
+   * catalog. Custom models bypass free-tier gating (the user supplies the key).
+   */
+  isCustom?: boolean;
+
+  /**
+   * Wire API format for this provider (optional).
+   * Determines which OpenAI-compatible client a custom provider routes through:
+   * - 'chat_completions' (default) → OpenAI Chat Completions API. The broadly
+   *   compatible baseline (vLLM, Ollama, OpenRouter, DeepSeek, most gateways).
+   * - 'responses' → OpenAI Responses API. Opt-in; few third-party servers
+   *   implement it.
+   * Only consulted for custom providers; built-in providers route by id.
+   */
+  apiFormat?: 'chat_completions' | 'responses';
+
+  /**
    * Models hosted by this provider
    * Array of models available through this provider's API
    * MUST contain at least one model
@@ -605,6 +626,18 @@ export interface IStoredConfig {
   modelForTitleGenerate?: string;
   /** Provider API keys and organization IDs only */
   providerKeys: Record<string, IStoredProviderConfig>;
+  /**
+   * User-defined custom providers (BYOK), persisted in full.
+   *
+   * Built-in provider metadata is reloaded from default.json each boot and is
+   * NOT stored here; only `providerKeys` carries their secrets. Custom
+   * providers have no default.json entry, so their complete definition
+   * (baseUrl, models, apiFormat, …) is persisted here and re-injected into the
+   * runtime catalog by buildRuntimeConfig. The `apiKey` field holds the
+   * CREDENTIAL_SECURED_MARKER, never the raw key (the key lives in the
+   * CredentialStore, keyed by the custom provider id).
+   */
+  customProviders?: IProviderConfig[];
   /** User preferences */
   preferences: IUserPreferences;
   /** Cache settings */

--- a/src/core/models/ModelClientFactory.ts
+++ b/src/core/models/ModelClientFactory.ts
@@ -540,61 +540,25 @@ export class ModelClientFactory {
   }
 
   /**
-   * Get configuration status for all providers
-   * @returns Promise resolving to configuration status
+   * Get configuration status for all providers.
+   *
+   * Iterates the live provider catalog rather than a hardcoded list, so it
+   * stays correct as providers are added/removed (including user-defined custom
+   * BYOK providers) without hand-editing a parallel ladder.
+   * @returns Promise resolving to configuration status keyed by provider id
    */
   async getConfigurationStatus(): Promise<Record<ModelProvider, { hasApiKey: boolean; isDefault: boolean }>> {
-    const [openaiHasKey, xaiHasKey, anthropicHasKey, groqHasKey, googleAiStudioHasKey, fireworksHasKey, moonshotHasKey, togetherHasKey, deepseekHasKey, defaultProvider] = await Promise.all([
-      this.hasValidApiKey('openai'),
-      this.hasValidApiKey('xai'),
-      this.hasValidApiKey('anthropic'),
-      this.hasValidApiKey('groq'),
-      this.hasValidApiKey('google-ai-studio'),
-      this.hasValidApiKey('fireworks'),
-      this.hasValidApiKey('moonshot'),
-      this.hasValidApiKey('together'),
-      this.hasValidApiKey('deepseek'),
-      this.getDefaultProvider(),
-    ]);
+    const providerIds = Object.keys(this.config?.getProviders() ?? {});
+    const defaultProvider = await this.getDefaultProvider();
 
-    return {
-      deepseek: {
-        hasApiKey: deepseekHasKey,
-        isDefault: defaultProvider === 'deepseek',
-      },
-      moonshot: {
-        hasApiKey: moonshotHasKey,
-        isDefault: defaultProvider === 'moonshot',
-      },
-      fireworks: {
-        hasApiKey: fireworksHasKey,
-        isDefault: defaultProvider === 'fireworks',
-      },
-      together: {
-        hasApiKey: togetherHasKey,
-        isDefault: defaultProvider === 'together',
-      },
-      openai: {
-        hasApiKey: openaiHasKey,
-        isDefault: defaultProvider === 'openai',
-      },
-      xai: {
-        hasApiKey: xaiHasKey,
-        isDefault: defaultProvider === 'xai',
-      },
-      anthropic: {
-        hasApiKey: anthropicHasKey,
-        isDefault: defaultProvider === 'anthropic',
-      },
-      groq: {
-        hasApiKey: groqHasKey,
-        isDefault: defaultProvider === 'groq',
-      },
-      'google-ai-studio': {
-        hasApiKey: googleAiStudioHasKey,
-        isDefault: defaultProvider === 'google-ai-studio',
-      },
-    };
+    const entries = await Promise.all(
+      providerIds.map(
+        async (id) =>
+          [id, { hasApiKey: await this.hasValidApiKey(id), isDefault: defaultProvider === id }] as const
+      )
+    );
+
+    return Object.fromEntries(entries) as Record<ModelProvider, { hasApiKey: boolean; isDefault: boolean }>;
   }
 
   /**

--- a/src/core/models/ModelClientFactory.ts
+++ b/src/core/models/ModelClientFactory.ts
@@ -18,7 +18,7 @@ import type { IAuthManager } from './types/Auth';
 /**
  * Supported model providers
  */
-export type ModelProvider = 'openai' | 'xai' | 'anthropic' | 'groq' | 'google-ai-studio' | 'fireworks' | 'moonshot' | 'together';
+export type ModelProvider = 'openai' | 'xai' | 'anthropic' | 'groq' | 'google-ai-studio' | 'fireworks' | 'moonshot' | 'together' | 'deepseek' | (string & {});
 
 /**
  * Configuration for model client creation
@@ -178,7 +178,13 @@ export class ModelClientFactory {
    * @returns ModelProvider type
    */
   private mapProviderIdToType(providerId: string): ModelProvider {
-    if (providerId === 'openai' || providerId === 'xai' || providerId === 'anthropic' || providerId === 'groq' || providerId === 'google-ai-studio' || providerId === 'fireworks' || providerId === 'moonshot' || providerId === 'together') {
+    if (providerId === 'openai' || providerId === 'xai' || providerId === 'anthropic' || providerId === 'groq' || providerId === 'google-ai-studio' || providerId === 'fireworks' || providerId === 'moonshot' || providerId === 'together' || providerId === 'deepseek') {
+      return providerId;
+    }
+    // User-defined custom providers (BYOK) have arbitrary ids. Allow any provider
+    // that exists in config and is flagged isCustom through; it routes by its
+    // apiFormat in instantiateClient. Reject anything else as unsupported.
+    if (this.config?.getProvider(providerId)?.isCustom) {
       return providerId;
     }
     throw new ModelClientError(`Unsupported provider: ${providerId}`);
@@ -206,8 +212,13 @@ export class ModelClientFactory {
       return cached;
     }
 
+    // User-defined custom providers (BYOK) always use direct API-key mode — the
+    // backend gateway only knows about built-in providers, so never route a
+    // custom endpoint through it even when the user is logged in.
+    const isCustomProvider = !!this.config?.getProvider(provider)?.isCustom;
+
     // If using backend routing (logged in), create backend-routed client
-    if (this.isBackendRouting()) {
+    if (!isCustomProvider && this.isBackendRouting()) {
       const gatewayLlmBaseUrl = this.authManager?.getGatewayLlmBaseUrl?.();
       const client = gatewayLlmBaseUrl
         ? await this.createGatewayRoutedClient(provider, gatewayLlmBaseUrl)
@@ -533,7 +544,7 @@ export class ModelClientFactory {
    * @returns Promise resolving to configuration status
    */
   async getConfigurationStatus(): Promise<Record<ModelProvider, { hasApiKey: boolean; isDefault: boolean }>> {
-    const [openaiHasKey, xaiHasKey, anthropicHasKey, groqHasKey, googleAiStudioHasKey, fireworksHasKey, moonshotHasKey, togetherHasKey, defaultProvider] = await Promise.all([
+    const [openaiHasKey, xaiHasKey, anthropicHasKey, groqHasKey, googleAiStudioHasKey, fireworksHasKey, moonshotHasKey, togetherHasKey, deepseekHasKey, defaultProvider] = await Promise.all([
       this.hasValidApiKey('openai'),
       this.hasValidApiKey('xai'),
       this.hasValidApiKey('anthropic'),
@@ -542,10 +553,15 @@ export class ModelClientFactory {
       this.hasValidApiKey('fireworks'),
       this.hasValidApiKey('moonshot'),
       this.hasValidApiKey('together'),
+      this.hasValidApiKey('deepseek'),
       this.getDefaultProvider(),
     ]);
 
     return {
+      deepseek: {
+        hasApiKey: deepseekHasKey,
+        isDefault: defaultProvider === 'deepseek',
+      },
       moonshot: {
         hasApiKey: moonshotHasKey,
         isDefault: defaultProvider === 'moonshot',
@@ -728,10 +744,33 @@ export class ModelClientFactory {
       reasoningEffort = 'medium'; // Default reasoning effort
     }
 
+    // User-defined custom providers (BYOK) route by their wire API format rather
+    // than by provider id. Default to Chat Completions — the broadly compatible
+    // baseline most OpenAI-compatible servers implement; 'responses' is opt-in.
+    const customProvider = this.config?.getProvider(providerName);
+    if (customProvider?.isCustom) {
+      const clientArgs = {
+        apiKey: config.apiKey,
+        baseUrl: resolvedBaseUrl,
+        organization,
+        sessionId,
+        modelFamily,
+        provider,
+        modelConfig,
+        reasoningEffort: reasoningEffort as any,
+        reasoningSummary: supportsReasoningSummaries ? { enabled: true } : undefined,
+        parallelToolCalls,
+      };
+      return customProvider.apiFormat === 'responses'
+        ? new OpenAIResponsesClient(clientArgs)
+        : new OpenAIChatCompletionClient(clientArgs);
+    }
+
     // Direct provider-to-client mapping
     // This is the single source of truth for which client each provider uses
     switch (providerName) {
       case 'moonshot':
+      case 'deepseek':
         return new OpenAIChatCompletionClient({
           apiKey: config.apiKey,
           baseUrl: resolvedBaseUrl,

--- a/src/core/models/__tests__/ModelClientFactory.test.ts
+++ b/src/core/models/__tests__/ModelClientFactory.test.ts
@@ -348,7 +348,7 @@ describe('ModelClientFactory', () => {
     });
 
     it('should map all valid provider IDs without error', async () => {
-      const validProviders: ModelProvider[] = ['openai', 'xai', 'anthropic', 'groq', 'google-ai-studio', 'fireworks', 'moonshot', 'together'];
+      const validProviders: ModelProvider[] = ['openai', 'xai', 'anthropic', 'groq', 'google-ai-studio', 'fireworks', 'moonshot', 'together', 'deepseek'];
       for (const pid of validProviders) {
         const f = new ModelClientFactory();
         await f.initialize(createMockAgentConfig({

--- a/src/core/models/__tests__/ModelClientFactory.test.ts
+++ b/src/core/models/__tests__/ModelClientFactory.test.ts
@@ -113,6 +113,13 @@ function createMockAgentConfig(overrides: {
     getModelByKey: vi.fn().mockReturnValue(defaultModelData),
     getProviderApiKey: vi.fn().mockResolvedValue(providerApiKey),
     getProvider: vi.fn().mockReturnValue(providerData),
+    getProviders: vi.fn().mockReturnValue({
+      openai: { id: 'openai' },
+      xai: { id: 'xai' },
+      anthropic: { id: 'anthropic' },
+      'google-ai-studio': { id: 'google-ai-studio' },
+      deepseek: { id: 'deepseek' },
+    }),
     getToolsConfig: vi.fn().mockReturnValue(toolsConfig),
   } as any;
 }
@@ -650,15 +657,18 @@ describe('ModelClientFactory', () => {
   // getConfigurationStatus
   // =========================================================================
   describe('getConfigurationStatus', () => {
-    it('should return status for all 8 providers with correct isDefault', async () => {
+    it('should return status for the live provider catalog with correct isDefault', async () => {
       await factory.initialize(createMockAgentConfig({ providerApiKey: null }));
       const status = await factory.getConfigurationStatus();
 
       expect(Object.keys(status)).toEqual(
-        expect.arrayContaining(['openai', 'xai', 'anthropic', 'groq', 'google-ai-studio', 'fireworks', 'moonshot', 'together'])
+        expect.arrayContaining(['openai', 'xai', 'anthropic', 'google-ai-studio', 'deepseek'])
       );
+      // Removed providers must NOT appear once they leave the catalog.
+      expect(status).not.toHaveProperty('groq');
+      expect(status).not.toHaveProperty('moonshot');
       expect(status.openai.isDefault).toBe(true);
-      expect(status.groq.isDefault).toBe(false);
+      expect(status.xai.isDefault).toBe(false);
     });
 
     it('should reflect hasApiKey correctly', async () => {

--- a/src/core/models/cost/modelCostTable.ts
+++ b/src/core/models/cost/modelCostTable.ts
@@ -51,21 +51,18 @@ export const MODEL_COST_TABLE: Record<string, ModelRate> = {
   'google-ai-studio:gemini-3-pro-preview': { inputPer1M: 2.0, outputPer1M: 12.0, cachedInputPer1M: 2.0 },
   'google-ai-studio:gemini-2.5-pro': { inputPer1M: 1.25, outputPer1M: 10.0, cachedInputPer1M: 1.25 },
 
-  // moonshot — Cache Miss = input rate, Cache Hit = cached rate
+  // deepseek — Cache Miss = input rate, Cache Hit = cached rate (free-tier default)
+  'deepseek:deepseek-v4-flash': { inputPer1M: 0.14, outputPer1M: 0.28, cachedInputPer1M: 0.0028 },
+
+  // legacy — Kimi (moonshot/fireworks/together) retired from the picker; rows
+  // retained so historical usage records still cost correctly.
   'moonshot:kimi-k2.6': { inputPer1M: 0.95, outputPer1M: 4.0, cachedInputPer1M: 0.16 },
-  // legacy
   'moonshot:kimi-k2-thinking': { inputPer1M: 0.6, outputPer1M: 2.5, cachedInputPer1M: 0.15 },
   'moonshot:kimi-k2-thinking-turbo': { inputPer1M: 1.15, outputPer1M: 8.0, cachedInputPer1M: 0.15 },
-
-  // fireworks
   'fireworks:accounts/fireworks/models/kimi-k2p6': { inputPer1M: 0.95, outputPer1M: 4.0, cachedInputPer1M: 0.16 },
-  // legacy
   'fireworks:accounts/fireworks/models/kimi-k2-thinking': { inputPer1M: 0.6, outputPer1M: 2.5, cachedInputPer1M: 0.6 },
   'fireworks:accounts/fireworks/models/kimi-k2p5': { inputPer1M: 0.6, outputPer1M: 0.3, cachedInputPer1M: 0.1 },
-
-  // together
   'together:moonshotai/Kimi-K2.6': { inputPer1M: 1.2, outputPer1M: 4.5, cachedInputPer1M: 0.2 },
-  // legacy
   'together:moonshotai/Kimi-K2-Thinking': { inputPer1M: 1.2, outputPer1M: 4.0, cachedInputPer1M: 1.2 },
 
   // anthropic — cache hit/refresh rate used for cached input

--- a/src/core/models/providers/default.json
+++ b/src/core/models/providers/default.json
@@ -165,12 +165,12 @@
       }
     ]
   },
-  "moonshot": {
-    "id": "moonshot",
-    "name": "Moonshot AI",
+  "deepseek": {
+    "id": "deepseek",
+    "name": "DeepSeek",
     "apiKey": "",
     "organization": null,
-    "baseUrl": "https://api.moonshot.ai/v1",
+    "baseUrl": "https://api.deepseek.com",
     "version": null,
     "headers": {},
     "timeout": 30000,
@@ -182,127 +182,24 @@
     },
     "models": [
       {
-        "name": "Kimi K2.6",
-        "modelKey": "kimi-k2.6",
-        "creator": "Moonshot AI",
-        "contextWindow": 262144,
-        "maxOutputTokens": 16384,
+        "name": "DeepSeek V4 Flash",
+        "modelKey": "deepseek-v4-flash",
+        "creator": "DeepSeek",
+        "contextWindow": 1000000,
+        "maxOutputTokens": 65536,
         "supportsReasoning": true,
-        "reasoningEfforts": [
-          "low",
-          "medium",
-          "high"
-        ],
+        "reasoningEfforts": [],
         "supportsReasoningSummaries": false,
         "supportsVerbosity": false,
-        "supportsImage": true,
-        "releaseDate": "2026-04-20",
+        "supportsImage": false,
+        "releaseDate": null,
         "deprecated": false,
         "pricing": {
-          "inputToken": "Cache Hit: $0.16 / 1M tokens, Cache Miss: $0.95 / 1M tokens",
-          "outputToken": "$4.00 / 1M tokens",
-          "link": "https://platform.moonshot.ai/docs/pricing/chat"
-        }
-      }
-    ]
-  },
-  "groq": {
-    "id": "groq",
-    "name": "Groq",
-    "apiKey": "",
-    "organization": null,
-    "baseUrl": "https://api.groq.com/openai/v1",
-    "version": null,
-    "headers": {},
-    "timeout": 30000,
-    "retryConfig": {
-      "maxRetries": 3,
-      "initialDelay": 1000,
-      "maxDelay": 10000,
-      "backoffMultiplier": 2
-    },
-    "models": []
-  },
-  "fireworks": {
-    "id": "fireworks",
-    "name": "Fireworks AI",
-    "apiKey": "",
-    "organization": null,
-    "baseUrl": "https://api.fireworks.ai/inference/v1",
-    "version": null,
-    "headers": {},
-    "timeout": 30000,
-    "retryConfig": {
-      "maxRetries": 3,
-      "initialDelay": 1000,
-      "maxDelay": 10000,
-      "backoffMultiplier": 2
-    },
-    "models": [
-      {
-        "name": "Kimi K2.6",
-        "modelKey": "accounts/fireworks/models/kimi-k2p6",
-        "creator": "Moonshot AI",
-        "contextWindow": 262144,
-        "maxOutputTokens": 16384,
-        "supportsReasoning": true,
-        "reasoningEfforts": [
-          "low",
-          "medium",
-          "high"
-        ],
-        "supportsReasoningSummaries": false,
-        "supportsVerbosity": false,
-        "supportsImage": true,
-        "releaseDate": "2026-04-20",
-        "deprecated": false,
-        "pricing": {
-          "inputToken": "$0.95 / 1M tokens, Cached: $0.16 / 1M tokens",
-          "outputToken": "$4.00 / 1M tokens",
-          "link": "https://fireworks.ai/models/fireworks/kimi-k2p6"
+          "inputToken": "Cache Hit: $0.0028 / 1M tokens, Cache Miss: $0.14 / 1M tokens",
+          "outputToken": "$0.28 / 1M tokens",
+          "link": "https://api-docs.deepseek.com/quick_start/pricing"
         },
         "supportBackendMode": 2
-      }
-    ]
-  },
-  "together": {
-    "id": "together",
-    "name": "Together AI",
-    "apiKey": "",
-    "organization": null,
-    "baseUrl": "https://api.together.xyz/v1",
-    "version": null,
-    "headers": {},
-    "timeout": 30000,
-    "retryConfig": {
-      "maxRetries": 3,
-      "initialDelay": 1000,
-      "maxDelay": 10000,
-      "backoffMultiplier": 2
-    },
-    "models": [
-      {
-        "name": "Kimi K2.6",
-        "modelKey": "moonshotai/Kimi-K2.6",
-        "creator": "Moonshot AI",
-        "contextWindow": 256000,
-        "maxOutputTokens": 16384,
-        "supportsReasoning": true,
-        "reasoningEfforts": [
-          "low",
-          "medium",
-          "high"
-        ],
-        "supportsReasoningSummaries": false,
-        "supportsVerbosity": false,
-        "supportsImage": true,
-        "releaseDate": "2026-04-20",
-        "deprecated": false,
-        "pricing": {
-          "inputToken": "$1.20 / 1M tokens, Cached: $0.20 / 1M tokens",
-          "outputToken": "$4.50 / 1M tokens",
-          "link": "https://www.together.ai/models/kimi-k26"
-        }
       }
     ]
   },

--- a/src/webfront/components/chat/ModelSelection.svelte
+++ b/src/webfront/components/chat/ModelSelection.svelte
@@ -54,7 +54,9 @@
 
   // Filter models based on useOwnApiKey setting
   let filteredModelItems = $derived(isUserLoggedIn && !useOwnApiKey
-    ? modelSelectionItems.filter(item => (item.supportBackendMode ?? 0) > 0)
+    // Custom (BYOK) endpoints are direct-only but must remain selectable in
+    // backend mode — they run on the user's own key.
+    ? modelSelectionItems.filter(item => (item.supportBackendMode ?? 0) > 0 || item.isCustom)
     : modelSelectionItems);
 
   // Group models by name
@@ -76,6 +78,10 @@
     for (const item of filteredModelItems) {
       const existing = groups.get(item.modelName);
       if (existing) {
+        // A group is "custom" only if EVERY provider in it is custom. A name
+        // collision between a built-in and a BYOK endpoint must NOT unlock the
+        // built-in for free users, so mixed groups safe-fail to non-custom.
+        existing.isCustom = existing.isCustom && (item.isCustom ?? false);
         // Check for duplicate provider before adding
         const isDuplicate = existing.providers.some(p => p.providerId === item.providerId);
         if (!isDuplicate) {

--- a/src/webfront/components/chat/ModelSelection.svelte
+++ b/src/webfront/components/chat/ModelSelection.svelte
@@ -38,6 +38,7 @@
     providerId: string;
     providerName: string;
     supportBackendMode?: number;
+    isCustom?: boolean;
   }
   let modelSelectionItems: ModelSelectionItem[] = $state([]);
 
@@ -60,6 +61,7 @@
   interface GroupedModel {
     modelName: string;
     modelKey: string; // First provider's modelKey, used for free user check
+    isCustom: boolean; // True for user-defined custom endpoints (BYOK) — bypass free-tier lock
     providers: Array<{
       modelId: string;
       modelKey: string;
@@ -88,6 +90,7 @@
         groups.set(item.modelName, {
           modelName: item.modelName,
           modelKey: item.modelKey,
+          isCustom: item.isCustom ?? false,
           providers: [{
             modelId: item.modelId,
             modelKey: item.modelKey,
@@ -136,6 +139,7 @@
             providerId: provider.id,
             providerName: provider.name,
             supportBackendMode: model.supportBackendMode,
+            isCustom: provider.isCustom ?? false,
           });
         }
       }
@@ -175,14 +179,14 @@
     isOpen = false;
   }
 
-  async function selectModel(modelId: string, modelName: string, modelKey: string) {
+  async function selectModel(modelId: string, modelName: string, modelKey: string, isCustom = false) {
     if (modelId === selectedModelKey) {
       isOpen = false;
       return;
     }
 
     // Block selection for free users trying to select premium models
-    if (isUserLoggedIn && isFreeUser && !isModelAvailableForFreeUser(modelKey)) {
+    if (isUserLoggedIn && isFreeUser && !isModelAvailableForFreeUser(modelKey, isCustom)) {
       // Model is locked for free users - don't allow selection
       return;
     }
@@ -257,7 +261,7 @@
       {#each groupedModels as group (group.modelName)}
         {@const isSelected = selectedGroup?.modelName === group.modelName}
         {@const hasMultipleProviders = group.providers.length > 1}
-        {@const isLockedForFreeUser = isUserLoggedIn && isFreeUser && !isModelAvailableForFreeUser(group.modelKey)}
+        {@const isLockedForFreeUser = isUserLoggedIn && isFreeUser && !isModelAvailableForFreeUser(group.modelKey, group.isCustom)}
 
         <div class="{currentTheme === 'modern'
           ? 'border-b border-white/10 last:border-b-0'
@@ -298,7 +302,7 @@
                         {currentTheme === 'modern'
                           ? 'font-chat bg-white/10 border border-white/20 rounded-2xl text-white/80 py-1 px-2.5 hover:bg-white/15 hover:border-white/30 hover:text-chat-tooltip-text dark:hover:text-chat-tooltip-text-dark ' + (isProviderSelected ? 'bg-blue-400/25 border-chat-primary dark:border-chat-primary-dark text-chat-primary dark:text-chat-primary-dark' : '')
                           : 'font-terminal bg-transparent border border-term-dim-green/40 rounded py-1 px-2 text-term-dim-green hover:border-term-green hover:bg-term-green/10 ' + (isProviderSelected ? 'bg-term-green/20 border-term-bright-green text-term-bright-green' : '')}"
-                      onclick={() => selectModel(provider.modelId, group.modelName, provider.modelKey)}
+                      onclick={() => selectModel(provider.modelId, group.modelName, provider.modelKey, group.isCustom)}
                       role="option"
                       aria-selected={isProviderSelected}
                     >
@@ -337,7 +341,7 @@
                   {currentTheme === 'modern'
                     ? 'font-chat text-sm py-2.5 px-3.5 text-chat-tooltip-text dark:text-chat-tooltip-text-dark hover:bg-white/10 ' + (isSelected ? 'bg-blue-400/20 text-chat-primary dark:text-chat-primary-dark' : '')
                     : 'font-terminal text-sm py-2 px-3 text-term-dim-green hover:bg-term-green/10 hover:text-term-green ' + (isSelected ? 'bg-term-green/15 text-term-bright-green' : '')}"
-                onclick={() => selectModel(group.providers[0].modelId, group.modelName, group.providers[0].modelKey)}
+                onclick={() => selectModel(group.providers[0].modelId, group.modelName, group.providers[0].modelKey, group.isCustom)}
                 role="option"
                 aria-selected={isSelected}
               >

--- a/src/webfront/lib/freeUserModels.ts
+++ b/src/webfront/lib/freeUserModels.ts
@@ -16,24 +16,29 @@
 
 /**
  * Composite key ("providerId:modelKey") used as the free-user default when no
- * model is selected. Must match the runtime composite key exactly — note the
- * `accounts/` segment that is part of the Fireworks raw model key.
+ * model is selected. Must match the runtime composite key exactly.
  */
-export const FREE_USER_DEFAULT_COMPOUND_KEY = 'fireworks:accounts/fireworks/models/kimi-k2p6';
+export const FREE_USER_DEFAULT_COMPOUND_KEY = 'deepseek:deepseek-v4-flash';
 
 /**
- * Raw model keys (lowercased) that free users are allowed to select. This is
- * the same Kimi K2.6 model offered across Fireworks, Moonshot, and Together —
- * the providers diverge on spelling (`kimi-k2p6` vs `kimi-k2.6`), so an explicit
- * allow-list is used instead of a substring match.
+ * Raw model keys (lowercased) that free users are allowed to select. Currently
+ * the single DeepSeek V4 Flash model, served through the backend gateway for
+ * free-tier users. An explicit allow-list is used instead of a substring match.
  */
 const FREE_USER_MODEL_KEYS = new Set<string>([
-  'accounts/fireworks/models/kimi-k2p6',
-  'kimi-k2.6',
-  'moonshotai/kimi-k2.6',
+  'deepseek-v4-flash',
 ]);
 
-/** True when `modelKey` (a raw model key) is selectable by a free user. */
-export function isModelAvailableForFreeUser(modelKey: string): boolean {
+/**
+ * True when `modelKey` (a raw model key) is selectable by a free user.
+ *
+ * User-added custom endpoints are BYOK — they run on the user's own API key and
+ * billing, so they are never gated behind the free-tier allow-list. Pass
+ * `isCustom = true` for models that belong to a custom (user-defined) provider.
+ */
+export function isModelAvailableForFreeUser(modelKey: string, isCustom = false): boolean {
+  if (isCustom) {
+    return true;
+  }
   return FREE_USER_MODEL_KEYS.has(modelKey.toLowerCase());
 }

--- a/src/webfront/settings/ModelSettings.svelte
+++ b/src/webfront/settings/ModelSettings.svelte
@@ -72,6 +72,24 @@
   let chatgptOAuthSigningIn = $state(false);
   let chatgptOAuthError = $state('');
 
+  // Custom endpoint (BYOK) form state
+  let customName = $state('');
+  let customBaseUrl = $state('');
+  let customModelHandle = $state('');
+  let customApiKey = $state('');
+  let customApiFormat: 'chat_completions' | 'responses' = $state('chat_completions');
+  let customContextWindow = $state(128000);
+  let isAddingCustom = $state(false);
+  let customError = $state('');
+  interface CustomEndpointItem {
+    id: string;
+    name: string;
+    baseUrl: string;
+    modelKey: string;
+    apiFormat: 'chat_completions' | 'responses';
+  }
+  let customEndpoints: CustomEndpointItem[] = $state([]);
+
   // Derived state from user store
   let isUserLoggedIn = $derived($userStore.isLoggedIn);
   let isFreeUser = $derived($userStore.userType === 0);
@@ -99,6 +117,7 @@
       link: string;
     };
     supportBackendMode?: number;
+    isCustom?: boolean;
   }
   let modelSelectionItems: ModelSelectionItem[] = $state([]);
 
@@ -309,11 +328,13 @@
             reasoningEfforts: model.reasoningEfforts,
             pricing: model.pricing,
             supportBackendMode: model.supportBackendMode,
+            isCustom: provider.isCustom ?? false,
           });
         }
       }
 
       modelSelectionItems = tempModelItems;
+      loadCustomEndpoints();
       console.log(
         '[ModelSettings] Available model IDs:',
         modelSelectionItems.map((m) => m.modelId)
@@ -441,6 +462,140 @@
       showMessage(t('Failed to save API key'), 'error');
     } finally {
       isSaving = false;
+    }
+  }
+
+  /** Refresh the list of user-defined custom endpoints from the live config. */
+  function loadCustomEndpoints() {
+    if (!settingsConfig) return;
+    const providers = settingsConfig.getProviders();
+    customEndpoints = Object.values(providers)
+      .filter((p) => p.isCustom)
+      .map((p) => ({
+        id: p.id,
+        name: p.name,
+        baseUrl: p.baseUrl || '',
+        modelKey: p.models?.[0]?.modelKey || '',
+        apiFormat: p.apiFormat === 'responses' ? 'responses' : 'chat_completions',
+      }));
+  }
+
+  /**
+   * Add a user-defined custom endpoint (BYOK). Modelled as a runtime provider
+   * with a single model so it flows through the existing model picker, cost,
+   * and credential machinery. The provider definition is persisted in full (see
+   * IStoredConfig.customProviders); the key goes to the credential store.
+   */
+  async function addCustomEndpoint() {
+    if (!settingsConfig || isAddingCustom) return;
+    customError = '';
+
+    const name = customName.trim();
+    const baseUrl = customBaseUrl.trim();
+    const modelKey = customModelHandle.trim();
+    const key = customApiKey.trim();
+
+    if (!name || !baseUrl || !modelKey) {
+      customError = t('Display name, API base URL, and model handle are required.');
+      return;
+    }
+    if (!/^https:\/\//i.test(baseUrl)) {
+      customError = t('API base URL must start with https://');
+      return;
+    }
+    try {
+      // eslint-disable-next-line no-new
+      new URL(baseUrl);
+    } catch {
+      customError = t('API base URL is not a valid URL.');
+      return;
+    }
+    const contextWindow =
+      typeof customContextWindow === 'number' && customContextWindow > 0 ? customContextWindow : 128000;
+
+    try {
+      isAddingCustom = true;
+      const id = `custom-${Date.now().toString(36)}`;
+
+      settingsConfig.addProvider({
+        id,
+        name,
+        apiKey: '',
+        baseUrl,
+        timeout: 30000,
+        retryConfig: { maxRetries: 3, initialDelay: 1000, maxDelay: 10000, backoffMultiplier: 2 },
+        isCustom: true,
+        apiFormat: customApiFormat,
+        models: [
+          {
+            name,
+            modelKey,
+            creator: 'Custom',
+            contextWindow,
+            maxOutputTokens: Math.min(16384, contextWindow),
+            supportsReasoning: false,
+            supportsImage: false,
+            supportBackendMode: 0,
+          },
+        ],
+      });
+
+      if (key) {
+        await settingsConfig.setProviderApiKey(id, key);
+      }
+
+      // Reset the form
+      customName = '';
+      customBaseUrl = '';
+      customModelHandle = '';
+      customApiKey = '';
+      customApiFormat = 'chat_completions';
+      customContextWindow = 128000;
+
+      await loadSettings();
+      loadCustomEndpoints();
+      showMessage(t('Custom endpoint added.'), 'success');
+      getInitializedUIClient()
+        .then((c) => c.serviceRequest('agent.configUpdate'))
+        .catch((err) => console.warn('[ModelSettings] Failed to send configUpdate:', err));
+    } catch (error) {
+      console.error('[ModelSettings] Failed to add custom endpoint:', error);
+      customError = error instanceof Error ? error.message : t('Failed to add custom endpoint.');
+    } finally {
+      isAddingCustom = false;
+    }
+  }
+
+  /** Remove a custom endpoint, switching away from it first if it is selected. */
+  async function deleteCustomEndpoint(id: string) {
+    if (!settingsConfig || isAddingCustom) return;
+    try {
+      isAddingCustom = true;
+
+      // deleteProvider rejects removing the provider that hosts the selected
+      // model, so switch to another available model first.
+      if (selectedModelKey.startsWith(`${id}:`)) {
+        const fallback = modelSelectionItems.find((m) => !m.modelId.startsWith(`${id}:`));
+        if (fallback) {
+          await settingsConfig.setSelectedModel(fallback.modelId);
+          selectedModelKey = fallback.modelId;
+        }
+      }
+
+      await settingsConfig.deleteProviderApiKey(id).catch(() => {});
+      settingsConfig.deleteProvider(id);
+
+      await loadSettings();
+      loadCustomEndpoints();
+      showMessage(t('Custom endpoint removed.'), 'success');
+      getInitializedUIClient()
+        .then((c) => c.serviceRequest('agent.configUpdate'))
+        .catch((err) => console.warn('[ModelSettings] Failed to send configUpdate:', err));
+    } catch (error) {
+      console.error('[ModelSettings] Failed to remove custom endpoint:', error);
+      showMessage(t('Failed to remove custom endpoint.'), 'error');
+    } finally {
+      isAddingCustom = false;
     }
   }
 
@@ -1144,6 +1299,123 @@
     {/if}
   </div>
 
+  <!-- Custom Endpoints (BYOK) -->
+  <div class="settings-section settings-card">
+    <h3 class="section-title">{t("Custom Endpoints")}</h3>
+    <p class="custom-help">
+      {t("Add any OpenAI-compatible LLM endpoint with your own API key. Added models appear in the model picker above and run on your own key and billing.")}
+    </p>
+
+    {#if customEndpoints.length > 0}
+      <div class="custom-list">
+        {#each customEndpoints as ep (ep.id)}
+          <div class="custom-item">
+            <div class="custom-item-info">
+              <div class="custom-item-name">{ep.name}</div>
+              <div class="custom-item-meta">
+                {ep.modelKey} · {ep.baseUrl} · {ep.apiFormat === 'responses' ? t('Responses API') : t('Chat Completions')}
+              </div>
+            </div>
+            <button
+              type="button"
+              class="btn btn-danger btn-sm"
+              onclick={() => deleteCustomEndpoint(ep.id)}
+              disabled={isAddingCustom}
+            >
+              {t("Remove")}
+            </button>
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    <div class="form-group">
+      <label class="form-label" for="custom-name">{t("Display name")}</label>
+      <input
+        id="custom-name"
+        class="api-key-input"
+        bind:value={customName}
+        placeholder={t("My LLM")}
+        disabled={isAddingCustom}
+        autocomplete="off"
+      />
+    </div>
+    <div class="form-group">
+      <label class="form-label" for="custom-base-url">{t("API base URL")}</label>
+      <input
+        id="custom-base-url"
+        class="api-key-input"
+        bind:value={customBaseUrl}
+        placeholder="https://api.example.com/v1"
+        disabled={isAddingCustom}
+        autocomplete="off"
+        spellcheck="false"
+      />
+    </div>
+    <div class="form-group">
+      <label class="form-label" for="custom-model">{t("Model handle")}</label>
+      <input
+        id="custom-model"
+        class="api-key-input"
+        bind:value={customModelHandle}
+        placeholder="model-name"
+        disabled={isAddingCustom}
+        autocomplete="off"
+        spellcheck="false"
+      />
+    </div>
+    <div class="form-group">
+      <label class="form-label" for="custom-key">{t("API key")}</label>
+      <input
+        id="custom-key"
+        type="password"
+        class="api-key-input"
+        bind:value={customApiKey}
+        placeholder="sk-..."
+        disabled={isAddingCustom}
+        autocomplete="off"
+        spellcheck="false"
+      />
+    </div>
+    <div class="form-row">
+      <div class="form-group form-group-half">
+        <label class="form-label" for="custom-format">{t("API format")}</label>
+        <select id="custom-format" class="api-key-input" bind:value={customApiFormat} disabled={isAddingCustom}>
+          <option value="chat_completions">{t("Chat Completions (recommended)")}</option>
+          <option value="responses">{t("Responses API")}</option>
+        </select>
+      </div>
+      <div class="form-group form-group-half">
+        <label class="form-label" for="custom-ctx">{t("Context window")}</label>
+        <input
+          id="custom-ctx"
+          type="number"
+          min="1"
+          class="api-key-input"
+          bind:value={customContextWindow}
+          disabled={isAddingCustom}
+        />
+      </div>
+    </div>
+
+    {#if customError}
+      <div class="message error">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <circle cx="12" cy="12" r="10"></circle>
+          <line x1="15" y1="9" x2="9" y2="15"></line>
+          <line x1="9" y1="9" x2="15" y2="15"></line>
+        </svg>
+        {customError}
+      </div>
+    {/if}
+
+    <div class="button-group">
+      <button type="button" class="btn btn-primary" onclick={addCustomEndpoint} disabled={isAddingCustom}>
+        {isAddingCustom ? t("Adding...") : t("Add Endpoint")}
+      </button>
+    </div>
+  </div>
+
   <!-- Security Notice -->
   <div class="settings-section settings-card">
     <h3 class="section-title">{t("Security & Privacy")}</h3>
@@ -1674,5 +1946,67 @@
     font-size: 0.8rem;
     text-transform: uppercase;
     letter-spacing: 0.05em;
+  }
+
+  /* Custom endpoints (BYOK) */
+  .custom-help {
+    margin: 0 0 1rem 0;
+    font-size: 0.85rem;
+    color: var(--workx-text-secondary, var(--workx-text));
+    opacity: 0.8;
+    line-height: 1.4;
+  }
+
+  .custom-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .custom-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.625rem 0.75rem;
+    border: 1px solid var(--workx-border);
+    border-radius: 0.5rem;
+    background: var(--workx-surface);
+  }
+
+  .custom-item-info {
+    min-width: 0;
+  }
+
+  .custom-item-name {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--workx-text);
+  }
+
+  .custom-item-meta {
+    font-size: 0.75rem;
+    color: var(--workx-text-secondary, var(--workx-text));
+    opacity: 0.75;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .form-row {
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  .form-group-half {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .btn-sm {
+    padding: 0.35rem 0.7rem;
+    font-size: 0.8rem;
+    flex-shrink: 0;
   }
 </style>

--- a/src/webfront/settings/ModelSettings.svelte
+++ b/src/webfront/settings/ModelSettings.svelte
@@ -16,7 +16,7 @@
   import { highlightSetting } from './utils/highlightSetting';
   import './utils/highlight-pulse.css';
   import { platform } from '../stores/platformStore';
-  import { FREE_USER_DEFAULT_COMPOUND_KEY } from '../lib/freeUserModels';
+  import { FREE_USER_DEFAULT_COMPOUND_KEY, isModelAvailableForFreeUser } from '../lib/freeUserModels';
 
   let {
     settingsConfig,
@@ -125,7 +125,9 @@
   // supportBackendMode > 0 means the model supports backend routing
   let filteredModelItems = $derived(
     isUserLoggedIn && !useOwnApiKey
-      ? modelSelectionItems.filter(item => (item.supportBackendMode ?? 0) > 0)
+      // Custom (BYOK) endpoints are direct-only (supportBackendMode 0) but must
+      // still be selectable in backend mode — they run on the user's own key.
+      ? modelSelectionItems.filter(item => (item.supportBackendMode ?? 0) > 0 || item.isCustom)
       : modelSelectionItems
   );
 
@@ -495,8 +497,8 @@
     const modelKey = customModelHandle.trim();
     const key = customApiKey.trim();
 
-    if (!name || !baseUrl || !modelKey) {
-      customError = t('Display name, API base URL, and model handle are required.');
+    if (!name || !baseUrl || !modelKey || !key) {
+      customError = t('Display name, API base URL, model handle, and API key are required.');
       return;
     }
     if (!/^https:\/\//i.test(baseUrl)) {
@@ -510,8 +512,12 @@
       customError = t('API base URL is not a valid URL.');
       return;
     }
-    const contextWindow =
+    // Floor the context window so a tiny/empty value can't silently clamp
+    // maxOutputTokens to an unusable size (e.g. user types 100 → 100-token cap).
+    const requestedContext =
       typeof customContextWindow === 'number' && customContextWindow > 0 ? customContextWindow : 128000;
+    const contextWindow = Math.max(4096, requestedContext);
+    const maxOutputTokens = Math.min(16384, contextWindow);
 
     try {
       isAddingCustom = true;
@@ -532,7 +538,7 @@
             modelKey,
             creator: 'Custom',
             contextWindow,
-            maxOutputTokens: Math.min(16384, contextWindow),
+            maxOutputTokens,
             supportsReasoning: false,
             supportsImage: false,
             supportBackendMode: 0,
@@ -573,9 +579,18 @@
       isAddingCustom = true;
 
       // deleteProvider rejects removing the provider that hosts the selected
-      // model, so switch to another available model first.
+      // model, so switch to another available model first. For free users, the
+      // fallback must itself be free-tier-allowed — otherwise we'd silently park
+      // them on a premium model that every subsequent message fails on.
       if (selectedModelKey.startsWith(`${id}:`)) {
-        const fallback = modelSelectionItems.find((m) => !m.modelId.startsWith(`${id}:`));
+        const candidates = modelSelectionItems.filter((m) => !m.modelId.startsWith(`${id}:`));
+        let fallback = candidates[0];
+        if (isFreeUser) {
+          fallback =
+            candidates.find((m) => m.modelId === FREE_USER_DEFAULT_COMPOUND_KEY) ??
+            candidates.find((m) => isModelAvailableForFreeUser(m.modelKey, m.isCustom)) ??
+            candidates[0];
+        }
         if (fallback) {
           await settingsConfig.setSelectedModel(fallback.modelId);
           selectedModelKey = fallback.modelId;

--- a/src/webfront/settings/components/ModelSelector.svelte
+++ b/src/webfront/settings/components/ModelSelector.svelte
@@ -32,6 +32,7 @@
       maxOutputTokens: number;
       baseUrl: string;
       selected: boolean;
+      isCustom?: boolean;
       pricing?: {
         inputToken: string;
         outputToken: string;
@@ -58,6 +59,7 @@
   interface GroupedModel {
     modelName: string;
     modelKey: string; // First provider's modelKey, used for free user check
+    isCustom: boolean; // True for user-defined custom endpoints (BYOK) — bypass free-tier lock
     providers: Array<{
       modelId: string;
       modelKey: string;
@@ -106,6 +108,7 @@
         groups.set(item.modelName, {
           modelName: item.modelName,
           modelKey: item.modelKey, // Store modelKey for free user check
+          isCustom: item.isCustom ?? false,
           providers: [
             {
               modelId: item.modelId,
@@ -145,7 +148,7 @@
     if (disabled) return;
 
     // Block selection for free users trying to select premium models
-    if (isUserLoggedIn && isFreeUser && !isModelAvailableForFreeUser(group.modelKey)) {
+    if (isUserLoggedIn && isFreeUser && !isModelAvailableForFreeUser(group.modelKey, group.isCustom)) {
       // Model is locked for free users - don't allow selection
       return;
     }
@@ -388,7 +391,7 @@
         {@const hasError = pendingProviderErrors.get(group.modelName)}
         {@const firstProvider = group.providers[0]}
         {@const isLockedForFreeUser =
-          isUserLoggedIn && isFreeUser && !isModelAvailableForFreeUser(group.modelKey)}
+          isUserLoggedIn && isFreeUser && !isModelAvailableForFreeUser(group.modelKey, group.isCustom)}
 
         <Tooltip
           content={$_t("Please upgrade the plan to unblock world's most advanced models")}

--- a/src/webfront/settings/components/ModelSelector.svelte
+++ b/src/webfront/settings/components/ModelSelector.svelte
@@ -83,6 +83,10 @@
     for (const item of modelSelectionItems) {
       const existing = groups.get(item.modelName);
       if (existing) {
+        // A group is "custom" only if EVERY provider in it is custom, so a name
+        // collision between a built-in and a BYOK endpoint can't unlock the
+        // built-in for free users (mixed groups safe-fail to non-custom).
+        existing.isCustom = existing.isCustom && (item.isCustom ?? false);
         // Check for duplicate provider before adding
         const isDuplicate = existing.providers.some((p) => p.providerId === item.providerId);
         if (isDuplicate) {
@@ -176,7 +180,8 @@
     event: MouseEvent,
     modelId: string,
     modelName: string,
-    modelKey: string
+    modelKey: string,
+    isCustom = false
   ) {
     if (disabled) {
       event.stopPropagation();
@@ -184,7 +189,7 @@
     }
 
     // Block selection for free users trying to select premium models
-    if (isUserLoggedIn && isFreeUser && !isModelAvailableForFreeUser(modelKey)) {
+    if (isUserLoggedIn && isFreeUser && !isModelAvailableForFreeUser(modelKey, isCustom)) {
       // Model is locked for free users - don't allow selection
       // We don't stop propagation here so parent tooltip can catch the click
       return;
@@ -468,7 +473,8 @@
                               e,
                               provider.modelId,
                               group.modelName,
-                              provider.modelKey
+                              provider.modelKey,
+                              group.isCustom
                             )}
                         >
                           <span class="provider-name">{provider.providerName}</span>

--- a/src/webfront/stores/__tests__/modelStore.test.ts
+++ b/src/webfront/stores/__tests__/modelStore.test.ts
@@ -77,9 +77,9 @@ describe('modelStore', () => {
   it('re-reads from getConfig() rather than trusting the event payload', () => {
     // updateModelConfig emits full IModelConfig objects, not string keys.
     // The store must ignore the payload and re-read the canonical selectedModelKey.
-    state.mockSelectedModelKey ='fireworks:kimi-k2';
-    fireConfigEvent('model', { name: 'Kimi K2', modelKey: 'kimi-k2' } /* wrong shape on purpose */);
+    state.mockSelectedModelKey ='deepseek:deepseek-v4-flash';
+    fireConfigEvent('model', { name: 'DeepSeek V4 Flash', modelKey: 'deepseek-v4-flash' } /* wrong shape on purpose */);
 
-    expect(get(selectedModelKey)).toBe('fireworks:kimi-k2');
+    expect(get(selectedModelKey)).toBe('deepseek:deepseek-v4-flash');
   });
 });


### PR DESCRIPTION
## Summary

Reduces the built-in model catalog and adds runtime flexibility for users to bring their own OpenAI-compatible LLM endpoints (BYOK).

### Catalog
- **Add DeepSeek** provider with `deepseek-v4-flash` (1M context, Chat Completions) and make it the **free-tier default**.
- **Remove all Kimi models** and the now-empty `moonshot` / `groq` / `fireworks` / `together` provider blocks. Default providers are now: **xAI · OpenAI · Google · DeepSeek · Anthropic**.
- Groq/Together **client classes are kept** (only removed from the catalog); `ModelClientFactory` routing for them is untouched.

### Free-tier + cost
- Repoint `FREE_USER_DEFAULT_COMPOUND_KEY`, fresh-install defaults (both spots in `defaults.ts`), and the cost table at `deepseek-v4-flash`.
- Retired Kimi cost rows kept as **legacy** so historical usage records still cost correctly.

### Custom endpoints (BYOK)
- **Persistence:** add `isCustom` / `apiFormat` to `IProviderConfig` and `customProviders` to `IStoredConfig`; round-trip them through `extractStoredConfig` / `buildRuntimeConfig` (built-ins are rebuilt from `default.json` each boot and would otherwise drop custom providers). Keys persist via the existing **`CredentialStore`**, so it works on **extension (chrome.storage), desktop (OS keychain), and server (encrypted file)** with no per-surface code.
- **Routing:** custom providers route by `apiFormat`, **defaulting to Chat Completions** for broad compatibility (Responses API is opt-in). Custom endpoints always use direct BYOK mode and never the backend gateway.
- **UI:** Settings → Model Config gains an **"Add Custom Endpoint"** section (display name, HTTPS base URL, model handle, API key, API format, context window) with list/remove. Custom models appear in both pickers and **bypass the free-tier lock** since they run on the user's own key.

### Out of scope (by design)
- Local-deployment SDKs (Ollama / LM Studio) — custom endpoints require an `https://` base URL per the existing provider validator. Local-model support is a separate future effort.
- Backend gateway routing for `deepseek-v4-flash` is handled separately (outside this repo); the catalog side is wired via `supportBackendMode: 2`.

## Testing
- **Type-check:** clean (only the pre-existing missing `@anthropic-ai/sdk` local-dependency error remains).
- **Vitest:** 1840 pass. The 2 failing files fail at the `@anthropic-ai/sdk` import (same pre-existing env issue), before any changed code runs.
- Added a custom-endpoint persistence round-trip suite (5 tests) and a DeepSeek cost row that keeps the catalog↔cost coverage test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)