### PR TITLE
feat(tools): AI Hub gateway tools usable without the mcpTools toggle

### DIFF
--- a/src/core/mcp/MCPConfig.ts
+++ b/src/core/mcp/MCPConfig.ts
@@ -109,7 +109,10 @@ export const MCPServerConfigCreateSchema = z.object({
   authMode: MCPAuthModeSchema.optional(),
   headers: z.record(z.string()).optional(),
   platform: MCPPlatformScopeSchema.default('shared'),
-  builtin: z.boolean().optional(),
+  // NOTE: `builtin` is intentionally NOT accepted from the create payload. It is
+  // an authorization signal — builtin/first-party servers (the AI Hub gateway)
+  // are exempt from the user `mcpTools` toggle — so it must only ever be set by
+  // internal seeding (seedGatewayServer), never by a user-supplied addServer.
   command: z.string().optional(),
   args: z.array(z.string()).optional(),
   env: z.record(z.string()).optional(),
@@ -309,7 +312,9 @@ export function createServerConfig(
     authMode: (validated.authMode ?? (validated.apiKey ? 'api-key' : 'none')) as MCPAuthMode,
     headers: validated.headers,
     platform: (validated.platform ?? 'shared') as MCPPlatformScope,
-    builtin: validated.builtin,
+    // `builtin` is never taken from user input — only internal seeding sets it
+    // (it exempts a server from the mcpTools toggle). User-created servers are
+    // always non-builtin.
     command: validated.command,
     args: validated.args,
     env: validated.env,

--- a/src/core/mcp/MCPToolAdapter.ts
+++ b/src/core/mcp/MCPToolAdapter.ts
@@ -196,6 +196,11 @@ export async function registerMCPTools(
 ): Promise<void> {
   const adapter = getMCPToolAdapter();
 
+  // Builtin servers (e.g. the AI Hub gateway) are first-party: their tools are
+  // exempt from the user-facing `mcpTools` toggle so activated Hub apps work
+  // without the user enabling generic MCP tools.
+  const isBuiltinServer = manager.getServers().some((s) => s.name === serverName && s.builtin === true);
+
   for (const tool of tools) {
     const definition = adapter.adaptTool(tool, serverName);
     const handler = adapter.createHandler(manager, serverName, tool.name);
@@ -233,6 +238,7 @@ export async function registerMCPTools(
           serverName,
           displayName: `${serverName}: ${tool.name}`,
           searchHint: tool.description,
+          builtin: isBuiltinServer,
         },
       });
     } catch (error) {

--- a/src/core/mcp/MCPToolAdapter.ts
+++ b/src/core/mcp/MCPToolAdapter.ts
@@ -198,12 +198,17 @@ export async function registerMCPTools(
 
   // Builtin servers (e.g. the AI Hub gateway) are first-party: their tools are
   // exempt from the user-facing `mcpTools` toggle so activated Hub apps work
-  // without the user enabling generic MCP tools. `getServers` is optional-chained
-  // so a partial manager (e.g. test doubles) degrades to non-builtin instead of
-  // throwing.
-  const isBuiltinServer = (manager.getServers?.() ?? []).some(
-    (s) => s.name === serverName && s.builtin === true,
-  );
+  // without the user enabling generic MCP tools. Guarded so a partial or
+  // uninitialized manager (test doubles, or getServers() throwing pre-init)
+  // degrades to non-builtin rather than aborting tool registration.
+  let isBuiltinServer = false;
+  try {
+    isBuiltinServer = (manager.getServers?.() ?? []).some(
+      (s) => s.name === serverName && s.builtin === true,
+    );
+  } catch {
+    isBuiltinServer = false;
+  }
 
   for (const tool of tools) {
     const definition = adapter.adaptTool(tool, serverName);

--- a/src/core/mcp/MCPToolAdapter.ts
+++ b/src/core/mcp/MCPToolAdapter.ts
@@ -198,8 +198,12 @@ export async function registerMCPTools(
 
   // Builtin servers (e.g. the AI Hub gateway) are first-party: their tools are
   // exempt from the user-facing `mcpTools` toggle so activated Hub apps work
-  // without the user enabling generic MCP tools.
-  const isBuiltinServer = manager.getServers().some((s) => s.name === serverName && s.builtin === true);
+  // without the user enabling generic MCP tools. `getServers` is optional-chained
+  // so a partial manager (e.g. test doubles) degrades to non-builtin instead of
+  // throwing.
+  const isBuiltinServer = (manager.getServers?.() ?? []).some(
+    (s) => s.name === serverName && s.builtin === true,
+  );
 
   for (const tool of tools) {
     const definition = adapter.adaptTool(tool, serverName);

--- a/src/core/mcp/__tests__/MCPConfig.test.ts
+++ b/src/core/mcp/__tests__/MCPConfig.test.ts
@@ -360,6 +360,20 @@ describe('MCPConfig Functions', () => {
       expect(result.updatedAt).toBe(result.createdAt);
     });
 
+    it('ignores a user-supplied builtin flag (authz: only seeding may set builtin)', () => {
+      // A user-added server must never be able to mark itself builtin, which
+      // would exempt it from the mcpTools toggle.
+      const input = {
+        name: 'evil',
+        url: 'https://evil.example.com',
+        builtin: true,
+      } as unknown as IMCPServerConfigCreate;
+
+      const result = createServerConfig(input, []);
+
+      expect(result.builtin).toBeFalsy();
+    });
+
     it('should throw on duplicate server name', () => {
       const existingServers: IMCPServerConfig[] = [
         {

--- a/src/tools/exposure/ToolExposureManager.ts
+++ b/src/tools/exposure/ToolExposureManager.ts
@@ -95,7 +95,13 @@ export class ToolExposureManager {
     if (input.toolsConfig.disabled?.includes(entry.name) || input.toolsConfig.hiddenTools?.includes(entry.name)) {
       return decision(entry, profile, 'hidden', input.toolsConfig.disabled?.includes(entry.name) ? 'disabled' : 'config-hidden', false, description);
     }
-    if (profile.source === 'mcp' && !(input.toolsConfig.enable_all_tools || input.toolsConfig.mcpTools === true)) {
+    if (
+      profile.source === 'mcp' &&
+      !profile.builtin &&
+      !(input.toolsConfig.enable_all_tools || input.toolsConfig.mcpTools === true)
+    ) {
+      // User-added MCP servers respect the `mcpTools` toggle; builtin/first-party
+      // servers (the AI Hub gateway) are exempt so activated apps are usable.
       return decision(entry, profile, 'hidden', 'mcp-disabled', false, description);
     }
     if (entry.name === 'tool_search') {

--- a/src/tools/exposure/ToolExposureTypes.ts
+++ b/src/tools/exposure/ToolExposureTypes.ts
@@ -18,6 +18,13 @@ export interface ToolExposureProfile {
   displayName?: string;
   serverName?: string;
   alwaysLoadReason?: string;
+  /**
+   * True for tools from a builtin MCP server (e.g. the AI Hub gateway). These
+   * are first-party, so they are exempt from the user-facing `mcpTools` toggle
+   * (which gates user-added MCP servers) — an installed/activated Hub app is
+   * usable without flipping a generic MCP switch.
+   */
+  builtin?: boolean;
 }
 
 export type ToolExposureReason =

--- a/src/tools/exposure/__tests__/ToolExposureManager.test.ts
+++ b/src/tools/exposure/__tests__/ToolExposureManager.test.ts
@@ -89,4 +89,23 @@ describe('ToolExposureManager', () => {
     expect(result.hidden.map((d) => d.name)).toEqual(['github__create_issue']);
     expect(result.deferred).toEqual([]);
   });
+
+  it('exposes builtin (AI Hub gateway) MCP tools even when mcpTools is off', () => {
+    const manager = new ToolExposureManager(new ToolSelectionStore());
+    const result = manager.buildExposure({
+      entries: [
+        // user-added MCP server tool: gated off
+        { name: 'github__create_issue', definition: tool('github__create_issue'), exposure: { source: 'mcp', mode: 'deferred', serverName: 'github' } },
+        // builtin gateway tool: exempt from the mcpTools toggle
+        { name: 'ai-hub__github__get_me', definition: tool('ai-hub__github__get_me'), exposure: { source: 'mcp', mode: 'deferred', serverName: 'ai-hub', builtin: true } },
+      ],
+      toolsConfig: { dynamicToolLoading: true, mcpTools: false },
+      sessionId: 's1',
+    } as never);
+
+    // The user MCP tool stays hidden; the builtin gateway tool is available
+    // (deferred, discoverable) despite mcpTools being false.
+    expect(result.hidden.map((d) => d.name)).toEqual(['github__create_issue']);
+    expect(result.deferred.map((d) => d.name)).toContain('ai-hub__github__get_me');
+  });
 });


### PR DESCRIPTION
## Summary
The AI Hub gateway is a **builtin, first-party** MCP server, but its tools were being hidden behind the user-facing **`mcpTools`** toggle (which is meant for *user-added* MCP servers). Result: a user could install + connect a Hub app (e.g. GitHub) and still not be able to use it until they flipped an unrelated generic MCP switch.

## Change
- `ToolExposureProfile` gains a `builtin` flag.
- `registerMCPTools` marks a server's tools `builtin` when `manager.getServers()` reports that server as builtin (covers all platforms — it's the single registration chokepoint).
- `ToolExposureManager`'s `mcp-disabled` gate now **skips builtin tools**. User-added MCP servers still respect `mcpTools`; activated Hub apps work out of the box.

This was the only gate involved — `mcpTools` is read nowhere else; the gateway already connected/listed/registered its tools, they were just hidden at exposure.

## Test
New regression test: a builtin gateway tool stays available while a user MCP tool is hidden when `mcpTools: false`. Full exposure suite green (4/4).

## Verified end-to-end
With this fix, the workx agent calls `github__get_me` / `github__search_repositories` through the AI Hub gateway with no activation/toggle step (confirmed via the gateway metering table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)