### PR TITLE
feat(desktop-auth): make OIDC scopes configurable for Hub gateway access

### DIFF
--- a/src/config/authConfig.ts
+++ b/src/config/authConfig.ts
@@ -36,6 +36,14 @@ export interface AuthConfig {
    * once that client exists, otherwise the legacy desktop-token flow runs.
    */
   oidcEnabled: boolean;
+  /**
+   * Space-separated OIDC scopes the desktop requests at authorize time. Null
+   * when unset, in which case the caller applies the default
+   * (`openid profile email`). Set `WORKX_/VITE_AUTH_OIDC_SCOPES` to request the
+   * Hub gateway scopes (`chat apps models`) so the issued token carries the
+   * `svc:hub` audience needed to reach the AI Hub gateway.
+   */
+  oidcScopes: string | null;
   source: {
     authBaseUrl: AuthConfigSource;
     cookieDomain: AuthConfigSource;
@@ -136,6 +144,12 @@ export function resolveAuthConfig(): AuthConfig {
     vite.VITE_AUTH_OIDC_ENABLED,
   ));
 
+  const oidcScopes = firstNonEmpty(
+    env.WORKX_AUTH_OIDC_SCOPES,
+    env.VITE_AUTH_OIDC_SCOPES,
+    vite.VITE_AUTH_OIDC_SCOPES,
+  ) ?? null;
+
   const usesDefaultCookieNames = Object.entries(cookieNames).every(
     ([key, value]) => value === DEFAULT_COOKIE_NAMES[key as keyof AuthCookieNames],
   );
@@ -148,6 +162,7 @@ export function resolveAuthConfig(): AuthConfig {
     routes,
     oidcClientId,
     oidcEnabled,
+    oidcScopes,
     source: {
       authBaseUrl: authBaseUrl ? 'env' : 'default',
       cookieDomain: cookieDomain ? 'env' : 'default',

--- a/src/webfront/lib/constants.ts
+++ b/src/webfront/lib/constants.ts
@@ -19,6 +19,12 @@ export const AUTH_OIDC_CLIENT_ID = authConfig.oidcClientId ?? 'workx-desktop';
  * legacy desktop-token flow is used so login never hard-breaks pre-registration.
  */
 export const AUTH_OIDC_ENABLED = authConfig.oidcEnabled;
+/**
+ * OIDC scopes requested at authorize time. Defaults to the identity scopes;
+ * override via `WORKX_/VITE_AUTH_OIDC_SCOPES` (e.g. add `chat apps models`) so
+ * the issued token carries the `svc:hub` audience required by the Hub gateway.
+ */
+export const AUTH_OIDC_SCOPES = authConfig.oidcScopes ?? 'openid profile email';
 /** Custom-scheme deep-link the desktop registers for the OIDC redirect. */
 export const DESKTOP_OIDC_REDIRECT_URI = 'workx://auth/callback';
 

--- a/src/webfront/stores/__tests__/userStore.test.ts
+++ b/src/webfront/stores/__tests__/userStore.test.ts
@@ -5,8 +5,15 @@ async function loadUserStore(opts: {
   loginPath?: string | null;
   oidcEnabled?: boolean;
   clientId?: string | null;
+  scopes?: string;
 }) {
-  const { homeUrl, loginPath = '/signin', oidcEnabled = false, clientId = 'workx-desktop' } = opts;
+  const {
+    homeUrl,
+    loginPath = '/signin',
+    oidcEnabled = false,
+    clientId = 'workx-desktop',
+    scopes = 'openid profile email',
+  } = opts;
   vi.resetModules();
   vi.doMock('../../lib/constants', () => ({
     AUTH_ROUTE_PATHS: {
@@ -17,6 +24,7 @@ async function loadUserStore(opts: {
     AUTH_OIDC_TOKEN_PATH: '/auth/token',
     AUTH_OIDC_CLIENT_ID: clientId,
     AUTH_OIDC_ENABLED: oidcEnabled,
+    AUTH_OIDC_SCOPES: scopes,
     DESKTOP_OIDC_REDIRECT_URI: 'workx://auth/callback',
   }));
   return import('../userStore');
@@ -101,6 +109,16 @@ describe('userStore desktop OIDC helpers', () => {
     expect(url.searchParams.get('code_challenge')).toBe('CHALLENGE');
     expect(url.searchParams.get('code_challenge_method')).toBe('S256');
     expect(url.searchParams.get('state')).toBe('STATE123');
+  });
+
+  it('requests the configured gateway scopes when AUTH_OIDC_SCOPES is overridden', async () => {
+    const { getDesktopAuthorizeUrl } = await loadUserStore({
+      homeUrl: 'https://home.example.com',
+      oidcEnabled: true,
+      scopes: 'openid profile email chat apps models',
+    });
+    const url = new URL(getDesktopAuthorizeUrl({ codeChallenge: 'CHALLENGE', state: 'STATE123' })!);
+    expect(url.searchParams.get('scope')).toBe('openid profile email chat apps models');
   });
 
   it('getDesktopAuthorizeUrl returns null when OIDC is disabled', async () => {

--- a/src/webfront/stores/userStore.ts
+++ b/src/webfront/stores/userStore.ts
@@ -13,6 +13,7 @@ import {
   AUTH_OIDC_TOKEN_PATH,
   AUTH_OIDC_CLIENT_ID,
   AUTH_OIDC_ENABLED,
+  AUTH_OIDC_SCOPES,
   DESKTOP_OIDC_REDIRECT_URI,
 } from '../lib/constants';
 
@@ -159,7 +160,7 @@ export function getDesktopAuthorizeUrl(opts: { codeChallenge: string; state: str
   url.searchParams.set('response_type', 'code');
   url.searchParams.set('client_id', AUTH_OIDC_CLIENT_ID);
   url.searchParams.set('redirect_uri', DESKTOP_OIDC_REDIRECT_URI);
-  url.searchParams.set('scope', 'openid profile email');
+  url.searchParams.set('scope', AUTH_OIDC_SCOPES);
   url.searchParams.set('code_challenge', opts.codeChallenge);
   url.searchParams.set('code_challenge_method', 'S256');
   url.searchParams.set('state', opts.state);


### PR DESCRIPTION
## Why

main's desktop OIDC+PKCE login (#5de86bc9 / #69eab7dc) hardcodes `scope=openid profile email` in the authorize URL. The issued token therefore never carries the `chat apps models` scopes that home-page's `_hub_gateway_grant` requires to mint the `svc:hub` audience — so the desktop can sign in but **cannot reach the AI Hub gateway**, which is the goal of the workx↔Hub first-party integration.

This is the missing piece after the parallel OIDC login landed on main. (It supersedes #287, which carried a different, configurable-scopes implementation; #287 is closed in favour of this minimal seam on top of main's hardened version.)

## What

- Add a `WORKX_/VITE_AUTH_OIDC_SCOPES` env seam: `authConfig.oidcScopes` → `AUTH_OIDC_SCOPES` → used by `getDesktopAuthorizeUrl`.
- **Default unchanged** (`openid profile email`), so behaviour is identical unless a deployment opts in by adding `chat apps models`.
- Preserves main's `oidcEnabled` kill-switch and token-URL origin validation — no change to either.

## Tests

- New unit test: overriding `AUTH_OIDC_SCOPES` flows `openid profile email chat apps models` through to the authorize URL's `scope` param.
- Existing authorize-URL test (asserts the default) still passes.
- `type-check` clean; userStore + authConfig suites green (14 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)