### PR TITLE
fix(auth): persist OIDC client config at login so desktop token refresh works

### DIFF
--- a/src/core/services/auth-services.ts
+++ b/src/core/services/auth-services.ts
@@ -21,6 +21,15 @@ import {
 const AUTH_SERVICE = 'auth';
 const ACCESS_TOKEN_ACCOUNT = 'access_token';
 const REFRESH_TOKEN_ACCOUNT = 'refresh_token';
+// OIDC client config captured at login so the runtime can refresh tokens
+// without depending on the sidecar's process.env (which never receives the
+// WebView-only VITE_/WORKX_ auth vars). The WebView supplies these at login;
+// persisting them lets refreshViaOidc rebuild the exact token request that
+// login used — otherwise refresh resolves a null clientId and silently
+// downgrades to the legacy (non-svc:hub) path, which the gateway rejects as
+// "Invalid JWT".
+const OIDC_CLIENT_ID_ACCOUNT = 'oidc_client_id';
+const OIDC_TOKEN_URL_ACCOUNT = 'oidc_token_url';
 
 export interface AuthServiceDeps {
   /** Registry for resolving active sessions when auth state changes. */
@@ -163,6 +172,7 @@ export function createAuthServices(deps: AuthServiceDeps): Record<string, Servic
     accessToken: string,
     refreshToken: string,
     backendBaseUrl: string | null,
+    oidc?: { clientId: string; tokenUrl: string },
   ) {
     if (!deps.getCredentialStore) {
       throw new Error('finalizeLogin: credential store not available on this platform');
@@ -171,6 +181,14 @@ export function createAuthServices(deps: AuthServiceDeps): Record<string, Servic
     await Promise.all([
       credentialStore.set(AUTH_SERVICE, ACCESS_TOKEN_ACCOUNT, accessToken),
       credentialStore.set(AUTH_SERVICE, REFRESH_TOKEN_ACCOUNT, refreshToken),
+      // Capture the OIDC client config from this login so token refresh can
+      // reuse it (the sidecar has no access to the WebView's auth env).
+      ...(oidc
+        ? [
+            credentialStore.set(AUTH_SERVICE, OIDC_CLIENT_ID_ACCOUNT, oidc.clientId),
+            credentialStore.set(AUTH_SERVICE, OIDC_TOKEN_URL_ACCOUNT, oidc.tokenUrl),
+          ]
+        : []),
     ]);
 
     // Switch the agent to backend routing exactly like `agent.initAuth`. Doing
@@ -316,7 +334,10 @@ export function createAuthServices(deps: AuthServiceDeps): Record<string, Servic
       if (!data.access_token || !data.refresh_token) {
         throw new Error('auth.exchangeOIDCCode: token endpoint did not return access_token and refresh_token');
       }
-      return finalizeLogin(data.access_token, data.refresh_token, backendBaseUrl ?? null);
+      return finalizeLogin(data.access_token, data.refresh_token, backendBaseUrl ?? null, {
+        clientId,
+        tokenUrl,
+      });
     },
 
     /**

--- a/src/desktop-runtime/auth/__tests__/runtimeProfileFetch.test.ts
+++ b/src/desktop-runtime/auth/__tests__/runtimeProfileFetch.test.ts
@@ -186,4 +186,57 @@ describe('refreshDesktopAuthTokens', () => {
 
     await expect(refreshDesktopAuthTokens('old-rt')).resolves.toBeNull();
   });
+
+  // Regression: the desktop sidecar's process.env has no OIDC auth vars (those
+  // are WebView-only), so without a persisted override the refresh would
+  // wrongly take the legacy path and the gateway rejects the result as
+  // "Invalid JWT". A persisted clientId+tokenUrl must force the OIDC
+  // refresh_token grant even when the env kill-switch is off.
+  it('uses the OIDC refresh grant from a persisted override when env has no OIDC config', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      access_token: 'new-at',
+      refresh_token: 'new-rt',
+      token_type: 'Bearer',
+      expires_in: 3600,
+    }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const tokens = await refreshDesktopAuthTokens('old-rt', {
+      clientId: 'workx-desktop-test',
+      tokenUrl: 'https://testhome.example.com/auth/token',
+    });
+
+    // OIDC token endpoint (the override), not the legacy /desktop/refresh path.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(calledUrl).toBe('https://testhome.example.com/auth/token');
+    // RFC 6749 refresh_token grant: form-encoded with the bound client_id.
+    expect((calledInit.headers as Record<string, string>)['Content-Type'])
+      .toBe('application/x-www-form-urlencoded');
+    const body = new URLSearchParams(String(calledInit.body));
+    expect(body.get('grant_type')).toBe('refresh_token');
+    expect(body.get('refresh_token')).toBe('old-rt');
+    expect(body.get('client_id')).toBe('workx-desktop-test');
+    expect(tokens).toEqual({
+      accessToken: 'new-at',
+      refreshToken: 'new-rt',
+      tokenType: 'Bearer',
+      expiresIn: 3600,
+    });
+  });
+
+  it('keeps the existing refresh token when the OIDC response omits a new one', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      access_token: 'new-at',
+    }), { status: 200 })));
+
+    const tokens = await refreshDesktopAuthTokens('old-rt', {
+      clientId: 'workx-desktop-test',
+      tokenUrl: 'https://testhome.example.com/auth/token',
+    });
+
+    expect(tokens?.accessToken).toBe('new-at');
+    // OIDC may omit refresh_token on rotation-less refresh; we retain ours.
+    expect(tokens?.refreshToken).toBe('old-rt');
+  });
 });

--- a/src/desktop-runtime/auth/__tests__/runtimeProfileFetch.test.ts
+++ b/src/desktop-runtime/auth/__tests__/runtimeProfileFetch.test.ts
@@ -193,7 +193,7 @@ describe('refreshDesktopAuthTokens', () => {
   // "Invalid JWT". A persisted clientId+tokenUrl must force the OIDC
   // refresh_token grant even when the env kill-switch is off.
   it('uses the OIDC refresh grant from a persisted override when env has no OIDC config', async () => {
-    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => new Response(JSON.stringify({
       access_token: 'new-at',
       refresh_token: 'new-rt',
       token_type: 'Bearer',
@@ -208,12 +208,12 @@ describe('refreshDesktopAuthTokens', () => {
 
     // OIDC token endpoint (the override), not the legacy /desktop/refresh path.
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [calledUrl, calledInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0];
     expect(calledUrl).toBe('https://testhome.example.com/auth/token');
     // RFC 6749 refresh_token grant: form-encoded with the bound client_id.
-    expect((calledInit.headers as Record<string, string>)['Content-Type'])
+    expect((calledInit?.headers as Record<string, string>)['Content-Type'])
       .toBe('application/x-www-form-urlencoded');
-    const body = new URLSearchParams(String(calledInit.body));
+    const body = new URLSearchParams(String(calledInit?.body));
     expect(body.get('grant_type')).toBe('refresh_token');
     expect(body.get('refresh_token')).toBe('old-rt');
     expect(body.get('client_id')).toBe('workx-desktop-test');

--- a/src/desktop-runtime/auth/runtimeProfileFetch.ts
+++ b/src/desktop-runtime/auth/runtimeProfileFetch.ts
@@ -196,16 +196,25 @@ export async function fetchUserProfileServerSide(
 
 export async function refreshDesktopAuthTokens(
   refreshToken: string,
+  // OIDC client config captured at login and persisted by the runtime. The
+  // sidecar's process.env does NOT carry the WebView-only auth vars
+  // (VITE_/WORKX_AUTH_OIDC_*), so without this override resolveAuthConfig()
+  // resolves a null clientId / oidcEnabled=false and refresh wrongly falls back
+  // to legacy. Passing the login-time clientId+tokenUrl makes refresh rebuild
+  // the exact OIDC request login used.
+  oidcOverride?: { clientId?: string | null; tokenUrl?: string | null },
 ): Promise<RuntimeDesktopTokens | null> {
   if (!refreshToken) return null;
   // OIDC sessions MUST refresh at the OIDC token endpoint (RFC 6749
   // refresh_token grant). The legacy /auth/desktop/refresh endpoint mints legacy
   // session tokens WITHOUT the gateway (svc:hub) audience, so refreshing an OIDC
   // session through it silently downgrades the token to legacy — which the Hub
-  // gateway then rejects as "Invalid JWT". Gate on the OIDC kill-switch; legacy
-  // refresh remains only for legacy (non-OIDC) deployments.
-  if (resolveAuthConfig().oidcEnabled) {
-    return refreshViaOidc(refreshToken);
+  // gateway then rejects as "Invalid JWT". Use OIDC when we either have a
+  // persisted OIDC client config (from login) or the env kill-switch is on;
+  // legacy refresh remains only for legacy (non-OIDC) deployments.
+  const hasPersistedOidc = Boolean(oidcOverride?.clientId && oidcOverride?.tokenUrl);
+  if (hasPersistedOidc || resolveAuthConfig().oidcEnabled) {
+    return refreshViaOidc(refreshToken, oidcOverride);
   }
   return refreshViaLegacyDesktop(refreshToken);
 }
@@ -217,10 +226,14 @@ export async function refreshDesktopAuthTokens(
  */
 async function refreshViaOidc(
   refreshToken: string,
+  oidcOverride?: { clientId?: string | null; tokenUrl?: string | null },
 ): Promise<RuntimeDesktopTokens | null> {
-  const tokenUrl = resolveHostedAuthUrl('token');
+  // Prefer the login-time OIDC config (persisted by the runtime) over env: the
+  // sidecar's process.env lacks the WebView auth vars, so resolveAuthConfig()
+  // would yield null here in a real desktop session.
+  const tokenUrl = oidcOverride?.tokenUrl || resolveHostedAuthUrl('token');
   if (!tokenUrl) return null;
-  const clientId = resolveAuthConfig().oidcClientId;
+  const clientId = oidcOverride?.clientId || resolveAuthConfig().oidcClientId;
   if (!clientId) {
     console.warn('[runtime-auth] OIDC token refresh skipped: no oidcClientId configured');
     return null;

--- a/src/server/agent/ServerAgentBootstrap.ts
+++ b/src/server/agent/ServerAgentBootstrap.ts
@@ -1246,7 +1246,7 @@ export class ServerAgentBootstrap {
         refreshAuthTokens: async (refreshToken: string) => {
           try {
             const { refreshDesktopAuthTokens } = await import('@/desktop-runtime/auth/runtimeProfileFetch');
-            return await refreshDesktopAuthTokens(refreshToken);
+            return await refreshDesktopAuthTokens(refreshToken, await this.readPersistedOidcConfig());
           } catch (err) {
             console.warn('[ServerAgentBootstrap] runtime token refresh failed:', err);
             return null;
@@ -1352,6 +1352,25 @@ export class ServerAgentBootstrap {
     return this.runtimeState.setAccessState(accessStateFromReadyState(ready));
   }
 
+  /**
+   * Read the OIDC client config captured at login. The sidecar's process.env
+   * has no access to the WebView-only auth vars, so the token-refresh path must
+   * reuse the clientId+tokenUrl persisted at login — otherwise it can't rebuild
+   * the OIDC token request and falls back to legacy refresh, which the gateway
+   * rejects as "Invalid JWT".
+   */
+  private async readPersistedOidcConfig(): Promise<{
+    clientId: string | null;
+    tokenUrl: string | null;
+  }> {
+    const credentialStore = getCredentialStore();
+    const [clientId, tokenUrl] = await Promise.all([
+      credentialStore.get('auth', 'oidc_client_id').catch(() => null),
+      credentialStore.get('auth', 'oidc_token_url').catch(() => null),
+    ]);
+    return { clientId, tokenUrl };
+  }
+
   private async refreshDesktopRuntimeSessionTokens(): Promise<string | null> {
     const credentialStore = getCredentialStore();
     const refreshToken = await credentialStore.get('auth', 'refresh_token').catch(() => null);
@@ -1359,7 +1378,7 @@ export class ServerAgentBootstrap {
 
     try {
       const { refreshDesktopAuthTokens } = await import('@/desktop-runtime/auth/runtimeProfileFetch');
-      const refreshed = await refreshDesktopAuthTokens(refreshToken);
+      const refreshed = await refreshDesktopAuthTokens(refreshToken, await this.readPersistedOidcConfig());
       if (!refreshed?.accessToken || !refreshed.refreshToken) {
         return null;
       }
@@ -1483,7 +1502,7 @@ export class ServerAgentBootstrap {
         const { fetchUserProfileServerSide, refreshDesktopAuthTokens } = await import('@/desktop-runtime/auth/runtimeProfileFetch');
         profile = accessToken ? await fetchUserProfileServerSide(accessToken) : null;
         if (!profile && refreshToken) {
-          const refreshed = await refreshDesktopAuthTokens(refreshToken);
+          const refreshed = await refreshDesktopAuthTokens(refreshToken, await this.readPersistedOidcConfig());
           if (refreshed?.accessToken && refreshed.refreshToken) {
             await Promise.all([
               credentialStore.set('auth', 'access_token', refreshed.accessToken),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "lib": ["ES2020", "DOM"],
+    "lib": ["ES2020", "ES2022.Error", "DOM"],
     "strict": true,
     "noImplicitAny": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Problem

Desktop sessions failed with **`ModelClientError: Invalid JWT`** a while after login (even on a plain "Hello"). The gateway rejected the access token once the 1-hour token expired, and workx's silent refresh could not recover it — so it kept sending the dead token.

## Root cause (client-side, not the IdP)

testhome is fine: it issues **30-day refresh tokens** and its `refresh_token` grant works for the public `workx-desktop-test` client (verified live — `client_id` accepted, only a dummy token is rejected). The test OIDC client is correctly registered with `chat apps models offline_access`.

The bug is in the **desktop runtime (Node sidecar)**:

- The sidecar resolves OIDC config from `process.env`, but `src/desktop/.env` is loaded **only by Vite for the WebView**. The sidecar spawn (`runtime_supervisor.rs`) injects only `WORKX_RUNTIME_PROFILE` + `WORKX_DESKTOP_RUNTIME_HOST`, and the runtime bundle inlines nothing (`import.meta.env` is `undefined` in Node).
- So at refresh time `resolveAuthConfig()` yields `oidcClientId = null` / `oidcEnabled = false`, and `refreshViaOidc` either bails ("no oidcClientId configured") or downgrades to the **legacy, non-`svc:hub`** refresh path → the gateway rejects the result as `Invalid JWT`.
- **Login** worked only because the WebView hands the runtime `clientId`/`tokenUrl` as explicit params; **refresh** had no such source.

## Fix

Capture the OIDC client config at login and reuse it on every refresh, independent of the sidecar env:

- **`auth-services.ts`** — `finalizeLogin` persists `oidc_client_id` / `oidc_token_url` alongside the tokens (from the WebView-supplied, known-good values).
- **`runtimeProfileFetch.ts`** — `refreshDesktopAuthTokens` accepts a persisted-OIDC override and takes the OIDC `refresh_token` grant whenever it's present (not only when the env kill-switch is on); `refreshViaOidc` prefers the override over env.
- **`ServerAgentBootstrap.ts`** — all three runtime refresh paths pass the persisted config via a shared `readPersistedOidcConfig()` helper.
- **`tsconfig.json`** — add `ES2022.Error` lib so `Error.cause` typechecks (unbreaks the `describeTaskError` test from the prior task; `npm run type-check` is now clean).

## Tests

- New regression tests in `runtimeProfileFetch.test.ts`: with **no OIDC env** (the real sidecar condition) a persisted override forces the OIDC `refresh_token` grant to the correct token endpoint with the bound `client_id`; and a rotation-less refresh retains the existing refresh token. Full suite green; type-check + lint clean.

## Note

Existing logged-in sessions must **re-login once** to populate the persisted OIDC config. A follow-up will add an auto-relogin fallback for when the 30-day refresh token itself expires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)