### PR TITLE
feat(apps): connect-auth flow so installed apps become usable

### DIFF
--- a/src/webfront/lib/apis/apps/__tests__/apps.test.ts
+++ b/src/webfront/lib/apis/apps/__tests__/apps.test.ts
@@ -213,4 +213,39 @@ describe('apps marketplace api', () => {
     const { submitApiKey: submit2 } = await loadModule();
     await expect(submit2('a1', { api_key: 'bad' }, { accessToken: 't' })).rejects.toThrow('does not match');
   });
+
+  it('treats a successful POST as success even if the status re-read fails', async () => {
+    getAccessToken.mockResolvedValue('tok');
+    const fetchMock = vi.fn()
+      // POST succeeds, echoing the connection…
+      .mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK', json: async () => ({ status: 'connected', connection: { accountHint: 'me@x.com' } }) })
+      // …but the canonical re-read throws.
+      .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Unavailable', json: async () => ({}) });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const { submitApiKey } = await loadModule();
+    const auth = await submitApiKey('a1', { api_key: 'pat-x' }, { accessToken: 't' });
+    // Must NOT reject — the credential was saved. Falls back to the POST echo.
+    expect(auth).toMatchObject({ type: 'api_key', status: 'connected', accountHint: 'me@x.com' });
+  });
+
+  it('surfaces a FastAPI list-shaped {detail} (not a generic status line)', async () => {
+    getAccessToken.mockResolvedValue('tok');
+    global.fetch = vi.fn(async () => ({
+      ok: false, status: 422, statusText: 'Unprocessable',
+      json: async () => ({ detail: [{ loc: ['body', 'fields', 'api_key'], msg: 'value is not a valid token' }] }),
+    })) as unknown as typeof fetch;
+    const { submitApiKey } = await loadModule();
+    await expect(submitApiKey('a1', { api_key: 'x' }, { accessToken: 't' })).rejects.toThrow('value is not a valid token');
+  });
+
+  it('falls back to a status line when the Hub error message is empty', async () => {
+    getAccessToken.mockResolvedValue('tok');
+    global.fetch = vi.fn(async () => ({
+      ok: false, status: 400, statusText: 'Bad Request',
+      json: async () => ({ error: { message: '' } }),
+    })) as unknown as typeof fetch;
+    const { startOAuth } = await loadModule();
+    // Not a blank message — the status line carries through.
+    await expect(startOAuth('a1', { accessToken: 't' })).rejects.toThrow('400 Bad Request');
+  });
 });

--- a/src/webfront/lib/apis/apps/__tests__/apps.test.ts
+++ b/src/webfront/lib/apis/apps/__tests__/apps.test.ts
@@ -136,4 +136,81 @@ describe('apps marketplace api', () => {
     // Token probe is memoized: one resolution despite three requests.
     expect(getAccessToken).toHaveBeenCalledTimes(1);
   });
