### PR TITLE
fix(task): show the real failure reason instead of a bare "Task failed"

### DIFF
--- a/src/core/TaskRunner.ts
+++ b/src/core/TaskRunner.ts
@@ -118,6 +118,45 @@ interface LoopOutcomeInit {
 }
 
 /**
+ * Build a human-readable description of a thrown value for the TaskFailed event,
+ * so the UI never shows a bare "Task failed" with no reason. Prefers the error
+ * message; falls back to the error name/constructor when the message is empty
+ * (some model/gateway clients throw with an empty message), and appends the
+ * cause when present.
+ */
+export function describeTaskError(error: unknown): string {
+  if (error instanceof Error) {
+    const name = error.name && error.name !== 'Error' ? error.name : '';
+    const message = (error.message ?? '').trim();
+    let text = message
+      ? name && !message.startsWith(name)
+        ? `${name}: ${message}`
+        : message
+      : name || error.constructor?.name || 'Unknown error';
+    const cause = (error as { cause?: unknown }).cause;
+    const causeText =
+      cause instanceof Error
+        ? (cause.message || cause.name || '').trim()
+        : typeof cause === 'string'
+          ? cause.trim()
+          : '';
+    if (causeText && !text.includes(causeText)) {
+      text = `${text} (cause: ${causeText})`;
+    }
+    return text;
+  }
+  if (typeof error === 'string' && error.trim()) return error.trim();
+  if (error == null) return 'Unknown error';
+  try {
+    const json = JSON.stringify(error);
+    if (json && json !== '{}') return json;
+  } catch {
+    /* fall through to String() */
+  }
+  return String(error) || 'Unknown error';
+}
+
+/**
  * TaskRunner handles the execution of a complete task which may involve multiple turns
  * Enhanced with AgentTask coordination - maintains the majority of task execution logic
  */
@@ -276,6 +315,9 @@ export class TaskRunner {
       };
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
+      // A descriptive reason so the UI shows more than a bare "Task failed"
+      // (covers errors thrown with an empty message — name/cause are surfaced).
+      const detail = describeTaskError(error);
       this.state.status = this.cancelled ? 'killed' : 'failed';
       this.state.lastError = err;
 
@@ -299,12 +341,12 @@ export class TaskRunner {
         // Emit a TERMINAL failure event (not the generic `Error` event, which
         // clears no "processing" state and resolves no awaiter — leaving the UI
         // stuck spinning). TaskFailed renders the reason and ends the turn.
-        await this.emitTaskFailed(err.message);
+        await this.emitTaskFailed(detail);
       }
 
       return {
         success: false,
-        error: err.message,
+        error: detail,
       };
     } finally {
       // Clean up abort handler if it was set up

--- a/src/core/__tests__/TaskRunner.test.ts
+++ b/src/core/__tests__/TaskRunner.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
-import { TaskRunner, type TaskOptions } from '@/core/TaskRunner';
+import { TaskRunner, describeTaskError, type TaskOptions } from '@/core/TaskRunner';
 import type { Session } from '@/core/Session';
 import type { TurnContext } from '@/core/TurnContext';
 import type { TurnManager, TurnRunResult } from '@/core/TurnManager';
@@ -1197,5 +1197,34 @@ describe('TaskRunner', () => {
       const usage = runner.getTokenUsage(SUBMISSION_ID);
       expect(usage.used).toBe(92000);
     });
+  });
+});
+
+describe('describeTaskError', () => {
+  it('uses the error message when present', () => {
+    expect(describeTaskError(new Error('boom'))).toBe('boom');
+  });
+
+  it('prefixes a meaningful error name', () => {
+    const e = new Error('rate limited');
+    e.name = 'ModelClientError';
+    expect(describeTaskError(e)).toBe('ModelClientError: rate limited');
+  });
+
+  it('falls back to the error name when the message is empty (no bare blank)', () => {
+    const e = new Error('');
+    e.name = 'ModelClientError';
+    expect(describeTaskError(e)).toBe('ModelClientError');
+  });
+
+  it('appends the cause when present', () => {
+    const e = new Error('upstream failed', { cause: new Error('429 rate limit') });
+    expect(describeTaskError(e)).toBe('upstream failed (cause: 429 rate limit)');
+  });
+
+  it('handles non-Error throws', () => {
+    expect(describeTaskError('plain string')).toBe('plain string');
+    expect(describeTaskError({ code: 402 })).toBe('{"code":402}');
+    expect(describeTaskError(undefined)).toBe('Unknown error');
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "lib": ["ES2020", "DOM"],
+    "lib": ["ES2020", "ES2022.Error", "DOM"],
     "strict": true,
     "noImplicitAny": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Problem
A failed task often rendered just **"Task failed"** with no reason. `TaskRunner` emits `TaskFailed` with `err.message`, but when the underlying error had an **empty message** (some model/gateway clients throw `new Error()` / lose their message), the UI fell back to the generic string — confusing for users and impossible to debug.

## Fix
- New `describeTaskError(error)` — prefers the message; falls back to the error **name/constructor** when the message is empty; prefixes a meaningful name (e.g. `ModelClientError: rate limited`); appends the **cause** when present; handles non-`Error` throws.
- `TaskRunner` emits this as the `TaskFailed` reason (and `TaskResult.error`). The UI already renders `msg.data.message`, so it now shows the real reason.

## Tests
`describeTaskError` unit tests: message, name-prefix, empty-message→name, cause, non-Error. Full TaskRunner suite green (52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)