### PR TITLE
fix(settings): route BYOK credential ops (Test Connection + key persistence) through the sidecar

### DIFF
--- a/packages/ws-server/src/__tests__/methods.test.ts
+++ b/packages/ws-server/src/__tests__/methods.test.ts
@@ -46,6 +46,7 @@ describe('METHOD_REGISTRY', () => {
     expect(METHOD_REGISTRY['credentials.list'].scope).toBe('credentials.read');
     expect(METHOD_REGISTRY['credentials.set'].scope).toBe('credentials.write');
     expect(METHOD_REGISTRY['credentials.delete'].scope).toBe('credentials.write');
+    expect(METHOD_REGISTRY['models.testConnection'].scope).toBe('credentials.write');
   });
 
   it('contains approval method', () => {

--- a/packages/ws-server/src/methods.ts
+++ b/packages/ws-server/src/methods.ts
@@ -71,6 +71,9 @@ export const METHOD_REGISTRY: Record<string, MethodSpec> = {
   'credentials.set': { scope: 'credentials.write' },
   'credentials.delete': { scope: 'credentials.write' },
 
+  // Model connection checks send caller-supplied API keys over the transport.
+  'models.testConnection': { scope: 'credentials.write' },
+
   // Execution approvals
   'exec.approval.resolve': { scope: 'operator.approvals' },
 };

--- a/src/core/services/__tests__/credentials-services.test.ts
+++ b/src/core/services/__tests__/credentials-services.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createCredentialServices } from '../credentials-services';
+import { setCredentialStore } from '@/core/storage';
+import type { CredentialStore } from '@/core/storage/CredentialStore';
+
+const handlers = createCredentialServices({});
+
+function mockStore(): CredentialStore & {
+  get: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  listAccounts: ReturnType<typeof vi.fn>;
+} {
+  return {
+    get: vi.fn(async () => 'sk-stored'),
+    set: vi.fn(async () => undefined),
+    delete: vi.fn(async () => undefined),
+    listAccounts: vi.fn(async () => ['provider-apikey-moonshot']),
+  };
+}
+
+describe('credentials.* service handlers', () => {
+  let store: ReturnType<typeof mockStore>;
+
+  beforeEach(() => {
+    store = mockStore();
+    setCredentialStore(store);
+  });
+
+  afterEach(() => {
+    // Reset the singleton so an uninitialized-store test can run.
+    setCredentialStore(null as unknown as CredentialStore);
+    vi.restoreAllMocks();
+  });
+
+  it('credentials.get reads from the store', async () => {
+    const res = await handlers['credentials.get']({ service: 'workx', account: 'provider-apikey-moonshot' }, {} as any);
+    expect(res).toEqual({ value: 'sk-stored' });
+    expect(store.get).toHaveBeenCalledWith('workx', 'provider-apikey-moonshot');
+  });
+
+  it('credentials.set writes to the store', async () => {
+    const res = await handlers['credentials.set'](
+      { service: 'workx', account: 'provider-apikey-moonshot', password: 'sk-new' },
+      {} as any,
+    );
+    expect(res).toEqual({ ok: true });
+    expect(store.set).toHaveBeenCalledWith('workx', 'provider-apikey-moonshot', 'sk-new');
+  });
+
+  it('credentials.delete removes from the store', async () => {
+    const res = await handlers['credentials.delete']({ service: 'workx', account: 'provider-apikey-moonshot' }, {} as any);
+    expect(res).toEqual({ ok: true });
+    expect(store.delete).toHaveBeenCalledWith('workx', 'provider-apikey-moonshot');
+  });
+
+  it('credentials.listAccounts lists accounts', async () => {
+    const res = await handlers['credentials.listAccounts']({ service: 'workx' }, {} as any);
+    expect(res).toEqual({ accounts: ['provider-apikey-moonshot'] });
+  });
+
+  it('throws a clear error when the store is not initialized', async () => {
+    setCredentialStore(null as unknown as CredentialStore);
+    await expect(
+      handlers['credentials.get']({ service: 'workx', account: 'x' }, {} as any),
+    ).rejects.toThrow(/not initialized/);
+  });
+});

--- a/src/core/services/__tests__/models-services.test.ts
+++ b/src/core/services/__tests__/models-services.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createModelServices } from '../models-services';
+
+const handler = createModelServices({})['models.testConnection'];
+
+function jsonResponse(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
+
+const OPENAI = {
+  providerId: 'moonshot',
+  baseUrl: 'https://api.moonshot.ai/v1',
+  apiKey: 'sk-test',
+  model: 'kimi-k2',
+  organization: null,
+};
+
+describe('models.testConnection', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('lists models (prompt-free) and reports valid on 200', async () => {
+    const fetchMock = vi.fn<FetchFn>(async () => jsonResponse(200, { data: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handler(OPENAI, {} as any);
+
+    expect(result).toEqual({ valid: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.moonshot.ai/v1/models');
+    expect(init?.method).toBe('GET');
+    expect((init?.headers as Record<string, string>).Authorization).toBe('Bearer sk-test');
+    // Prompt-free: only one request, no chat/completions.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports invalid API key on 401', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(401, { error: 'unauthorized' })));
+    const result = await handler(OPENAI, {} as any);
+    expect(result).toEqual({ valid: false, error: 'Invalid API key' });
+  });
+
+  it('falls back to a 1-token completion when /models is unsupported (404)', async () => {
+    const fetchMock = vi
+      .fn<FetchFn>()
+      .mockResolvedValueOnce(jsonResponse(404, { error: 'not found' }))
+      .mockResolvedValueOnce(jsonResponse(200, { id: 'x' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handler(OPENAI, {} as any);
+
+    expect(result).toEqual({ valid: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [url, init] = fetchMock.mock.calls[1];
+    expect(url).toBe('https://api.moonshot.ai/v1/chat/completions');
+    expect(init?.method).toBe('POST');
+    const body = JSON.parse(init?.body as string);
+    expect(body.max_tokens).toBe(1);
+  });
+
+  it('treats a 400 from the minimal payload as a valid key', async () => {
+    const fetchMock = vi
+      .fn<FetchFn>()
+      .mockResolvedValueOnce(jsonResponse(404))
+      .mockResolvedValueOnce(jsonResponse(400, { error: 'bad request' }));
+    vi.stubGlobal('fetch', fetchMock);
+    expect(await handler(OPENAI, {} as any)).toEqual({ valid: true });
+  });
+
+  it('uses Anthropic auth headers + messages endpoint on fallback', async () => {
+    const fetchMock = vi
+      .fn<FetchFn>()
+      .mockResolvedValueOnce(jsonResponse(405))
+      .mockResolvedValueOnce(jsonResponse(200));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await handler(
+      { providerId: 'anthropic', baseUrl: 'https://api.anthropic.com/v1/messages', apiKey: 'ak', model: 'claude-3' },
+      {} as any,
+    );
+
+    const [listUrl, listInit] = fetchMock.mock.calls[0];
+    expect(listUrl).toBe('https://api.anthropic.com/v1/models');
+    expect((listInit?.headers as Record<string, string>)['x-api-key']).toBe('ak');
+    expect((listInit?.headers as Record<string, string>)['anthropic-version']).toBe('2023-06-01');
+    const [msgUrl] = fetchMock.mock.calls[1];
+    expect(msgUrl).toBe('https://api.anthropic.com/v1/messages');
+  });
+
+  it('validates required params', async () => {
+    expect(await handler({ baseUrl: 'https://x/v1' }, {} as any)).toEqual({
+      valid: false,
+      error: 'API key is required',
+    });
+    expect(await handler({ apiKey: 'k' }, {} as any)).toEqual({
+      valid: false,
+      error: 'Base URL is required',
+    });
+  });
+
+  it('returns a network error message when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
+    expect(await handler(OPENAI, {} as any)).toEqual({ valid: false, error: 'ECONNREFUSED' });
+  });
+});

--- a/src/core/services/__tests__/models-services.test.ts
+++ b/src/core/services/__tests__/models-services.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { createModelServices } from '../models-services';
+import { createModelServices, testModelConnection } from '../models-services';
 
 const handler = createModelServices({})['models.testConnection'];
+const context = {} as Parameters<typeof handler>[1];
 
 function jsonResponse(status: number, body: unknown = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -23,6 +24,7 @@ const OPENAI = {
 
 describe('models.testConnection', () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -30,7 +32,7 @@ describe('models.testConnection', () => {
     const fetchMock = vi.fn<FetchFn>(async () => jsonResponse(200, { data: [] }));
     vi.stubGlobal('fetch', fetchMock);
 
-    const result = await handler(OPENAI, {} as any);
+    const result = await handler(OPENAI, context);
 
     expect(result).toEqual({ valid: true });
     const [url, init] = fetchMock.mock.calls[0];
@@ -43,7 +45,7 @@ describe('models.testConnection', () => {
 
   it('reports invalid API key on 401', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(401, { error: 'unauthorized' })));
-    const result = await handler(OPENAI, {} as any);
+    const result = await handler(OPENAI, context);
     expect(result).toEqual({ valid: false, error: 'Invalid API key' });
   });
 
@@ -54,7 +56,7 @@ describe('models.testConnection', () => {
       .mockResolvedValueOnce(jsonResponse(200, { id: 'x' }));
     vi.stubGlobal('fetch', fetchMock);
 
-    const result = await handler(OPENAI, {} as any);
+    const result = await handler(OPENAI, context);
 
     expect(result).toEqual({ valid: true });
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -65,13 +67,41 @@ describe('models.testConnection', () => {
     expect(body.max_tokens).toBe(1);
   });
 
+  it('preserves base URL query params when appending probe paths', async () => {
+    const fetchMock = vi
+      .fn<FetchFn>()
+      .mockResolvedValueOnce(jsonResponse(404))
+      .mockResolvedValueOnce(jsonResponse(200));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handler(
+      {
+        providerId: 'custom-azure',
+        baseUrl: 'https://example.openai.azure.com/openai/deployments/test/chat/completions?api-version=2024-02-15',
+        apiKey: 'sk-custom',
+        model: 'deployment-name',
+        isCustom: true,
+        apiFormat: 'chat_completions',
+      },
+      context,
+    );
+
+    expect(result).toEqual({ valid: true });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://example.openai.azure.com/openai/deployments/test/models?api-version=2024-02-15',
+    );
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      'https://example.openai.azure.com/openai/deployments/test/chat/completions?api-version=2024-02-15',
+    );
+  });
+
   it('treats a 400 from the minimal payload as a valid key', async () => {
     const fetchMock = vi
       .fn<FetchFn>()
       .mockResolvedValueOnce(jsonResponse(404))
       .mockResolvedValueOnce(jsonResponse(400, { error: 'bad request' }));
     vi.stubGlobal('fetch', fetchMock);
-    expect(await handler(OPENAI, {} as any)).toEqual({ valid: true });
+    expect(await handler(OPENAI, context)).toEqual({ valid: true });
   });
 
   it('uses Anthropic auth headers + messages endpoint on fallback', async () => {
@@ -82,8 +112,8 @@ describe('models.testConnection', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     await handler(
-      { providerId: 'anthropic', baseUrl: 'https://api.anthropic.com/v1/messages', apiKey: 'ak', model: 'claude-3' },
-      {} as any,
+      { providerId: 'anthropic', baseUrl: 'https://api.anthropic.com', apiKey: 'ak', model: 'claude-3' },
+      context,
     );
 
     const [listUrl, listInit] = fetchMock.mock.calls[0];
@@ -94,12 +124,79 @@ describe('models.testConnection', () => {
     expect(msgUrl).toBe('https://api.anthropic.com/v1/messages');
   });
 
+  it('uses Google AI Studio native models endpoint with API key query auth', async () => {
+    const fetchMock = vi.fn<FetchFn>(async () => jsonResponse(200, { models: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handler(
+      {
+        providerId: 'google-ai-studio',
+        baseUrl: 'https://generativelanguage.googleapis.com',
+        apiKey: 'AIza-test',
+        model: 'gemini-3.1-pro',
+      },
+      context,
+    );
+
+    expect(result).toEqual({ valid: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://generativelanguage.googleapis.com/v1beta/models?key=AIza-test');
+    expect(init?.method).toBe('GET');
+    expect((init?.headers as Record<string, string> | undefined)?.Authorization).toBeUndefined();
+  });
+
+  it('reports invalid Google API keys from the Google 400 error shape', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(400, {
+      error: { message: 'API key not valid. Please pass a valid API key.' },
+    })));
+
+    expect(await handler(
+      {
+        providerId: 'google-ai-studio',
+        baseUrl: 'https://generativelanguage.googleapis.com',
+        apiKey: 'bad',
+        model: 'gemini-3.1-pro',
+      },
+      context,
+    )).toEqual({ valid: false, error: 'Invalid API key' });
+  });
+
+  it('falls back to /responses for custom Responses API providers', async () => {
+    const fetchMock = vi
+      .fn<FetchFn>()
+      .mockResolvedValueOnce(jsonResponse(404))
+      .mockResolvedValueOnce(jsonResponse(200));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handler(
+      {
+        providerId: 'custom-abc',
+        baseUrl: 'https://api.example.com/v1',
+        apiKey: 'sk-custom',
+        model: 'custom-model',
+        apiFormat: 'responses',
+        isCustom: true,
+      },
+      context,
+    );
+
+    expect(result).toEqual({ valid: true });
+    const [url, init] = fetchMock.mock.calls[1];
+    expect(url).toBe('https://api.example.com/v1/responses');
+    const body = JSON.parse(init?.body as string);
+    expect(body).toMatchObject({ model: 'custom-model', input: 'ping', max_output_tokens: 1 });
+  });
+
   it('validates required params', async () => {
-    expect(await handler({ baseUrl: 'https://x/v1' }, {} as any)).toEqual({
+    expect(await testModelConnection()).toEqual({
       valid: false,
       error: 'API key is required',
     });
-    expect(await handler({ apiKey: 'k' }, {} as any)).toEqual({
+    expect(await handler({ baseUrl: 'https://x/v1' }, context)).toEqual({
+      valid: false,
+      error: 'API key is required',
+    });
+    expect(await handler({ apiKey: 'k' }, context)).toEqual({
       valid: false,
       error: 'Base URL is required',
     });
@@ -107,6 +204,27 @@ describe('models.testConnection', () => {
 
   it('returns a network error message when fetch throws', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
-    expect(await handler(OPENAI, {} as any)).toEqual({ valid: false, error: 'ECONNREFUSED' });
+    expect(await handler(OPENAI, context)).toEqual({ valid: false, error: 'ECONNREFUSED' });
+  });
+
+  it('times out a hanging provider request', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn<FetchFn>(
+      (_url, init) => new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('Aborted', 'AbortError'));
+        });
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const resultPromise = handler(OPENAI, context);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await expect(resultPromise).resolves.toEqual({
+      valid: false,
+      error: 'Connection test timed out after 30 seconds',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/core/services/credentials-services.ts
+++ b/src/core/services/credentials-services.ts
@@ -1,0 +1,62 @@
+/**
+ * Credential Service Handlers
+ *
+ * Platform-agnostic `credentials.*` service handlers that expose the runtime's
+ * credential store (OS keychain on desktop, chrome.storage in the extension
+ * service worker) to callers that cannot reach it directly.
+ *
+ * The desktop **webview** has no access to the OS keychain — that store is only
+ * initialized in the `desktop-runtime` sidecar (`ServerAgentBootstrap`). Without
+ * these handlers, a webview-side `AgentConfig` silently drops BYOK API keys
+ * (`AgentConfig.getCredentials()` returns null), so saved keys vanish on reload.
+ * The webview's `RuntimeRelayCredentialStore` forwards get/set/delete/list here
+ * so credential operations execute where the real store lives.
+ *
+ * @module core/services/credentials-services
+ */
+
+import type { ServiceHandler } from '@/core/channels/ServiceRegistry';
+import { getCredentialStore, isCredentialStoreInitialized } from '@/core/storage';
+
+export interface CredentialServiceDeps {
+  /**
+   * Reserved for future injected dependencies. The handlers use the runtime's
+   * global credential-store singleton, but a deps object is still required so
+   * `registerAllServices` wires the factory.
+   */
+  enabled?: boolean;
+}
+
+function requireStore() {
+  if (!isCredentialStoreInitialized()) {
+    throw new Error('Credential store is not initialized in this runtime');
+  }
+  return getCredentialStore();
+}
+
+export function createCredentialServices(_deps: CredentialServiceDeps): Record<string, ServiceHandler> {
+  return {
+    'credentials.get': async (params) => {
+      const { service, account } = params as { service: string; account: string };
+      return { value: await requireStore().get(service, account) };
+    },
+    'credentials.set': async (params) => {
+      const { service, account, password } = params as {
+        service: string;
+        account: string;
+        password: string;
+      };
+      await requireStore().set(service, account, password);
+      return { ok: true };
+    },
+    'credentials.delete': async (params) => {
+      const { service, account } = params as { service: string; account: string };
+      await requireStore().delete(service, account);
+      return { ok: true };
+    },
+    'credentials.listAccounts': async (params) => {
+      const { service } = params as { service: string };
+      return { accounts: await requireStore().listAccounts(service) };
+    },
+  };
+}

--- a/src/core/services/index.ts
+++ b/src/core/services/index.ts
@@ -21,6 +21,7 @@ import { createPluginsServices, type PluginsServiceDeps } from './plugins-servic
 import { createDiagnosticsServices, type DiagnosticsServiceDeps } from './diagnostics-services';
 import { createMemoryServices, type MemoryServiceDeps } from './memory-services';
 import { createRuntimeServices, type RuntimeServiceDeps } from './runtime-services';
+import { createModelServices, type ModelsServiceDeps } from './models-services';
 
 /**
  * Dependencies for registering all services.
@@ -40,6 +41,7 @@ export interface AllServiceDeps {
   diagnostics?: DiagnosticsServiceDeps;
   memory?: MemoryServiceDeps;
   runtime?: RuntimeServiceDeps;
+  models?: ModelsServiceDeps;
 }
 
 /**
@@ -67,6 +69,7 @@ export function registerAllServices(
     ['diagnostics', createDiagnosticsServices],
     ['memory', createMemoryServices],
     ['runtime', createRuntimeServices],
+    ['models', createModelServices],
   ];
 
   for (const [key, factory] of factories) {
@@ -97,3 +100,4 @@ export { createPluginsServices, type PluginsServiceDeps } from './plugins-servic
 export { createDiagnosticsServices, type DiagnosticsServiceDeps } from './diagnostics-services';
 export { createMemoryServices, type MemoryServiceDeps } from './memory-services';
 export { createRuntimeServices, type RuntimeServiceDeps } from './runtime-services';
+export { createModelServices, type ModelsServiceDeps } from './models-services';

--- a/src/core/services/index.ts
+++ b/src/core/services/index.ts
@@ -22,6 +22,7 @@ import { createDiagnosticsServices, type DiagnosticsServiceDeps } from './diagno
 import { createMemoryServices, type MemoryServiceDeps } from './memory-services';
 import { createRuntimeServices, type RuntimeServiceDeps } from './runtime-services';
 import { createModelServices, type ModelsServiceDeps } from './models-services';
+import { createCredentialServices, type CredentialServiceDeps } from './credentials-services';
 
 /**
  * Dependencies for registering all services.
@@ -42,6 +43,7 @@ export interface AllServiceDeps {
   memory?: MemoryServiceDeps;
   runtime?: RuntimeServiceDeps;
   models?: ModelsServiceDeps;
+  credentials?: CredentialServiceDeps;
 }
 
 /**
@@ -70,6 +72,7 @@ export function registerAllServices(
     ['memory', createMemoryServices],
     ['runtime', createRuntimeServices],
     ['models', createModelServices],
+    ['credentials', createCredentialServices],
   ];
 
   for (const [key, factory] of factories) {
@@ -101,3 +104,4 @@ export { createDiagnosticsServices, type DiagnosticsServiceDeps } from './diagno
 export { createMemoryServices, type MemoryServiceDeps } from './memory-services';
 export { createRuntimeServices, type RuntimeServiceDeps } from './runtime-services';
 export { createModelServices, type ModelsServiceDeps } from './models-services';
+export { createCredentialServices, type CredentialServiceDeps } from './credentials-services';

--- a/src/core/services/models-services.ts
+++ b/src/core/services/models-services.ts
@@ -29,10 +29,23 @@ export interface ModelsServiceDeps {
   enabled?: boolean;
 }
 
-interface TestConnectionResult {
+export interface TestConnectionResult {
   valid: boolean;
   error?: string;
 }
+
+interface TestConnectionParams {
+  providerId?: unknown;
+  baseUrl?: unknown;
+  apiKey?: unknown;
+  model?: unknown;
+  organization?: unknown;
+  apiFormat?: unknown;
+  isCustom?: unknown;
+}
+
+const TEST_CONNECTION_TIMEOUT_MS = 30_000;
+const TRAILING_OPERATION_PATH = /\/(chat\/completions|completions|messages|responses|models)$/i;
 
 /**
  * Strip a trailing operation path so we can derive sibling endpoints. Stored
@@ -42,9 +55,11 @@ interface TestConnectionResult {
  * `/models` and the completion endpoint uniformly.
  */
 function rootOf(baseUrl: string): string {
-  return baseUrl
+  const url = new URL(baseUrl);
+  url.pathname = url.pathname
     .replace(/\/+$/, '')
-    .replace(/\/(chat\/completions|completions|messages)$/i, '');
+    .replace(TRAILING_OPERATION_PATH, '') || '/';
+  return url.toString();
 }
 
 function authHeaders(
@@ -60,65 +75,209 @@ function authHeaders(
   return headers;
 }
 
+function joinUrl(root: string, path: string): string {
+  const url = new URL(root);
+  const rootPath = url.pathname.replace(/\/+$/, '');
+  const childPath = path.replace(/^\/+/, '');
+  url.pathname = `${rootPath}/${childPath}`.replace(/\/{2,}/g, '/');
+  return url.toString();
+}
+
+function ensureVersion(root: string, version: string): string {
+  const url = new URL(root);
+  return new RegExp(`/${version}$`, 'i').test(url.pathname.replace(/\/+$/, ''))
+    ? url.toString()
+    : joinUrl(url.toString(), version);
+}
+
+function googleRootOf(baseUrl: string): string {
+  const url = new URL(baseUrl);
+  url.pathname = url.pathname
+    .replace(/\/+$/, '')
+    .replace(/\/v1beta\/openai$/i, '')
+    .replace(/\/v1beta$/i, '')
+    .replace(/\/v1$/i, '') || '/';
+  return url.toString();
+}
+
+function withApiKey(url: string, apiKey: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set('key', apiKey);
+  return parsed.toString();
+}
+
+function isAbortError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'name' in error
+    && error.name === 'AbortError';
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit = {}): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TEST_CONNECTION_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: init.signal ?? controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function responseText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return '';
+  }
+}
+
+function invalidApiKeyMessage(status: number, body: string): string | null {
+  if (status === 401 || status === 403) return 'Invalid API key';
+  if (status !== 400) return null;
+
+  const text = body.toLowerCase();
+  if (
+    text.includes('invalid_api_key') ||
+    text.includes('api key not valid') ||
+    text.includes('invalid api key') ||
+    text.includes('invalid authentication') ||
+    text.includes('authentication failed')
+  ) {
+    return 'Invalid API key';
+  }
+  return null;
+}
+
 /**
  * Map an HTTP status to a verdict, or `null` when inconclusive (caller may
  * fall back to a completion probe before surfacing an error).
  */
-function classify(status: number, ok: boolean): TestConnectionResult | null {
-  if (ok) return { valid: true };
+async function classify(
+  response: Response,
+  opts: { allowBadRequestAsValid?: boolean } = {},
+): Promise<TestConnectionResult | null> {
+  if (response.ok) return { valid: true };
+  const body = await responseText(response);
+  const authError = invalidApiKeyMessage(response.status, body);
+  if (authError) return { valid: false, error: authError };
   // The request reached the model and authenticated, but our deliberately
   // minimal payload was rejected — the key itself is valid.
-  if (status === 400 || status === 422) return { valid: true };
-  if (status === 401 || status === 403) return { valid: false, error: 'Invalid API key' };
+  if (opts.allowBadRequestAsValid && (response.status === 400 || response.status === 422)) {
+    return { valid: true };
+  }
   return null;
+}
+
+function usesResponsesProbe(providerId: string, apiFormat: string, isCustom: boolean): boolean {
+  if (isCustom) return apiFormat === 'responses';
+  return providerId === 'openai' || providerId === 'xai' || providerId === 'groq';
+}
+
+async function testGoogleConnection(root: string, apiKey: string, model: string): Promise<TestConnectionResult> {
+  const versionRoot = joinUrl(googleRootOf(root), 'v1beta');
+  const listed = await fetchWithTimeout(withApiKey(joinUrl(versionRoot, 'models'), apiKey), { method: 'GET' });
+  const listedVerdict = await classify(listed);
+  if (listedVerdict) return listedVerdict;
+
+  if (!model) return { valid: false, error: `API error: ${listed.status}` };
+
+  const completed = await fetchWithTimeout(
+    withApiKey(joinUrl(versionRoot, `models/${encodeURIComponent(model)}:generateContent`), apiKey),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ role: 'user', parts: [{ text: 'ping' }] }],
+        generationConfig: { maxOutputTokens: 1 },
+      }),
+    },
+  );
+  const completedVerdict = await classify(completed, { allowBadRequestAsValid: true });
+  if (completedVerdict) return completedVerdict;
+  return { valid: false, error: `API error: ${completed.status}` };
+}
+
+async function testAnthropicConnection(
+  baseUrl: string,
+  apiKey: string,
+  model: string,
+): Promise<TestConnectionResult> {
+  const root = ensureVersion(rootOf(baseUrl), 'v1');
+  const headers = authHeaders('anthropic', apiKey, null);
+
+  const listed = await fetchWithTimeout(joinUrl(root, 'models'), { method: 'GET', headers });
+  const listedVerdict = await classify(listed);
+  if (listedVerdict) return listedVerdict;
+
+  if (!model) return { valid: false, error: `API error: ${listed.status}` };
+
+  const completed = await fetchWithTimeout(joinUrl(root, 'messages'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify({
+      model,
+      max_tokens: 1,
+      messages: [{ role: 'user', content: 'ping' }],
+    }),
+  });
+  const completedVerdict = await classify(completed, { allowBadRequestAsValid: true });
+  if (completedVerdict) return completedVerdict;
+  return { valid: false, error: `API error: ${completed.status}` };
+}
+
+export async function testModelConnection(params: TestConnectionParams = {}): Promise<TestConnectionResult> {
+  const providerId = String(params.providerId ?? '');
+  const baseUrl = String(params.baseUrl ?? '');
+  const apiKey = String(params.apiKey ?? '');
+  const model = String(params.model ?? '');
+  const organization = params.organization ? String(params.organization) : null;
+  const apiFormat = String(params.apiFormat ?? '');
+  const isCustom = params.isCustom === true;
+
+  if (!apiKey) return { valid: false, error: 'API key is required' };
+  if (!baseUrl) return { valid: false, error: 'Base URL is required' };
+
+  try {
+    if (providerId === 'google-ai-studio') {
+      return await testGoogleConnection(baseUrl, apiKey, model);
+    }
+    if (providerId === 'anthropic') {
+      return await testAnthropicConnection(baseUrl, apiKey, model);
+    }
+
+    const root = rootOf(baseUrl);
+    const headers = authHeaders(providerId, apiKey, organization);
+
+    // 1) Prompt-free probe: list models. Sufficient for virtually all
+    //    OpenAI-compatible providers.
+    const listed = await fetchWithTimeout(joinUrl(root, 'models'), { method: 'GET', headers });
+    const listedVerdict = await classify(listed);
+    if (listedVerdict) return listedVerdict;
+
+    // 2) Provider doesn't implement /models (404/405) or returned an
+    //    inconclusive status — fall back to a single 1-token completion,
+    //    matching the provider wire API where possible.
+    if (model) {
+      const useResponses = usesResponsesProbe(providerId, apiFormat, isCustom);
+      const completed = await fetchWithTimeout(joinUrl(root, useResponses ? 'responses' : 'chat/completions'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...headers },
+        body: JSON.stringify(useResponses
+          ? { model, input: 'ping', max_output_tokens: 1 }
+          : { model, max_tokens: 1, messages: [{ role: 'user', content: 'ping' }] }),
+      });
+      const completedVerdict = await classify(completed, { allowBadRequestAsValid: true });
+      if (completedVerdict) return completedVerdict;
+      return { valid: false, error: `API error: ${completed.status}` };
+    }
+
+    return { valid: false, error: `API error: ${listed.status}` };
+  } catch (error) {
+    if (isAbortError(error)) return { valid: false, error: 'Connection test timed out after 30 seconds' };
+    return { valid: false, error: error instanceof Error ? error.message : 'Network error' };
+  }
 }
 
 export function createModelServices(_deps: ModelsServiceDeps): Record<string, ServiceHandler> {
   return {
-    'models.testConnection': async (params): Promise<TestConnectionResult> => {
-      const providerId = String(params.providerId ?? '');
-      const baseUrl = String(params.baseUrl ?? '');
-      const apiKey = String(params.apiKey ?? '');
-      const model = String(params.model ?? '');
-      const organization = params.organization ? String(params.organization) : null;
-
-      if (!apiKey) return { valid: false, error: 'API key is required' };
-      if (!baseUrl) return { valid: false, error: 'Base URL is required' };
-
-      const root = rootOf(baseUrl);
-      const headers = authHeaders(providerId, apiKey, organization);
-
-      try {
-        // 1) Prompt-free probe: list models. Sufficient for virtually all
-        //    OpenAI-compatible providers and Anthropic.
-        const listed = await fetch(`${root}/models`, { method: 'GET', headers });
-        const listedVerdict = classify(listed.status, listed.ok);
-        if (listedVerdict) return listedVerdict;
-
-        // 2) Provider doesn't implement /models (404/405) or returned an
-        //    inconclusive status — fall back to a single 1-token completion,
-        //    which every chat provider supports, to confirm auth + reachability.
-        if (model) {
-          const isAnthropic = providerId === 'anthropic';
-          const url = isAnthropic ? `${root}/messages` : `${root}/chat/completions`;
-          const completed = await fetch(url, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', ...headers },
-            body: JSON.stringify({
-              model,
-              max_tokens: 1,
-              messages: [{ role: 'user', content: 'ping' }],
-            }),
-          });
-          const completedVerdict = classify(completed.status, completed.ok);
-          if (completedVerdict) return completedVerdict;
-          return { valid: false, error: `API error: ${completed.status}` };
-        }
-
-        return { valid: false, error: `API error: ${listed.status}` };
-      } catch (error) {
-        return { valid: false, error: error instanceof Error ? error.message : 'Network error' };
-      }
-    },
+    'models.testConnection': async (params): Promise<TestConnectionResult> => testModelConnection(params ?? {}),
   };
 }

--- a/src/core/services/models-services.ts
+++ b/src/core/services/models-services.ts
@@ -1,0 +1,124 @@
+/**
+ * Model Service Handlers
+ *
+ * Platform-agnostic `models.*` service handlers. Auto-registered on extension,
+ * desktop, and server by `registerAllServices`.
+ *
+ * `models.testConnection` validates a BYOK provider's API key + base URL by
+ * making a REAL request from the runtime (desktop sidecar / extension service
+ * worker / server) — never the webview. Third-party LLM APIs are server-to-
+ * server endpoints: they reject browser-origin requests via CORS (and the Tauri
+ * webview cannot reach them at all), so the old in-webview probe always failed
+ * for desktop. Routing the probe through the runtime sidesteps CORS entirely.
+ *
+ * The probe is prompt-free where possible: it lists models (`GET {root}/models`)
+ * and only falls back to a single 1-token completion when a provider does not
+ * implement the models endpoint.
+ *
+ * @module core/services/models-services
+ */
+
+import type { ServiceHandler } from '@/core/channels/ServiceRegistry';
+
+export interface ModelsServiceDeps {
+  /**
+   * Reserved for future injected dependencies. The connection probe is
+   * currently stateless (it only needs the caller-supplied credentials), but a
+   * deps object is still required so `registerAllServices` wires the factory.
+   */
+  enabled?: boolean;
+}
+
+interface TestConnectionResult {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * Strip a trailing operation path so we can derive sibling endpoints. Stored
+ * base URLs are inconsistent across providers: OpenAI-compatible ones are the
+ * API root (e.g. `https://api.moonshot.ai/v1`), while Anthropic's may be the
+ * full `.../v1/messages` endpoint. Normalising to the root lets us address both
+ * `/models` and the completion endpoint uniformly.
+ */
+function rootOf(baseUrl: string): string {
+  return baseUrl
+    .replace(/\/+$/, '')
+    .replace(/\/(chat\/completions|completions|messages)$/i, '');
+}
+
+function authHeaders(
+  providerId: string,
+  apiKey: string,
+  organization: string | null,
+): Record<string, string> {
+  if (providerId === 'anthropic') {
+    return { 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' };
+  }
+  const headers: Record<string, string> = { Authorization: `Bearer ${apiKey}` };
+  if (organization) headers['OpenAI-Organization'] = organization;
+  return headers;
+}
+
+/**
+ * Map an HTTP status to a verdict, or `null` when inconclusive (caller may
+ * fall back to a completion probe before surfacing an error).
+ */
+function classify(status: number, ok: boolean): TestConnectionResult | null {
+  if (ok) return { valid: true };
+  // The request reached the model and authenticated, but our deliberately
+  // minimal payload was rejected — the key itself is valid.
+  if (status === 400 || status === 422) return { valid: true };
+  if (status === 401 || status === 403) return { valid: false, error: 'Invalid API key' };
+  return null;
+}
+
+export function createModelServices(_deps: ModelsServiceDeps): Record<string, ServiceHandler> {
+  return {
+    'models.testConnection': async (params): Promise<TestConnectionResult> => {
+      const providerId = String(params.providerId ?? '');
+      const baseUrl = String(params.baseUrl ?? '');
+      const apiKey = String(params.apiKey ?? '');
+      const model = String(params.model ?? '');
+      const organization = params.organization ? String(params.organization) : null;
+
+      if (!apiKey) return { valid: false, error: 'API key is required' };
+      if (!baseUrl) return { valid: false, error: 'Base URL is required' };
+
+      const root = rootOf(baseUrl);
+      const headers = authHeaders(providerId, apiKey, organization);
+
+      try {
+        // 1) Prompt-free probe: list models. Sufficient for virtually all
+        //    OpenAI-compatible providers and Anthropic.
+        const listed = await fetch(`${root}/models`, { method: 'GET', headers });
+        const listedVerdict = classify(listed.status, listed.ok);
+        if (listedVerdict) return listedVerdict;
+
+        // 2) Provider doesn't implement /models (404/405) or returned an
+        //    inconclusive status — fall back to a single 1-token completion,
+        //    which every chat provider supports, to confirm auth + reachability.
+        if (model) {
+          const isAnthropic = providerId === 'anthropic';
+          const url = isAnthropic ? `${root}/messages` : `${root}/chat/completions`;
+          const completed = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...headers },
+            body: JSON.stringify({
+              model,
+              max_tokens: 1,
+              messages: [{ role: 'user', content: 'ping' }],
+            }),
+          });
+          const completedVerdict = classify(completed.status, completed.ok);
+          if (completedVerdict) return completedVerdict;
+          return { valid: false, error: `API error: ${completed.status}` };
+        }
+
+        return { valid: false, error: `API error: ${listed.status}` };
+      } catch (error) {
+        return { valid: false, error: error instanceof Error ? error.message : 'Network error' };
+      }
+    },
+  };
+}

--- a/src/desktop/ui/main.ts
+++ b/src/desktop/ui/main.ts
@@ -25,7 +25,8 @@ import { initializeDesktop } from '../main';
 import { getInitializedUIClient } from '@/core/messaging';
 import { initLocale } from '../../webfront/lib/i18n';
 import { AgentConfig } from '@/config/AgentConfig';
-import { initializeConfigStorage } from '@/core/storage';
+import { initializeConfigStorage, setCredentialStore } from '@/core/storage';
+import { RuntimeRelayCredentialStore } from '@/webfront/credentials/RuntimeRelayCredentialStore';
 import { markDesktopWelcomeCompleted, shouldShowDesktopWelcome } from './desktopWelcome';
 
 // Add desktop-mode and terminal-mode classes to body
@@ -47,6 +48,11 @@ async function init() {
     console.warn('[Desktop] Failed to initialize config storage:', error);
     // Continue - will fall back to in-memory storage
   }
+
+  // 0b. Install the credential store. The OS keychain lives in the sidecar, so
+  // the webview relays credential ops over the runtime channel. Without this,
+  // AgentConfig.getCredentials() is null and BYOK API keys are silently dropped.
+  setCredentialStore(new RuntimeRelayCredentialStore());
 
   // 1. Subscribe to runtime lifecycle events before starting the sidecar so
   // the very first `runtime:ready` / `runtime:reconnecting` event flips the

--- a/src/extension/background/service-worker.ts
+++ b/src/extension/background/service-worker.ts
@@ -668,6 +668,10 @@ async function registerServiceHandlers(): Promise<void> {
       // Stateless BYOK connection probe — runs the real provider call from the
       // service worker (no CORS), matching desktop/server behavior.
       models: {},
+      // Credential store relay (parity with desktop/server). The side panel uses
+      // ChromeCredentialStore directly, so these are unused in practice here, but
+      // registering keeps the service surface uniform across platforms.
+      credentials: {},
       diagnostics: {
         buildCtx: () => ({
           platformId: 'extension',

--- a/src/extension/background/service-worker.ts
+++ b/src/extension/background/service-worker.ts
@@ -665,6 +665,9 @@ async function registerServiceHandlers(): Promise<void> {
     const count = registerAllServices(serviceRegistry, {
       mcp: mcpManager ? { mcpManager } : undefined,
       scheduler: scheduler ? { scheduler } : undefined,
+      // Stateless BYOK connection probe — runs the real provider call from the
+      // service worker (no CORS), matching desktop/server behavior.
+      models: {},
       diagnostics: {
         buildCtx: () => ({
           platformId: 'extension',

--- a/src/server/agent/ServerAgentBootstrap.ts
+++ b/src/server/agent/ServerAgentBootstrap.ts
@@ -84,6 +84,7 @@ import { ServerLogSink } from '../telemetry/ServerLogSink';
 import { registerExecHandlers } from '../handlers/exec';
 import { registerSchedulerHandlers } from '../handlers/scheduler';
 import { registerCredentialsHandlers } from '../handlers/credentials';
+import { registerModelHandlers } from '../handlers/models';
 import { emitLog } from '../handlers/logs';
 
 // Scheduler
@@ -1709,6 +1710,7 @@ export class ServerAgentBootstrap {
     registerConfigHandlers();
     registerHealthHandlers();
     registerLogsHandlers();
+    registerModelHandlers();
 
     registerToolsHandlers({
       getToolCatalog: async () => {

--- a/src/server/agent/ServerAgentBootstrap.ts
+++ b/src/server/agent/ServerAgentBootstrap.ts
@@ -1269,6 +1269,10 @@ export class ServerAgentBootstrap {
       // Stateless BYOK connection probe — runs the real provider call from the
       // runtime (no CORS), so the webview never has to reach LLM APIs directly.
       models: {},
+      // Expose the runtime credential store (OS keychain) to the desktop
+      // webview, which cannot reach it directly. Without this, webview-side
+      // BYOK API key saves are silently dropped.
+      credentials: {},
     });
 
     console.log(`[ServerAgentBootstrap] Registered ${count} service handlers`);

--- a/src/server/agent/ServerAgentBootstrap.ts
+++ b/src/server/agent/ServerAgentBootstrap.ts
@@ -1266,6 +1266,9 @@ export class ServerAgentBootstrap {
       },
       memory: this.registry ? { registry: this.registry } : undefined,
       runtime: runtimeState ? { runtimeState } : undefined,
+      // Stateless BYOK connection probe — runs the real provider call from the
+      // runtime (no CORS), so the webview never has to reach LLM APIs directly.
+      models: {},
     });
 
     console.log(`[ServerAgentBootstrap] Registered ${count} service handlers`);

--- a/src/server/handlers/__tests__/models.test.ts
+++ b/src/server/handlers/__tests__/models.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@workx/ws-server', () => {
+  const handlers = new Map<string, Function>();
+  return {
+    registerMethodHandler: vi.fn((method: string, handler: Function) => {
+      handlers.set(method, handler);
+    }),
+    getMethodHandler: (method: string) => handlers.get(method),
+    unauthorized: (msg: string) => ({ code: 'UNAUTHORIZED', message: msg, retryable: false }),
+  };
+});
+
+vi.mock('../../auth/authorize', () => ({
+  getConnectionAuth: vi.fn(),
+}));
+
+vi.mock('../../config/server-config', () => ({
+  getServerConfig: vi.fn(),
+}));
+
+vi.mock('@/core/services/models-services', () => ({
+  testModelConnection: vi.fn(),
+}));
+
+import { getMethodHandler } from '@workx/ws-server';
+import type { MethodContext } from '@workx/ws-server';
+import { testModelConnection } from '@/core/services/models-services';
+import { getConnectionAuth } from '../../auth/authorize';
+import { getServerConfig } from '../../config/server-config';
+import { registerModelHandlers } from '../models';
+
+function makeCtx(overrides?: Partial<MethodContext>): MethodContext {
+  return {
+    connectionId: 'conn_test123',
+    requestId: 'req_1',
+    role: 'operator',
+    scopes: ['credentials.write'],
+    sendEvent: vi.fn(),
+    ...overrides,
+  };
+}
+
+function mockLoopback(): void {
+  vi.mocked(getConnectionAuth).mockReturnValue({
+    connectionId: 'conn_test123',
+    role: 'operator',
+    scopes: ['credentials.write'],
+    authenticated: true,
+    isLoopback: true,
+  });
+  vi.mocked(getServerConfig).mockReturnValue({
+    server: { tls: { enabled: false } },
+  } as ReturnType<typeof getServerConfig>);
+}
+
+function mockRemoteNoTls(): void {
+  vi.mocked(getConnectionAuth).mockReturnValue({
+    connectionId: 'conn_test123',
+    role: 'operator',
+    scopes: ['credentials.write'],
+    authenticated: true,
+    isLoopback: false,
+  });
+  vi.mocked(getServerConfig).mockReturnValue({
+    server: { tls: { enabled: false } },
+  } as ReturnType<typeof getServerConfig>);
+}
+
+function mockTlsEnabled(): void {
+  vi.mocked(getConnectionAuth).mockReturnValue({
+    connectionId: 'conn_test123',
+    role: 'operator',
+    scopes: ['credentials.write'],
+    authenticated: true,
+    isLoopback: false,
+  });
+  vi.mocked(getServerConfig).mockReturnValue({
+    server: { tls: { enabled: true } },
+  } as ReturnType<typeof getServerConfig>);
+}
+
+describe('models handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registerModelHandlers();
+    vi.mocked(testModelConnection).mockResolvedValue({ valid: true });
+  });
+
+  it('registers models.testConnection and delegates on loopback', async () => {
+    mockLoopback();
+    const handler = getMethodHandler('models.testConnection')!;
+
+    const params = { providerId: 'openai', baseUrl: 'https://api.openai.com/v1', apiKey: 'sk-test' };
+    await expect(handler(params, makeCtx())).resolves.toEqual({ valid: true });
+    expect(testModelConnection).toHaveBeenCalledWith(params);
+  });
+
+  it('allows remote connection tests over TLS', async () => {
+    mockTlsEnabled();
+    const handler = getMethodHandler('models.testConnection')!;
+
+    await expect(handler({ apiKey: 'sk-test' }, makeCtx())).resolves.toEqual({ valid: true });
+  });
+
+  it('rejects non-TLS remote connection tests', async () => {
+    mockRemoteNoTls();
+    const handler = getMethodHandler('models.testConnection')!;
+
+    await expect(handler({ apiKey: 'sk-test' }, makeCtx())).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+      message: expect.stringContaining('TLS or loopback'),
+    });
+    expect(testModelConnection).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/handlers/models.ts
+++ b/src/server/handlers/models.ts
@@ -1,0 +1,32 @@
+/**
+ * Model Method Handlers
+ *
+ * Handles models.testConnection for web/server RPC clients by delegating to the
+ * shared runtime-side model service implementation.
+ *
+ * @module server/handlers/models
+ */
+
+import { registerMethodHandler, unauthorized, type MethodContext } from '@workx/ws-server';
+import { testModelConnection } from '@/core/services/models-services';
+import { getConnectionAuth } from '../auth/authorize';
+import { getServerConfig } from '../config/server-config';
+
+export function registerModelHandlers(): void {
+  registerMethodHandler('models.testConnection', handleModelsTestConnection);
+}
+
+function requireSecureTransport(ctx: MethodContext): void {
+  const config = getServerConfig();
+  const conn = getConnectionAuth(ctx.connectionId);
+  if (config.server.tls.enabled || conn?.isLoopback) return;
+  throw unauthorized('Connection tests require TLS or loopback connection');
+}
+
+async function handleModelsTestConnection(
+  params: Record<string, unknown> | undefined,
+  ctx: MethodContext,
+): Promise<unknown> {
+  requireSecureTransport(ctx);
+  return testModelConnection(params ?? {});
+}

--- a/src/webfront/credentials/RuntimeRelayCredentialStore.ts
+++ b/src/webfront/credentials/RuntimeRelayCredentialStore.ts
@@ -1,0 +1,46 @@
+/**
+ * Runtime-relay credential store (desktop webview).
+ *
+ * The desktop webview cannot reach the OS keychain — that store lives in the
+ * Node `desktop-runtime` sidecar. This implementation satisfies the
+ * `CredentialStore` interface by forwarding every operation over the runtime
+ * channel (`credentials.*` service handlers) so the real keychain set/get/delete
+ * happens in the sidecar. Installing it via `setCredentialStore()` at desktop
+ * boot makes the webview's `AgentConfig` persist BYOK API keys correctly instead
+ * of silently dropping them.
+ *
+ * @module webfront/credentials/RuntimeRelayCredentialStore
+ */
+
+import type { CredentialStore } from '@/core/storage/CredentialStore';
+import { getInitializedUIClient } from '@/core/messaging';
+
+export class RuntimeRelayCredentialStore implements CredentialStore {
+  async get(service: string, account: string): Promise<string | null> {
+    const client = await getInitializedUIClient();
+    const { value } = await client.serviceRequest<{ value: string | null }>('credentials.get', {
+      service,
+      account,
+    });
+    return value ?? null;
+  }
+
+  async set(service: string, account: string, password: string): Promise<void> {
+    const client = await getInitializedUIClient();
+    await client.serviceRequest('credentials.set', { service, account, password });
+  }
+
+  async delete(service: string, account: string): Promise<void> {
+    const client = await getInitializedUIClient();
+    await client.serviceRequest('credentials.delete', { service, account });
+  }
+
+  async listAccounts(service: string): Promise<string[]> {
+    const client = await getInitializedUIClient();
+    const { accounts } = await client.serviceRequest<{ accounts: string[] }>(
+      'credentials.listAccounts',
+      { service },
+    );
+    return accounts ?? [];
+  }
+}

--- a/src/webfront/main.ts
+++ b/src/webfront/main.ts
@@ -10,7 +10,7 @@ import { mount } from 'svelte';
 import App from './App.svelte';
 import { initLocale } from './lib/i18n';
 import { AgentConfig } from '@/config/AgentConfig';
-import { initializeConfigStorage } from '@/core/storage';
+import { initializeConfigStorage, initializeCredentialStore } from '@/core/storage';
 
 // Add terminal-mode class to body for terminal styling
 document.body.classList.add('terminal-mode');
@@ -26,6 +26,15 @@ async function init() {
     await initializeConfigStorage();
   } catch (error) {
     console.warn('[Extension] Failed to initialize config storage:', error);
+  }
+
+  // The side panel has its own JS context, separate from the service worker.
+  // AgentConfig writes BYOK keys through this singleton, so initialize it here
+  // before settings code creates its local AgentConfig instance.
+  try {
+    await initializeCredentialStore();
+  } catch (error) {
+    console.warn('[Extension] Failed to initialize credential storage:', error);
   }
 
   // Initialize locale

--- a/src/webfront/settings/ModelSettings.svelte
+++ b/src/webfront/settings/ModelSettings.svelte
@@ -118,6 +118,7 @@
     };
     supportBackendMode?: number;
     isCustom?: boolean;
+    apiFormat?: 'chat_completions' | 'responses';
   }
   let modelSelectionItems: ModelSelectionItem[] = $state([]);
 
@@ -331,6 +332,7 @@
             pricing: model.pricing,
             supportBackendMode: model.supportBackendMode,
             isCustom: provider.isCustom ?? false,
+            apiFormat: provider.apiFormat === 'responses' ? 'responses' : 'chat_completions',
           });
         }
       }
@@ -652,7 +654,15 @@
       const client = await getInitializedUIClient();
       const result = await client.serviceRequest<{ valid: boolean; error?: string }>(
         'models.testConnection',
-        { providerId, baseUrl, apiKey, model: modelKey, organization: organization ?? null },
+        {
+          providerId,
+          baseUrl,
+          apiKey,
+          model: modelKey,
+          organization: organization ?? null,
+          apiFormat: selectedItem.apiFormat ?? null,
+          isCustom: selectedItem.isCustom ?? false,
+        },
       );
 
       if (result.valid) {

--- a/src/webfront/settings/ModelSettings.svelte
+++ b/src/webfront/settings/ModelSettings.svelte
@@ -642,10 +642,26 @@
         return;
       }
 
-      if (providerId === 'anthropic') {
-        await testAnthropicConnection(baseUrl, modelKey);
+      // Route the probe through the runtime (desktop sidecar / extension service
+      // worker / server) rather than the webview. LLM provider APIs reject
+      // browser-origin requests via CORS — and the Tauri webview cannot reach
+      // them at all — so a direct in-webview fetch always failed on desktop. The
+      // runtime makes the real call from Node where there is no CORS. The handler
+      // is prompt-free where possible (lists models; falls back to one 1-token
+      // completion only when a provider lacks a models endpoint).
+      const client = await getInitializedUIClient();
+      const result = await client.serviceRequest<{ valid: boolean; error?: string }>(
+        'models.testConnection',
+        { providerId, baseUrl, apiKey, model: modelKey, organization: organization ?? null },
+      );
+
+      if (result.valid) {
+        testResult = { valid: true };
+        showMessage(t('Connection test successful!'), 'success');
       } else {
-        await testOpenAICompatibleConnection(baseUrl, modelKey, organization);
+        const errorMsg = result.error || t('Network error');
+        testResult = { valid: false, error: errorMsg };
+        showMessage(t('Connection test failed: $1$', { substitutions: [errorMsg] }), 'error');
       }
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : t('Network error');
@@ -653,74 +669,6 @@
       showMessage(t('Failed to test connection'), 'error');
     } finally {
       isTesting = false;
-    }
-  }
-
-  async function testAnthropicConnection(baseUrl: string, modelKey: string) {
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-      'x-api-key': apiKey,
-      'anthropic-version': '2023-06-01',
-    };
-
-    const response = await fetch(baseUrl, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        model: modelKey,
-        max_tokens: 1,
-        messages: [{ role: 'user', content: 'test' }],
-      }),
-    });
-
-    if (response.ok || response.status === 400) {
-      testResult = { valid: true };
-      showMessage(t('Connection test successful!'), 'success');
-    } else if (response.status === 401) {
-      testResult = { valid: false, error: t('Invalid API key') };
-      showMessage(t('Connection test failed: Invalid API key'), 'error');
-    } else {
-      testResult = { valid: false, error: `API error: ${response.status}` };
-      showMessage(t('Connection test failed: $1$', { substitutions: [`API error ${response.status}`] }), 'error');
-    }
-  }
-
-  async function testOpenAICompatibleConnection(
-    baseUrl: string,
-    modelKey: string,
-    organization: string | null
-  ) {
-    const { default: OpenAI } = await import('openai');
-
-    const client = new OpenAI({
-      apiKey: apiKey,
-      baseURL: baseUrl,
-      organization: organization || undefined,
-      timeout: 30000,
-      maxRetries: 0,
-      dangerouslyAllowBrowser: true,
-    });
-
-    try {
-      await client.chat.completions.create({
-        model: modelKey,
-        messages: [{ role: 'user', content: 'test' }],
-        max_tokens: 1,
-      });
-      testResult = { valid: true };
-      showMessage(t('Connection test successful!'), 'success');
-    } catch (error: any) {
-      if (error?.status === 401 || error?.code === 'invalid_api_key') {
-        testResult = { valid: false, error: t('Invalid API key') };
-        showMessage(t('Connection test failed: Invalid API key'), 'error');
-      } else if (error?.status === 400) {
-        testResult = { valid: true };
-        showMessage(t('Connection test successful! (API key is valid)'), 'success');
-      } else {
-        const errorMsg = error?.message || t('Network error');
-        testResult = { valid: false, error: errorMsg };
-        showMessage(t('Connection test failed: $1$', { substitutions: [errorMsg] }), 'error');
-      }
     }
   }
 


### PR DESCRIPTION
Two related desktop bugs, same root cause: **credential operations were running in the webview instead of the Node `desktop-runtime` sidecar**, where the LLM providers (CORS) and the OS keychain actually live.

## 1. Test Connection failed with CORS
The "Test Connection" button instantiated the OpenAI SDK in the webview (`dangerouslyAllowBrowser: true`) / raw `fetch`. LLM APIs reject browser-origin requests (CORS), and the Tauri webview can't reach them at all — so testing a key always failed with `User-Agent is not allowed by Access-Control-Allow-Headers`.

**Fix:** new `models.testConnection` handler runs the real probe from the runtime (no CORS). Prompt-free where possible (`GET {baseUrl}/models`; falls back to one 1-token completion only when a provider lacks a models endpoint). Webview routes through `serviceRequest`. Removed the in-webview `fetch`/OpenAI-SDK helpers.

## 2. BYOK API keys silently dropped on desktop ("NO API KEY" after reopen)
`initializeCredentialStore()` runs **only** in the sidecar, so the webview-local `AgentConfig` (created in `Settings.svelte`) had `getCredentials()` return null — `setProviderApiKey` hit the null branch and dropped the key.

**Fix:** new `credentials.{get,set,delete,listAccounts}` handlers operate the runtime credential store; new `RuntimeRelayCredentialStore` (webview) forwards each op over the runtime channel; desktop boot installs it via `setCredentialStore()`. All existing `AgentConfig` credential call sites (save/load/delete/custom provider) now resolve a non-null store and work unchanged. Extension unaffected (side panel keeps `ChromeCredentialStore`).

## Tests
- `models.testConnection`: 7 unit tests; `credentials.*`: 5 unit tests.
- `type-check` clean; lint **0 errors**; `core/services` + `core/channels` + `core/storage` suites (183 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)