+
+  it('normalizes a card auth block (type + manual fields) and computes needsAuth', async () => {
+    global.fetch = vi.fn(async (_url: string, _init?: RequestInit) => ({
+      ok: true, status: 200, statusText: 'OK',
+      json: async () => ({ items: [{
+        appId: 'a1', slug: 'jira',
+        auth: { type: 'api_key', status: 'needs_auth', manualSetup: { setupUrl: 'https://mint', fields: [
+          { key: 'api_key', label: 'Token', type: 'secret', validation: '^pat-' },
+          {}, // junk row → dropped (no key)
+        ] } },
+      }] }),
+    })) as unknown as typeof fetch;
+
+    const { fetchMarketplace, needsAuth } = await loadModule();
+    const [app] = (await fetchMarketplace()).items;
+    expect(app.auth).toMatchObject({ type: 'api_key', status: 'needs_auth', setupUrl: 'https://mint' });
+    expect(app.auth!.manualFields).toHaveLength(1);
+    expect(app.auth!.manualFields[0]).toMatchObject({ key: 'api_key', type: 'secret', validation: '^pat-' });
+    expect(needsAuth(app.auth)).toBe(true);
+    expect(needsAuth({ type: 'none', status: 'connected', connectionStatus: null, accountHint: null, manualFields: [], setupUrl: null })).toBe(false);
+  });
+
+  it('getAuthStatus reads the auth status endpoint', async () => {
+    getAccessToken.mockResolvedValue('tok');
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
+      ok: true, status: 200, statusText: 'OK',
+      json: async () => ({ type: 'oauth2', status: 'connected', accountHint: 'me@x.com' }),
+    }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { getAuthStatus } = await loadModule();
+    const status = await getAuthStatus('a1');
+    expect(String(fetchMock.mock.calls[0][0])).toBe(`${CATALOG_API}/a1/auth/status`);
+    expect(status).toMatchObject({ type: 'oauth2', status: 'connected', accountHint: 'me@x.com' });
+  });
+
+  it('startOAuth returns the authorize URL and refuses without a token', async () => {
+    const { startOAuth, AppsApiError } = await loadModule();
+    getAccessToken.mockResolvedValue(null);
+    global.fetch = vi.fn() as unknown as typeof fetch;
+    await expect(startOAuth('a1')).rejects.toBeInstanceOf(AppsApiError);
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    global.fetch = vi.fn(async () => ({
+      ok: true, status: 200, statusText: 'OK',
+      json: async () => ({ authorizationUrl: 'https://provider/authorize?x=1', state: 's', expiresIn: 600 }),
+    })) as unknown as typeof fetch;
+    const start = await startOAuth('a1', { accessToken: 'desktop-tok' });
+    expect(start.authorizationUrl).toBe('https://provider/authorize?x=1');
+  });
+
+  it('surfaces the Hub error envelope message on a failed oauth start', async () => {
+    getAccessToken.mockResolvedValue('tok');
+    global.fetch = vi.fn(async () => ({
+      ok: false, status: 400, statusText: 'Bad Request',
+      json: async () => ({ error: { message: 'oauth config is incomplete' } }),
+    })) as unknown as typeof fetch;
+    const { startOAuth } = await loadModule();
+    await expect(startOAuth('a1', { accessToken: 't' })).rejects.toThrow('oauth config is incomplete');
+  });
+
+  it('submitApiKey posts fields then re-reads status; surfaces a {detail} error', async () => {
+    getAccessToken.mockResolvedValue('tok');
+    // First the POST (ok), then the getAuthStatus GET.
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK', json: async () => ({ status: 'connected' }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK', json: async () => ({ type: 'api_key', status: 'connected' }) });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const { submitApiKey } = await loadModule();
+    const auth = await submitApiKey('a1', { api_key: 'pat-x' }, { accessToken: 't' });
+    expect(JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string)).toMatchObject({ fields: { api_key: 'pat-x' } });
+    expect(auth).toMatchObject({ type: 'api_key', status: 'connected' });
+
+    global.fetch = vi.fn(async () => ({ ok: false, status: 422, statusText: 'Unprocessable', json: async () => ({ detail: 'api_key does not match the expected format' }) })) as unknown as typeof fetch;
+    const { submitApiKey: submit2 } = await loadModule();
+    await expect(submit2('a1', { api_key: 'bad' }, { accessToken: 't' })).rejects.toThrow('does not match');
+  });
 });

