### PR TITLE
fix: backend LLM gateway routing, OIDC-only desktop auth, and error surfacing

### DIFF
--- a/src/core/TaskRunner.ts
+++ b/src/core/TaskRunner.ts
@@ -287,15 +287,20 @@ export class TaskRunner {
       // consumers see the tail of a task that died mid-turn.
       await this.flushTaskOutput();
 
-      if (this.cancelled && !this.state.abortReason) {
-        this.state.abortReason = 'user_interrupt';
-        await this.emitAbortedEvent('user_interrupt');
+      if (this.cancelled) {
+        if (!this.state.abortReason) {
+          this.state.abortReason = 'user_interrupt';
+          await this.emitAbortedEvent('user_interrupt');
+        }
+        // A user stop is already represented by the aborted event above (which
+        // the engine resolves on), so do NOT also emit TaskFailed — that would
+        // render a spurious red "Task failed" entry for an intentional cancel.
+      } else {
+        // Emit a TERMINAL failure event (not the generic `Error` event, which
+        // clears no "processing" state and resolves no awaiter — leaving the UI
+        // stuck spinning). TaskFailed renders the reason and ends the turn.
+        await this.emitTaskFailed(err.message);
       }
-
-      // Emit a TERMINAL failure event (not the generic `Error` event, which
-      // clears no "processing" state and resolves no awaiter — leaving the UI
-      // stuck spinning). TaskFailed renders the reason and ends the turn.
-      await this.emitTaskFailed(err.message);
 
       return {
         success: false,
@@ -606,7 +611,10 @@ export class TaskRunner {
   private async emitTaskFailed(message: string): Promise<void> {
     const data: TaskFailedEvent = {
       submission_id: this.submissionId,
-      reason: 'error',
+      // `reason` is the human-readable text some consumers surface directly
+      // (e.g. UserNotifier's OS notification body), so use the message — not a
+      // category label, or the notification reads "Task Failed: error".
+      reason: message,
       error: message,
       message,
     };

--- a/src/core/TaskRunner.ts
+++ b/src/core/TaskRunner.ts
@@ -611,9 +611,9 @@ export class TaskRunner {
   private async emitTaskFailed(message: string): Promise<void> {
     const data: TaskFailedEvent = {
       submission_id: this.submissionId,
-      // `reason` is the human-readable text some consumers surface directly
-      // (e.g. UserNotifier's OS notification body), so use the message — not a
-      // category label, or the notification reads "Task Failed: error".
+      // All three carry the human-readable failure text. `reason` is a free
+      // string some consumers read directly, so it gets the message rather than
+      // a category label.
       reason: message,
       error: message,
       message,

--- a/src/core/TaskRunner.ts
+++ b/src/core/TaskRunner.ts
@@ -12,6 +12,7 @@ import type { InputItem, Event, ResponseItem } from './protocol/types';
 import type {
   EventMsg,
   TaskCompleteEvent,
+  TaskFailedEvent,
   TaskStartedEvent,
   TokenUsage,
   TurnAbortReason,
@@ -291,7 +292,10 @@ export class TaskRunner {
         await this.emitAbortedEvent('user_interrupt');
       }
 
-      await this.emitErrorEvent(`Task execution failed: ${err.message}`);
+      // Emit a TERMINAL failure event (not the generic `Error` event, which
+      // clears no "processing" state and resolves no awaiter — leaving the UI
+      // stuck spinning). TaskFailed renders the reason and ends the turn.
+      await this.emitTaskFailed(err.message);
 
       return {
         success: false,
@@ -591,6 +595,25 @@ export class TaskRunner {
       outcome.totalCostUSD,
       outcome.costEstimated ?? false,
     );
+  }
+
+  /**
+   * Terminal failure event. Unlike the generic `Error` event, `TaskFailed`
+   * resolves the turn for every consumer: the UI clears its "processing" state
+   * and renders the reason, and the engine's `waitForCompletion()` returns a
+   * failure. Carries `submission_id` so the engine matches the right awaiter.
+   */
+  private async emitTaskFailed(message: string): Promise<void> {
+    const data: TaskFailedEvent = {
+      submission_id: this.submissionId,
+      reason: 'error',
+      error: message,
+      message,
+    };
+    await this.emitEvent({
+      type: 'TaskFailed',
+      data,
+    });
   }
 
   /**

--- a/src/core/UserNotifier.ts
+++ b/src/core/UserNotifier.ts
@@ -646,9 +646,10 @@ export class UserNotifier implements IUserNotifier {
         break;
 
       case 'TaskFailed':
-        if (eventMsg.data?.reason) {
-          await this.notifyError('Task Failed', eventMsg.data.reason);
-        }
+        // OS notification for task failures is intentionally disabled pending a
+        // dedicated notification design. The failure is still surfaced in-chat
+        // (EventProcessor renders the "Task failed" entry with the reason); we
+        // just don't raise an OS-level notification with raw error text here.
         break;
 
       default:

--- a/src/core/__tests__/TaskRunner.test.ts
+++ b/src/core/__tests__/TaskRunner.test.ts
@@ -620,7 +620,7 @@ describe('TaskRunner', () => {
       expect(runner.getTaskStatus(SUBMISSION_ID)).toBe('failed');
     });
 
-    it('should emit Error event when task execution fails', async () => {
+    it('should emit a terminal TaskFailed event when task execution fails', async () => {
       const input: InputItem[] = [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'go' }] } as any];
 
       (turnManager.runTurn as Mock).mockRejectedValueOnce(new Error('network error'));
@@ -631,11 +631,15 @@ describe('TaskRunner', () => {
 
       await runner.run_task();
 
-      const errorEvent = (session.emitEvent as Mock).mock.calls.find(
-        (call: any[]) => call[0].msg.type === 'Error',
+      // The catch path emits TaskFailed (terminal) rather than the generic
+      // Error event — so the UI clears its processing state and the engine's
+      // waitForCompletion() resolves the awaiter with the failure reason.
+      const failedEvent = (session.emitEvent as Mock).mock.calls.find(
+        (call: any[]) => call[0].msg.type === 'TaskFailed',
       );
-      expect(errorEvent).toBeDefined();
-      expect(errorEvent![0].msg.data.message).toContain('network error');
+      expect(failedEvent).toBeDefined();
+      expect(failedEvent![0].msg.data.submission_id).toBe(SUBMISSION_ID);
+      expect(failedEvent![0].msg.data.message).toContain('network error');
     });
 
     it('should convert non-Error throws to Error objects', async () => {

--- a/src/core/__tests__/TaskRunner.test.ts
+++ b/src/core/__tests__/TaskRunner.test.ts
@@ -544,6 +544,31 @@ describe('TaskRunner', () => {
       expect(runner.getTaskStatus(SUBMISSION_ID)).toBe('killed');
     });
 
+    it('should NOT emit TaskFailed on cancellation (only the aborted event)', async () => {
+      const input: InputItem[] = [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'go' }] } as any];
+
+      (turnManager.runTurn as Mock).mockImplementation(
+        () => new Promise((_, reject) => {
+          setTimeout(() => reject(new Error('Task cancelled')), 10);
+        }),
+      );
+
+      const runner = new TaskRunner(
+        session, turnContext, turnManager, SUBMISSION_ID, input,
+      );
+
+      const runPromise = runner.run_task();
+      runner.cancel();
+      await runPromise;
+
+      // A user stop is an abort, not a failure — emitting TaskFailed would
+      // render a spurious red "Task failed" entry for an intentional cancel.
+      const failed = (session.emitEvent as Mock).mock.calls.find(
+        (call: any[]) => call[0].msg.type === 'TaskFailed',
+      );
+      expect(failed).toBeUndefined();
+    });
+
     // -------------------------------------------------------------------
     // Cancellation via AbortSignal
     // -------------------------------------------------------------------

--- a/src/core/__tests__/UserNotifier.test.ts
+++ b/src/core/__tests__/UserNotifier.test.ts
@@ -421,13 +421,13 @@ describe('UserNotifier', () => {
       expect(cb.mock.calls[0][0].message).toContain('/foo/bar.ts');
     });
 
-    it('should handle TaskFailed events', async () => {
+    it('should NOT raise an OS notification on TaskFailed (disabled pending dedicated design)', async () => {
       const cb = vi.fn();
       notifier.onNotification(cb);
       await notifier.processEvent(makeEvent('TaskFailed', { reason: 'timeout' }));
-      expect(cb).toHaveBeenCalledTimes(1);
-      expect(cb.mock.calls[0][0].type).toBe('error');
-      expect(cb.mock.calls[0][0].message).toBe('timeout');
+      // The failure is surfaced in-chat by EventProcessor; no OS-level
+      // notification is raised here.
+      expect(cb).not.toHaveBeenCalled();
     });
 
     it('should silently handle unknown event types', async () => {

--- a/src/core/engine/RepublicAgentEngine.ts
+++ b/src/core/engine/RepublicAgentEngine.ts
@@ -950,7 +950,7 @@ export class RepublicAgentEngine {
       // waitForCompletion() callers don't lose their completion signals.
       const eventSubmissionId = (event.msg.data as { submission_id?: string } | undefined)?.submission_id;
       if (eventSubmissionId && eventSubmissionId !== submissionId &&
-          (event.msg.type === 'TaskComplete' || event.msg.type === 'TurnAborted')) {
+          (event.msg.type === 'TaskComplete' || event.msg.type === 'TurnAborted' || event.msg.type === 'TaskFailed')) {
         this.eventQueue.push(event);
         // Wake any other waiter blocked on getNextEvent()
         if (this.eventWaiters.length > 0) {
@@ -975,6 +975,23 @@ export class RepublicAgentEngine {
             total_tokens: (tokenUsage.total.input_tokens ?? 0) + (tokenUsage.total.output_tokens ?? 0),
           } : undefined,
           stopReason: 'completed',
+          engineId: this.engineId,
+          submissionId,
+        };
+      }
+
+      // TaskRunner emits TaskFailed as the terminal event when a turn throws
+      // (e.g. the gateway returns 402/401). Resolve the awaiter as a failure
+      // carrying the reason, instead of hanging until interruption.
+      if (event.msg.type === 'TaskFailed' && event.msg.data?.submission_id === submissionId) {
+        const data = event.msg.data as { message?: string; error?: string; reason?: string } | undefined;
+        return {
+          success: false,
+          response: null,
+          turnCount: 0,
+          tokenUsage: undefined,
+          stopReason: 'error',
+          error: data?.message ?? data?.error ?? data?.reason ?? 'Task failed',
           engineId: this.engineId,
           submissionId,
         };

--- a/src/core/models/ModelClientFactory.ts
+++ b/src/core/models/ModelClientFactory.ts
@@ -383,7 +383,10 @@ export class ModelClientFactory {
         modelConfig = modelData.model;
         supportsReasoning = modelData.model.supportsReasoning ?? false;
         supportsReasoningSummaries = modelData.model.supportsReasoningSummaries ?? false;
-        selectedModel = modelData.model.modelKey;
+        // The Hub gateway resolves the canonical "<owner>/<model>" slug; for our
+        // first-party catalog the provider id is the owner. (A catalog-driven
+        // slug lookup would be the robust long-term form.)
+        selectedModel = `${modelData.provider.id}/${modelData.model.modelKey}`;
       }
     }
 

--- a/src/core/protocol/events.ts
+++ b/src/core/protocol/events.ts
@@ -583,6 +583,8 @@ export interface NotificationEvent {
 }
 
 export interface TaskFailedEvent {
+  /** Submission this failure terminates (lets the engine match the awaiter). */
+  submission_id?: string;
   reason: string;
   error?: string;
   message?: string;

--- a/src/desktop-runtime/auth/runtimeProfileFetch.ts
+++ b/src/desktop-runtime/auth/runtimeProfileFetch.ts
@@ -88,6 +88,21 @@ export function profileFromAccessToken(accessToken: string): RuntimeUserProfile 
   };
 }
 
+/**
+ * True when the access token's JWT `exp` claim is in the past (with a small
+ * skew). A token we cannot decode, or one without an `exp` claim, is treated as
+ * NOT expired here — eviction stays conservative and defers to the home-page
+ * validity check, so a transient/undecodable case never drops a good session.
+ */
+export function isAccessTokenExpired(accessToken: string, skewSeconds = 30): boolean {
+  const [, payloadSegment] = accessToken.split('.');
+  if (!payloadSegment) return false;
+  const payload = decodeBase64UrlJson(payloadSegment);
+  const exp = payload && typeof payload.exp === 'number' ? payload.exp : null;
+  if (exp === null) return false;
+  return exp * 1000 <= Date.now() + skewSeconds * 1000;
+}
+
 async function fetchJsonRecord(url: string, init: RequestInit): Promise<{
   ok: boolean;
   status: number;
@@ -183,6 +198,73 @@ export async function refreshDesktopAuthTokens(
   refreshToken: string,
 ): Promise<RuntimeDesktopTokens | null> {
   if (!refreshToken) return null;
+  // OIDC sessions MUST refresh at the OIDC token endpoint (RFC 6749
+  // refresh_token grant). The legacy /auth/desktop/refresh endpoint mints legacy
+  // session tokens WITHOUT the gateway (svc:hub) audience, so refreshing an OIDC
+  // session through it silently downgrades the token to legacy — which the Hub
+  // gateway then rejects as "Invalid JWT". Gate on the OIDC kill-switch; legacy
+  // refresh remains only for legacy (non-OIDC) deployments.
+  if (resolveAuthConfig().oidcEnabled) {
+    return refreshViaOidc(refreshToken);
+  }
+  return refreshViaLegacyDesktop(refreshToken);
+}
+
+/**
+ * Refresh via the OIDC token endpoint (`/auth/token`) using the standard
+ * `refresh_token` grant for the public PKCE desktop client. Preserves the
+ * gateway audience that the legacy desktop-refresh endpoint would strip.
+ */
+async function refreshViaOidc(
+  refreshToken: string,
+): Promise<RuntimeDesktopTokens | null> {
+  const tokenUrl = resolveHostedAuthUrl('token');
+  if (!tokenUrl) return null;
+  const clientId = resolveAuthConfig().oidcClientId;
+  if (!clientId) {
+    console.warn('[runtime-auth] OIDC token refresh skipped: no oidcClientId configured');
+    return null;
+  }
+  try {
+    const response = await fetch(tokenUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: clientId,
+      }).toString(),
+    });
+    if (!response.ok) {
+      console.warn(`[runtime-auth] OIDC token refresh failed from ${tokenUrl}: ${response.status} ${response.statusText}`);
+      return null;
+    }
+    const data = await response.json() as Record<string, unknown>;
+    const accessToken = pickString(data.access_token);
+    if (!accessToken) {
+      console.warn(`[runtime-auth] OIDC token refresh from ${tokenUrl} returned no access_token`);
+      return null;
+    }
+    return {
+      accessToken,
+      // OIDC may rotate the refresh token; if the response omits it, keep ours.
+      refreshToken: pickString(data.refresh_token) ?? refreshToken,
+      tokenType: pickString(data.token_type),
+      expiresIn: typeof data.expires_in === 'number' ? data.expires_in : undefined,
+    };
+  } catch (error) {
+    console.warn(`[runtime-auth] OIDC token refresh threw from ${tokenUrl}:`, error);
+    return null;
+  }
+}
+
+/** Legacy desktop-session refresh (`/auth/desktop/refresh`). Non-OIDC only. */
+async function refreshViaLegacyDesktop(
+  refreshToken: string,
+): Promise<RuntimeDesktopTokens | null> {
   const desktopRefreshUrl = resolveHostedAuthUrl('desktopRefresh');
   if (!desktopRefreshUrl) return null;
   try {

--- a/src/server/agent/ServerAgentBootstrap.ts
+++ b/src/server/agent/ServerAgentBootstrap.ts
@@ -1499,6 +1499,26 @@ export class ServerAgentBootstrap {
     }
 
     const hasUsableLogin = Boolean(accessToken && profile);
+
+    // Auth-state consistency (desktop): the stored login is only valid if BOTH
+    // (1) a token exists in the vault AND (2) it still authenticates against the
+    // home page (the profile fetch above). When that fails and the access token
+    // is actually expired (or absent), the session is dead — evict it from the
+    // vault so workx never shows a stale "logged in" while the home page is
+    // logged out. A non-expired token that merely failed to validate is kept
+    // (treated as a transient/network error, not a logout).
+    if (hadStoredAuth && !hasUsableLogin) {
+      const { isAccessTokenExpired } = await import('@/desktop-runtime/auth/runtimeProfileFetch');
+      const accessExpired = accessToken ? isAccessTokenExpired(accessToken) : true;
+      if (accessExpired) {
+        await Promise.all([
+          credentialStore.delete('auth', 'access_token').catch(() => undefined),
+          credentialStore.delete('auth', 'refresh_token').catch(() => undefined),
+        ]);
+        accessToken = null;
+      }
+    }
+
     const shouldUseBackend = Boolean(hasUsableLogin && !useOwnApiKey);
     const tokenGetter = shouldUseBackend
       ? async () => getCredentialStore().get('auth', 'access_token')

--- a/src/webfront/components/common/UserLoginStatus.svelte
+++ b/src/webfront/components/common/UserLoginStatus.svelte
@@ -337,9 +337,18 @@
   async function handleLogout() {
     showMenu = false;
     try {
-      const { getWebAuthService } = await import('../../auth/WebAuthService');
-      const authService = getWebAuthService();
-      await authService.logout();
+      if (platform.platformName === 'desktop') {
+        // Desktop: the session token lives in the runtime keychain, so logout
+        // must go through the runtime `auth.logout` service — it evicts the
+        // tokens from the vault and flips the runtime auth state to logged-out.
+        // (WebAuthService.logout only clears webfront localStorage, which is why
+        // the button was previously hidden on desktop and logout did nothing.)
+        const { getInitializedUIClient } = await import('@/core/messaging');
+        await (await getInitializedUIClient()).serviceRequest('auth.logout');
+      } else {
+        const { getWebAuthService } = await import('../../auth/WebAuthService');
+        await getWebAuthService().logout();
+      }
     } catch (error) {
       console.warn('[UserLoginStatus] Logout error:', error);
     }
@@ -468,21 +477,19 @@
           <span>{$_t("Settings")}</span>
         </button>
 
-        {#if platform.platformName === 'web'}
-          <button
-            class="flex items-center gap-2.5 w-full py-2.5 px-3 bg-transparent border-none cursor-pointer text-sm text-left transition-colors duration-150
-              {$uiTheme === 'modern'
-                ? 'text-chat-tooltip-text dark:text-chat-tooltip-text-dark font-chat rounded-md m-1 w-[calc(100%-8px)] hover:bg-white/10'
-                : 'text-term-green font-terminal hover:bg-term-green/10'}"
-            onclick={handleLogout}
-            role="menuitem"
-          >
-            <svg class="w-[18px] h-[18px] shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
-            </svg>
-            <span>{$_t("Logout")}</span>
-          </button>
-        {/if}
+        <button
+          class="flex items-center gap-2.5 w-full py-2.5 px-3 bg-transparent border-none cursor-pointer text-sm text-left transition-colors duration-150
+            {$uiTheme === 'modern'
+              ? 'text-chat-tooltip-text dark:text-chat-tooltip-text-dark font-chat rounded-md m-1 w-[calc(100%-8px)] hover:bg-white/10'
+              : 'text-term-green font-terminal hover:bg-term-green/10'}"
+          onclick={handleLogout}
+          role="menuitem"
+        >
+          <svg class="w-[18px] h-[18px] shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+          </svg>
+          <span>{$_t("Logout")}</span>
+        </button>
       </div>{/snippet}
     </PopupCard>
   {:else if hasHostedAuth}


### PR DESCRIPTION
Now based on `main` (the `models.testConnection`-via-sidecar work landed separately in #290, so that commit was dropped on rebase). This PR carries the fixes that got backend (gateway-routed) LLM requests working end-to-end on desktop, plus the error UX.

## Changes

**`fix(core)` — terminal TaskFailed so error UX clears the spinner**
On a thrown error (gateway 402/401, upstream timeout) `TaskRunner` emitted a generic `Error` event, which clears no UI processing state and resolves no awaiter — the chat spinner hung forever. Now it emits a terminal `TaskFailed` (with `submission_id`); `RepublicAgentEngine.waitForCompletion()` resolves on it, and the webview renders "Task failed: \<reason\>" and clears `isProcessing`.

**`fix(gateway)` — canonical owner/model slug for backend-routed requests**
The hub gateway now resolves inbound models against `models.slug` (`<owner>/<model>`) only; endpoint slugs are no longer accepted inbound. `createGatewayRoutedClient` was sending the bare `modelKey` ("Unsupported model"). It now sends `${provider.id}/${modelKey}` (e.g. `deepseek/deepseek-v4-flash`). Scoped to the gateway path only — BYOK/direct requests still send the bare model id.

**`fix(desktop-auth)` — OIDC-only refresh, evict expired tokens, expose logout**
- `refreshDesktopAuthTokens` dispatches on `oidcEnabled` — OIDC `grant_type=refresh_token` against `/auth/token`, no legacy fallback when OIDC is on. New `isAccessTokenExpired()`.
- `hydrateDesktopRuntimeAuthState`: when stored auth no longer yields a usable login and the access token is expired, evict access/refresh tokens from the vault and treat workx as logged out (refresh is attempted first).
- `UserLoginStatus`: logout is now desktop-aware (routes to `auth.logout`) and the Logout button is no longer hidden on desktop.

**`fix(core)` + `fix(notifications)` — review follow-ups**
- `TaskFailed.reason` carries the human-readable message (not the literal `'error'`).
- `TaskFailed` is no longer emitted on user cancellation (the aborted event already represents a stop) — avoids a spurious red "Task failed" on intentional stops; regression test added.
- The OS notification on `TaskFailed` is disabled pending a dedicated notification design; failures are still surfaced in-chat.

## Testing
- `npm run type-check` clean; `eslint` 0 errors.
- Affected suites green: TaskRunner, UserNotifier, engine (182 tests in the rebased set).
- Verified live on desktop: backend-routed `deepseek/deepseek-v4-flash` succeeds end-to-end; sidecar rebuilt with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)