--- a/src/webfront/lib/apis/apps/index.ts
+++ b/src/webfront/lib/apis/apps/index.ts
@@ -29,11 +29,49 @@ export interface MarketplaceApp {
   version: string | null;
   monetizationTier: string | null;
   trustTier: string | null;
+  /** Auth requirement + connection state, embedded on the card by the Hub. */
+  auth: AppAuthInfo | null;
 }
 
 export interface MarketplacePage {
   items: MarketplaceApp[];
   nextCursor: string | null;
+}
+
+/** A declared manual-credential field (api_key / basic apps). */
+export interface ManualSetupField {
+  key: string;
+  label: string;
+  /** "secret" renders a password input; "text" a plain one. */
+  type: string;
+  /** Optional validation regex (search semantics) the value must match. */
+  validation: string | null;
+  placeholder: string | null;
+  optional: boolean;
+}
+
+/**
+ * Per-app auth requirement, from the Hub's `GET /auth/status` (also embedded on
+ * each marketplace card as `auth`). Drives the connect UI.
+ */
+export interface AppAuthInfo {
+  /** "none" | "oauth2" | "api_key" | "basic". */
+  type: string;
+  /** "connected" | "needs_auth" | "expired" | "auth_error" | "ready". */
+  status: string;
+  connectionStatus: string | null;
+  accountHint: string | null;
+  /** Declared fields for the api_key/basic credential form (empty for oauth2). */
+  manualFields: ManualSetupField[];
+  /** Provider setup page (where to mint a token), when the Hub supplies one. */
+  setupUrl: string | null;
+}
+
+/** True when the app needs the user to connect a credential before use. */
+export function needsAuth(info: AppAuthInfo | null | undefined): boolean {
+  if (!info) return false;
+  if (info.type === 'none') return false;
+  return info.status !== 'connected';
 }
 
 export class AppsApiError extends Error {
@@ -135,6 +173,39 @@ function firstString(...candidates: unknown[]): string {
   return '';
 }
 
+function normalizeManualField(raw: Record<string, unknown>): ManualSetupField {
+  return {
+    key: asString(raw.key) ?? '',
+    label: firstString(raw.label, raw.key) || 'Value',
+    type: asString(raw.type) ?? 'text',
+    validation: asString(raw.validation),
+    placeholder: asString(raw.placeholder),
+    optional: Boolean(raw.optional),
+  };
+}
+
+/** Parse the Hub's auth status block (from a card's `auth` or `GET /auth/status`). */
+function normalizeAuth(raw: unknown): AppAuthInfo | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  const type = asString(obj.type);
+  if (!type) return null;
+  const manual = (obj.manualSetup ?? {}) as Record<string, unknown>;
+  const fields = Array.isArray(manual.fields)
+    ? (manual.fields as unknown[])
+        .map((f) => normalizeManualField(f as Record<string, unknown>))
+        .filter((f) => f.key)
+    : [];
+  return {
+    type,
+    status: firstString(obj.status, obj.connectionStatus) || 'needs_auth',
+    connectionStatus: asString(obj.connectionStatus),
+    accountHint: asString(obj.accountHint),
+    manualFields: fields,
+    setupUrl: asString(manual.setupUrl),
+  };
+}
+
 function normalizeApp(raw: Record<string, unknown>): MarketplaceApp {
   return {
     appId: firstString(raw.appId, raw.id),
@@ -151,6 +222,7 @@ function normalizeApp(raw: Record<string, unknown>): MarketplaceApp {
     version: asString(raw.version),
     monetizationTier: asString(raw.monetizationTier),
     trustTier: asString(raw.trustTier),
+    auth: normalizeAuth(raw.auth),
   };
 }
 
@@ -242,4 +314,92 @@ export function activateApp(appId: string, accessToken?: string | null): Promise
 
 export function deactivateApp(appId: string, accessToken?: string | null): Promise<MarketplaceApp | null> {
   return appAction(appId, 'deactivate', 'POST', accessToken);
+}
+
+/**
+ * Pull a human-readable message from a failed Hub response. Hub control-plane
+ * APIs use `{error:{message}}`; some validation paths use `{detail}`. Falls back
+ * to the status line.
+ */
+async function hubErrorDetail(response: Response, fallback: string): Promise<string> {
+  try {
+    const body = (await response.json()) as { detail?: unknown; error?: { message?: unknown } };
+    return (
+      asString(body?.error?.message) ??
+      asString(body?.detail) ??
+      `${fallback}: ${response.status} ${response.statusText}`
+    );
+  } catch {
+    return `${fallback}: ${response.status} ${response.statusText}`;
+  }
+}
+
+/** Fetch the app's current auth requirement + connection state. */
+export async function getAuthStatus(
+  appId: string,
+  accessToken?: string | null,
+): Promise<AppAuthInfo | null> {
+  if (!appId) throw new AppsApiError('Cannot read auth status without an id.', 400);
+  const response = await fetch(catalogUrl(`/${encodeURIComponent(appId)}/auth/status`), {
+    method: 'GET',
+    headers: await authHeaders(accessToken),
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    throw new AppsApiError(`Failed to read auth status: ${response.status} ${response.statusText}`, response.status);
+  }
+  return normalizeAuth(await response.json());
+}
+
+export interface OAuthStart {
+  authorizationUrl: string;
+  state: string;
+  expiresIn: number | null;
+}
+
+/** Begin an OAuth connect: returns the provider authorize URL to open. */
+export async function startOAuth(
+  appId: string,
+  options: { returnUrl?: string; accessToken?: string | null } = {},
+): Promise<OAuthStart> {
+  const token = await resolveToken(options.accessToken);
+  if (!token) throw new AppsApiError('Sign in to connect apps.', 401);
+  const response = await fetch(catalogUrl(`/${encodeURIComponent(appId)}/auth/oauth/start`), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    credentials: 'include',
+    body: JSON.stringify({ returnUrl: options.returnUrl ?? null }),
+  });
+  if (!response.ok) {
+    throw new AppsApiError(await hubErrorDetail(response, 'Failed to start OAuth'), response.status);
+  }
+  const data = (await response.json()) as Record<string, unknown>;
+  const url = asString(data.authorizationUrl);
+  if (!url) throw new AppsApiError('The Hub returned no authorization URL.', 502);
+  return {
+    authorizationUrl: url,
+    state: asString(data.state) ?? '',
+    expiresIn: typeof data.expiresIn === 'number' ? data.expiresIn : null,
+  };
+}
+
+/** Submit a manual credential (api_key / basic apps). */
+export async function submitApiKey(
+  appId: string,
+  fields: Record<string, string>,
+  options: { accountHint?: string; accessToken?: string | null } = {},
+): Promise<AppAuthInfo | null> {
+  const token = await resolveToken(options.accessToken);
+  if (!token) throw new AppsApiError('Sign in to connect apps.', 401);
+  const response = await fetch(catalogUrl(`/${encodeURIComponent(appId)}/auth/api-key`), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    credentials: 'include',
+    body: JSON.stringify({ fields, accountHint: options.accountHint ?? null }),
+  });
+  if (!response.ok) {
+    throw new AppsApiError(await hubErrorDetail(response, 'Failed to save credential'), response.status);
+  }
+  // The Hub echoes the new connection; re-read status for the canonical shape.
+  return getAuthStatus(appId, options.accessToken);
 }

--- a/src/webfront/lib/apis/apps/index.ts
+++ b/src/webfront/lib/apis/apps/index.ts
@@ -322,15 +322,22 @@ export function deactivateApp(appId: string, accessToken?: string | null): Promi
  * to the status line.
  */
 async function hubErrorDetail(response: Response, fallback: string): Promise<string> {
+  const statusLine = `${fallback}: ${response.status} ${response.statusText}`;
   try {
-    const body = (await response.json()) as { detail?: unknown; error?: { message?: unknown } };
+    const body = (await response.json()) as {
+      detail?: unknown;
+      error?: { message?: unknown };
+    };
+    // Hub envelope: {error:{message}}. FastAPI validation: {detail:[{msg}]} (a
+    // list) or {detail:"..."} (a string). firstString skips empty/non-strings.
+    const fromList = Array.isArray(body?.detail)
+      ? firstString(...(body.detail as unknown[]).map((d) => (d as { msg?: unknown })?.msg))
+      : '';
     return (
-      asString(body?.error?.message) ??
-      asString(body?.detail) ??
-      `${fallback}: ${response.status} ${response.statusText}`
+      firstString(body?.error?.message, body?.detail, fromList) || statusLine
     );
   } catch {
-    return `${fallback}: ${response.status} ${response.statusText}`;
+    return statusLine;
   }
 }
 
@@ -400,6 +407,21 @@ export async function submitApiKey(
   if (!response.ok) {
     throw new AppsApiError(await hubErrorDetail(response, 'Failed to save credential'), response.status);
   }
-  // The Hub echoes the new connection; re-read status for the canonical shape.
-  return getAuthStatus(appId, options.accessToken);
+  // The credential is now saved. Re-read status for the canonical shape, but
+  // best-effort: a transient failure on the re-read must NOT surface as if the
+  // save itself failed. Fall back to the connection the POST echoed.
+  const saved = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  try {
+    return await getAuthStatus(appId, options.accessToken);
+  } catch {
+    const connection = (saved.connection ?? {}) as Record<string, unknown>;
+    return {
+      type: 'api_key',
+      status: 'connected',
+      connectionStatus: 'connected',
+      accountHint: asString(connection.accountHint),
+      manualFields: [],
+      setupUrl: null,
+    };
+  }
 }

--- a/src/webfront/pages/apps/Apps.svelte
+++ b/src/webfront/pages/apps/Apps.svelte
@@ -7,10 +7,16 @@
     fetchMarketplace,
     installApp,
     activateApp,
+    getAuthStatus,
+    startOAuth,
+    submitApiKey,
+    needsAuth,
     isAppsCatalogConfigured,
     AppsApiError,
     type MarketplaceApp,
+    type ManualSetupField,
   } from '../../lib/apis/apps';
+  import { openExternalUrl } from '../../lib/gatewayCatalog';
 
   let currentTheme = $derived($uiTheme);
   let modern = $derived(currentTheme === 'modern');
@@ -113,11 +119,126 @@
     return app.installStatus === 'installed';
   }
 
+  /** True when an installed app still needs the user to connect a credential. */
+  function appNeedsConnect(app: MarketplaceApp): boolean {
+    return isInstalled(app) && needsAuth(app.auth);
+  }
+
+  // ─── Connect-auth flow ────────────────────────────────────────────────────
+  /** appId currently mid OAuth (browser open + polling). */
+  let oauthPendingId = $state<string | null>(null);
+  /** appId whose manual-credential form is open. */
+  let apiKeyFormId = $state<string | null>(null);
+  let apiKeyFields = $state<ManualSetupField[]>([]);
+  let apiKeyValues = $state<Record<string, string>>({});
+  let apiKeyError = $state<string | null>(null);
+  let apiKeySubmitting = $state(false);
+  let pollController: { cancelled: boolean } | null = null;
+
+  /** Patch one app's auth block in place (after a connect succeeds). */
+  function applyAuth(appId: string, auth: MarketplaceApp['auth']) {
+    apps = apps.map((a) => (a.appId === appId ? { ...a, auth } : a));
+  }
+
+  async function handleConnect(app: MarketplaceApp) {
+    const type = app.auth?.type ?? 'oauth2';
+    if (type === 'api_key' || type === 'basic') {
+      apiKeyError = null;
+      apiKeyFields = app.auth?.manualFields ?? [];
+      apiKeyValues = Object.fromEntries(apiKeyFields.map((f) => [f.key, '']));
+      apiKeyFormId = app.appId;
+      return;
+    }
+    await connectOAuth(app);
+  }
+
+  async function connectOAuth(app: MarketplaceApp) {
+    error = null;
+    oauthPendingId = app.appId;
+    pollController = { cancelled: false };
+    const controller = pollController;
+    try {
+      const accessToken = await resolveAccessToken();
+      const { authorizationUrl } = await startOAuth(app.appId, { accessToken });
+      await openExternalUrl(authorizationUrl);
+      // The provider redirects to the Hub callback (not back into the app), so
+      // poll the Hub for the new connection until it lands or we time out.
+      const connected = await pollAuthUntilConnected(app.appId, controller);
+      if (controller.cancelled) return;
+      if (connected) {
+        await load(query); // refresh suggestedAction / isActivated
+      } else {
+        error = `Couldn't confirm the ${app.name} connection. Finish in your browser, then Retry.`;
+      }
+    } catch (err) {
+      if (!controller.cancelled) error = err instanceof Error ? err.message : String(err);
+    } finally {
+      if (oauthPendingId === app.appId) oauthPendingId = null;
+    }
+  }
+
+  /** Poll auth status (~every 2.5s, ~90s budget) until connected. */
+  async function pollAuthUntilConnected(
+    appId: string,
+    controller: { cancelled: boolean },
+  ): Promise<boolean> {
+    const accessToken = await resolveAccessToken();
+    const deadline = Date.now() + 90_000;
+    while (!controller.cancelled && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 2500));
+      if (controller.cancelled) return false;
+      try {
+        const status = await getAuthStatus(appId, accessToken);
+        if (status) applyAuth(appId, status);
+        if (status && status.status === 'connected') return true;
+      } catch {
+        // transient — keep polling within the budget
+      }
+    }
+    return false;
+  }
+
+  function cancelOAuth() {
+    if (pollController) pollController.cancelled = true;
+    oauthPendingId = null;
+  }
+
+  function closeApiKeyForm() {
+    apiKeyFormId = null;
+    apiKeyError = null;
+    apiKeyValues = {};
+  }
+
+  async function submitApiKeyForm(app: MarketplaceApp) {
+    apiKeyError = null;
+    const missing = apiKeyFields.filter((f) => !f.optional && !(apiKeyValues[f.key] ?? '').trim());
+    if (missing.length) {
+      apiKeyError = `Enter ${missing.map((f) => f.label).join(', ')}.`;
+      return;
+    }
+    apiKeySubmitting = true;
+    try {
+      const accessToken = await resolveAccessToken();
+      const fields = Object.fromEntries(
+        Object.entries(apiKeyValues).filter(([, v]) => (v ?? '').trim()),
+      );
+      const auth = await submitApiKey(app.appId, fields, { accessToken });
+      if (auth) applyAuth(app.appId, auth);
+      closeApiKeyForm();
+      await load(query);
+    } catch (err) {
+      apiKeyError = err instanceof AppsApiError ? err.message : String(err);
+    } finally {
+      apiKeySubmitting = false;
+    }
+  }
+
   $effect(() => {
     load();
     return () => {
       searchController?.abort();
       if (searchTimer) clearTimeout(searchTimer);
+      if (pollController) pollController.cancelled = true;
     };
   });
 </script>
@@ -218,26 +339,8 @@
               </p>
             {/if}
 
-            <div class="mt-auto flex items-center gap-2 pt-1">
-              {#if isInstalled(app)}
-                {#if app.isActivated}
-                  <span class="text-xs px-2 py-1 rounded
-                    {modern ? 'bg-green-500/15 text-green-600 dark:text-green-400' : 'text-term-green'}">
-                    {$_t('Active')}
-                  </span>
-                {:else}
-                  <button
-                    disabled={pendingId === app.appId}
-                    onclick={() => handleActivate(app)}
-                    class="text-xs px-2.5 py-1 rounded cursor-pointer disabled:opacity-50
-                      {modern
-                        ? 'bg-chat-button-hover dark:bg-chat-button-hover-dark text-chat-text dark:text-chat-text-dark font-chat'
-                        : 'border border-term-dim-green text-term-green font-terminal hover:bg-[rgba(0,255,0,0.1)]'}"
-                  >
-                    {pendingId === app.appId ? $_t('Working…') : $_t('Activate')}
-                  </button>
-                {/if}
-              {:else}
+            <div class="mt-auto flex items-center gap-2 pt-1 flex-wrap">
+              {#if !isInstalled(app)}
                 <button
                   disabled={pendingId === app.appId}
                   onclick={() => handleInstall(app)}
@@ -248,6 +351,51 @@
                 >
                   {pendingId === app.appId ? $_t('Working…') : $_t('Install')}
                 </button>
+              {:else if appNeedsConnect(app)}
+                {#if oauthPendingId === app.appId}
+                  <span class="text-xs {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
+                    {$_t('Connecting… finish in your browser')}
+                  </span>
+                  <button
+                    onclick={cancelOAuth}
+                    class="text-xs px-2 py-1 rounded cursor-pointer
+                      {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark hover:underline' : 'text-term-dim-green hover:underline'}"
+                  >
+                    {$_t('Cancel')}
+                  </button>
+                {:else}
+                  <button
+                    onclick={() => handleConnect(app)}
+                    class="text-xs px-2.5 py-1 rounded cursor-pointer
+                      {modern
+                        ? 'bg-chat-primary dark:bg-chat-primary-dark text-white font-chat hover:opacity-90'
+                        : 'border border-term-dim-green text-term-green font-terminal hover:bg-[rgba(0,255,0,0.1)]'}"
+                  >
+                    {app.auth?.status === 'expired' ? $_t('Reconnect') : $_t('Connect')}
+                  </button>
+                {/if}
+              {:else if app.isActivated}
+                <span class="text-xs px-2 py-1 rounded
+                  {modern ? 'bg-green-500/15 text-green-600 dark:text-green-400' : 'text-term-green'}">
+                  {$_t('Active')}
+                </span>
+              {:else}
+                <button
+                  disabled={pendingId === app.appId}
+                  onclick={() => handleActivate(app)}
+                  class="text-xs px-2.5 py-1 rounded cursor-pointer disabled:opacity-50
+                    {modern
+                      ? 'bg-chat-button-hover dark:bg-chat-button-hover-dark text-chat-text dark:text-chat-text-dark font-chat'
+                      : 'border border-term-dim-green text-term-green font-terminal hover:bg-[rgba(0,255,0,0.1)]'}"
+                >
+                  {pendingId === app.appId ? $_t('Working…') : $_t('Activate')}
+                </button>
+              {/if}
+              {#if app.auth?.accountHint && app.auth?.status === 'connected'}
+                <span class="text-[10px] truncate max-w-[120px]
+                  {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
+                  {app.auth.accountHint}
+                </span>
               {/if}
               {#if app.version}
                 <span class="ml-auto text-[10px]
@@ -256,6 +404,57 @@
                 </span>
               {/if}
             </div>
+
+            {#if apiKeyFormId === app.appId}
+              <div class="flex flex-col gap-2 mt-1 p-2 rounded
+                {modern ? 'bg-chat-bg dark:bg-chat-bg-dark' : 'border border-term-dim-green'}">
+                {#each apiKeyFields as field (field.key)}
+                  <label class="flex flex-col gap-1 text-xs
+                    {modern ? 'text-chat-text dark:text-chat-text-dark' : 'text-term-green'}">
+                    <span>{field.label}{field.optional ? '' : ' *'}</span>
+                    <input
+                      type={field.type === 'secret' ? 'password' : 'text'}
+                      bind:value={apiKeyValues[field.key]}
+                      placeholder={field.placeholder ?? ''}
+                      autocomplete="off"
+                      class="px-2 py-1 rounded text-xs
+                        {modern
+                          ? 'bg-chat-surface dark:bg-chat-surface-dark border border-chat-border dark:border-chat-border-dark text-chat-text dark:text-chat-text-dark'
+                          : 'bg-transparent border border-term-dim-green text-term-green'}"
+                    />
+                  </label>
+                {/each}
+                {#if apiKeyError}
+                  <p class="m-0 text-xs text-red-500">{apiKeyError}</p>
+                {/if}
+                <div class="flex items-center gap-2">
+                  <button
+                    disabled={apiKeySubmitting}
+                    onclick={() => submitApiKeyForm(app)}
+                    class="text-xs px-2.5 py-1 rounded cursor-pointer disabled:opacity-50
+                      {modern
+                        ? 'bg-chat-primary dark:bg-chat-primary-dark text-white font-chat hover:opacity-90'
+                        : 'border border-term-dim-green text-term-green font-terminal hover:bg-[rgba(0,255,0,0.1)]'}"
+                  >
+                    {apiKeySubmitting ? $_t('Saving…') : $_t('Save')}
+                  </button>
+                  <button
+                    onclick={closeApiKeyForm}
+                    class="text-xs px-2 py-1 rounded cursor-pointer
+                      {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark hover:underline' : 'text-term-dim-green hover:underline'}"
+                  >
+                    {$_t('Cancel')}
+                  </button>
+                  {#if app.auth?.setupUrl}
+                    <a href={app.auth.setupUrl} target="_blank" rel="noopener noreferrer"
+                      class="ml-auto text-[10px] underline
+                        {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
+                      {$_t('Where do I get this?')}
+                    </a>
+                  {/if}
+                </div>
+              </div>
+            {/if}
           </div>
         {/each}
       </div>

--- a/src/webfront/pages/apps/Apps.svelte
+++ b/src/webfront/pages/apps/Apps.svelte
@@ -125,15 +125,29 @@
   }
 
   // ─── Connect-auth flow ────────────────────────────────────────────────────
-  /** appId currently mid OAuth (browser open + polling). */
-  let oauthPendingId = $state<string | null>(null);
+  /** appIds currently mid OAuth (browser open + polling). */
+  let oauthPendingIds = $state<string[]>([]);
+  /** Per-app connect error, shown inline on the card (never gates the grid). */
+  let connectErrors = $state<Record<string, string>>({});
   /** appId whose manual-credential form is open. */
   let apiKeyFormId = $state<string | null>(null);
   let apiKeyFields = $state<ManualSetupField[]>([]);
   let apiKeyValues = $state<Record<string, string>>({});
   let apiKeyError = $state<string | null>(null);
   let apiKeySubmitting = $state(false);
-  let pollController: { cancelled: boolean } | null = null;
+  /** In-flight OAuth polls keyed by appId, so concurrent connects don't leak. */
+  const pollers = new Map<string, { cancelled: boolean }>();
+
+  function isOauthPending(appId: string): boolean {
+    return oauthPendingIds.includes(appId);
+  }
+  function setConnectError(appId: string, message: string | null) {
+    if (message) connectErrors = { ...connectErrors, [appId]: message };
+    else {
+      const { [appId]: _drop, ...rest } = connectErrors;
+      connectErrors = rest;
+    }
+  }
 
   /** Patch one app's auth block in place (after a connect succeeds). */
   function applyAuth(appId: string, auth: MarketplaceApp['auth']) {
@@ -141,6 +155,7 @@
   }
 
   async function handleConnect(app: MarketplaceApp) {
+    setConnectError(app.appId, null);
     const type = app.auth?.type ?? 'oauth2';
     if (type === 'api_key' || type === 'basic') {
       apiKeyError = null;
@@ -153,27 +168,36 @@
   }
 
   async function connectOAuth(app: MarketplaceApp) {
-    error = null;
-    oauthPendingId = app.appId;
-    pollController = { cancelled: false };
-    const controller = pollController;
+    const appId = app.appId;
+    setConnectError(appId, null);
+    // Replace any previous in-flight poll for THIS app, then track by appId so a
+    // connect on another app never cancels or leaks this one.
+    const prev = pollers.get(appId);
+    if (prev) prev.cancelled = true;
+    const controller = { cancelled: false };
+    pollers.set(appId, controller);
+    if (!oauthPendingIds.includes(appId)) oauthPendingIds = [...oauthPendingIds, appId];
     try {
       const accessToken = await resolveAccessToken();
-      const { authorizationUrl } = await startOAuth(app.appId, { accessToken });
+      const { authorizationUrl } = await startOAuth(appId, { accessToken });
       await openExternalUrl(authorizationUrl);
       // The provider redirects to the Hub callback (not back into the app), so
       // poll the Hub for the new connection until it lands or we time out.
-      const connected = await pollAuthUntilConnected(app.appId, controller);
+      const connected = await pollAuthUntilConnected(appId, controller);
       if (controller.cancelled) return;
       if (connected) {
         await load(query); // refresh suggestedAction / isActivated
       } else {
-        error = `Couldn't confirm the ${app.name} connection. Finish in your browser, then Retry.`;
+        setConnectError(appId, `Couldn't confirm the ${app.name} connection. Finish in your browser, then Retry.`);
       }
     } catch (err) {
-      if (!controller.cancelled) error = err instanceof Error ? err.message : String(err);
+      if (!controller.cancelled) setConnectError(appId, err instanceof Error ? err.message : String(err));
     } finally {
-      if (oauthPendingId === app.appId) oauthPendingId = null;
+      // Only clear if this is still the active controller for the app.
+      if (pollers.get(appId) === controller) {
+        pollers.delete(appId);
+        oauthPendingIds = oauthPendingIds.filter((id) => id !== appId);
+      }
     }
   }
 
@@ -182,13 +206,13 @@
     appId: string,
     controller: { cancelled: boolean },
   ): Promise<boolean> {
-    const accessToken = await resolveAccessToken();
     const deadline = Date.now() + 90_000;
     while (!controller.cancelled && Date.now() < deadline) {
       await new Promise((r) => setTimeout(r, 2500));
       if (controller.cancelled) return false;
       try {
-        const status = await getAuthStatus(appId, accessToken);
+        // Re-resolve the token each round so a mid-poll refresh is picked up.
+        const status = await getAuthStatus(appId, await resolveAccessToken());
         if (status) applyAuth(appId, status);
         if (status && status.status === 'connected') return true;
       } catch {
@@ -198,9 +222,11 @@
     return false;
   }
 
-  function cancelOAuth() {
-    if (pollController) pollController.cancelled = true;
-    oauthPendingId = null;
+  function cancelOAuth(appId: string) {
+    const controller = pollers.get(appId);
+    if (controller) controller.cancelled = true;
+    pollers.delete(appId);
+    oauthPendingIds = oauthPendingIds.filter((id) => id !== appId);
   }
 
   function closeApiKeyForm() {
@@ -238,7 +264,8 @@
     return () => {
       searchController?.abort();
       if (searchTimer) clearTimeout(searchTimer);
-      if (pollController) pollController.cancelled = true;
+      for (const controller of pollers.values()) controller.cancelled = true;
+      pollers.clear();
     };
   });
 </script>
@@ -352,12 +379,12 @@
                   {pendingId === app.appId ? $_t('Working…') : $_t('Install')}
                 </button>
               {:else if appNeedsConnect(app)}
-                {#if oauthPendingId === app.appId}
+                {#if isOauthPending(app.appId)}
                   <span class="text-xs {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
                     {$_t('Connecting… finish in your browser')}
                   </span>
                   <button
-                    onclick={cancelOAuth}
+                    onclick={() => cancelOAuth(app.appId)}
                     class="text-xs px-2 py-1 rounded cursor-pointer
                       {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark hover:underline' : 'text-term-dim-green hover:underline'}"
                   >
@@ -404,6 +431,10 @@
                 </span>
               {/if}
             </div>
+
+            {#if connectErrors[app.appId]}
+              <p class="m-0 text-xs text-red-500">{connectErrors[app.appId]}</p>
+            {/if}
 
             {#if apiKeyFormId === app.appId}
               <div class="flex flex-col gap-2 mt-1 p-2 rounded


### PR DESCRIPTION
## Why
Install registers an app but doesn't capture the credential it needs to run. The Apps page (#291) shipped **install** and **activate** but no **connect** step — so apps like GitHub install yet stay unusable, and nothing prompts for auth. This adds that missing step.

## What
A **Connect** action adaptive to each app's auth type (the Hub embeds `auth` on every marketplace card and exposes `GET /auth/status`).

**API client (`lib/apis/apps/index.ts`)**
- `getAuthStatus(appId)`, `startOAuth(appId)`, `submitApiKey(appId, fields)`.
- Parse the card's `auth` block (`type`/`status`/`manualFields`/`setupUrl`) onto `MarketplaceApp`; `needsAuth()` helper; Hub error envelope (`{error.message}`/`{detail}`) surfaced to the user.

**UI (`pages/apps/Apps.svelte`)**
- Installed + needs-auth → **Connect** (or **Reconnect** when expired), gating **Activate** behind a live connection.
- **oauth2:** `startOAuth` → open the system browser (`openExternalUrl`) → poll `/auth/status` until connected. The provider redirects to the Hub callback (not back into the app), so the desktop completes by **polling** — no callback server needed.
- **api_key/basic:** inline credential form from the declared `manualFields` → `POST /auth/api-key`, with a "where do I get this?" setup link.
- Shows the connected account hint; cancels polling on unmount.

## Tests
`getAuthStatus`/`startOAuth`/`submitApiKey`, card `auth` normalization, `needsAuth`, and Hub-error surfacing (`apps.test.ts`). Existing apps + command tests stay green.

## Validation
Verified the workx→Hub wiring against the live test stack: `/auth/status` returns the expected shape and the UI renders **Connect**; `startOAuth` reaches the Hub. Hot-reloaded live in `tauri:dev` with no compile errors.

## Note (deployment)
Completing an **OAuth round trip** needs the Hub's provider OAuth client creds (`client_id`) configured per environment. Without them `startOAuth` returns "oauth config is incomplete" — surfaced cleanly in the UI. The **api_key** path needs no provider registration (no api_key apps in the current catalog, but the form + storage are covered by Hub tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)