### PR TITLE
chore(release): unify app version to a single source of truth (3.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workx",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "main": "index.js",
   "workspaces": [
     "packages/*"

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,0 +1,12 @@
+/**
+ * Runtime access to the app version.
+ *
+ * The canonical version lives in package.json; Vite injects it at build time as
+ * the bare `__APP_VERSION__` constant (see vite.version.mjs). The fallback keeps
+ * non-bundled contexts — ts-node dev server, vitest runs without the define —
+ * from crashing on an undefined global.
+ *
+ * @module config/version
+ */
+export const APP_VERSION: string =
+  typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0-dev';

--- a/src/storage/rollout/RolloutRecorder.ts
+++ b/src/storage/rollout/RolloutRecorder.ts
@@ -16,6 +16,7 @@ import {
   type RolloutMetadataRecord,
 } from './types';
 import { RolloutWriter } from './RolloutWriter';
+import { APP_VERSION } from '@/config/version';
 import { filterPersistedItems } from './policy';
 import { listConversations as listConversationsImpl } from './listing';
 import { cleanupExpired as cleanupExpiredImpl } from './cleanup';
@@ -149,7 +150,7 @@ export class RolloutRecorder {
         id: sessionId,
         timestamp: getCurrentTimestamp(),
         originator: 'chrome-extension',
-        cliVersion: '1.0.0', // TODO: Load from package.json or config
+        cliVersion: APP_VERSION,
         instructions,
         title: generatePlaceholderTitle(), // Placeholder title: "YYYY-MM-DD_HH-mm_chat"
       },

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -27,6 +27,12 @@ declare const __FEATURE_X402__: boolean;
 declare const __FEATURE_VOICE__: boolean;
 
 /**
+ * App version, injected by Vite `define` from vite.version.mjs (which reads the
+ * canonical value from package.json). App code reads it via src/config/version.ts.
+ */
+declare const __APP_VERSION__: string;
+
+/**
  * Augment the global scope
  */
 declare global {
@@ -36,6 +42,7 @@ declare global {
   const __FEATURE_REMOTE_BRIDGE__: boolean;
   const __FEATURE_X402__: boolean;
   const __FEATURE_VOICE__: boolean;
+  const __APP_VERSION__: string;
 }
 
 export {};

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WorkX",
   "mainBinaryName": "WorkX",
-  "version": "0.1.1",
+  "version": "../package.json",
   "identifier": "com.airepublic.workx",
   "build": {
     "beforeBuildCommand": { "script": "npm run build:desktop && npm run build:desktop-runtime-sidecar && npm run build:sidecar && npm run build:ripgrep-sidecar", "cwd": ".." },

--- a/vite.config.desktop-runtime.mts
+++ b/vite.config.desktop-runtime.mts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
+// @ts-ignore - plain .mjs data module, no types (dependency-free by design)
+import { versionDefine } from './vite.version.mjs';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -8,6 +10,7 @@ export default defineConfig({
   envDir: resolve(__dirname, 'src/desktop'),
   define: {
     __BUILD_MODE__: JSON.stringify('server'),
+    ...versionDefine(),
   },
   build: {
     ssr: resolve(__dirname, 'src/desktop-runtime/index.ts'),

--- a/vite.config.desktop.mts
+++ b/vite.config.desktop.mts
@@ -5,6 +5,8 @@ import { resolve } from 'path';
 import { fileURLToPath } from 'url';
 // @ts-ignore - plain .mjs data module, no types (dependency-free by design)
 import { featureDefine } from './vite.featureFlags.mjs';
+// @ts-ignore - plain .mjs data module, no types (dependency-free by design)
+import { versionDefine } from './vite.version.mjs';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -28,6 +30,7 @@ export default defineConfig({
   envDir: resolve(__dirname, 'src/desktop'), // Load .env from src/desktop
   define: {
     __BUILD_MODE__: JSON.stringify('desktop'),
+    ...versionDefine(),
     // Track 22 — desktop matrix (heavier subsystems default ON here).
     ...featureDefine('desktop', process.env),
   },

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -3,6 +3,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { featureDefine } from './vite.featureFlags.mjs';
+import { versionDefine } from './vite.version.mjs';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -115,6 +116,7 @@ export default defineConfig({
   envDir: resolve(__dirname, 'src/extension'), // Load .env from src/extension
   define: {
     __BUILD_MODE__: JSON.stringify('extension'),
+    ...versionDefine(),
     // Track 22 — compile-time feature flags (per-platform matrix). The SW
     // has no process.env; WORKX_FEATURE_* here is a build-time-only knob.
     ...featureDefine('extension', process.env),

--- a/vite.config.server.mts
+++ b/vite.config.server.mts
@@ -3,6 +3,8 @@ import { resolve } from 'path';
 import { fileURLToPath } from 'url';
 // @ts-ignore - plain .mjs data module, no types (dependency-free by design)
 import { featureDefine } from './vite.featureFlags.mjs';
+// @ts-ignore - plain .mjs data module, no types (dependency-free by design)
+import { versionDefine } from './vite.version.mjs';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -13,6 +15,7 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 export default defineConfig({
   define: {
     __BUILD_MODE__: JSON.stringify('server'),
+    ...versionDefine(),
     // Track 22 — server matrix. Bundle size barely matters here; the value
     // is keeping unvetted experimental paths out of the production image.
     ...featureDefine('server', process.env),

--- a/vite.config.web.mts
+++ b/vite.config.web.mts
@@ -3,6 +3,8 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 import sveltePreprocess from 'svelte-preprocess';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
+// @ts-ignore - plain .mjs data module, no types (dependency-free by design)
+import { versionDefine } from './vite.version.mjs';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -25,6 +27,7 @@ export default defineConfig({
   root: 'src/webfront',
   define: {
     __BUILD_MODE__: JSON.stringify('web'),
+    ...versionDefine(),
   },
   build: {
     rollupOptions: {

--- a/vite.version.mjs
+++ b/vite.version.mjs
@@ -1,0 +1,31 @@
+// vite.version.mjs
+//
+// Single, dependency-free source of truth for the app version at BUILD time.
+//
+// The version is defined in exactly ONE place — package.json — and every build
+// artifact reads it from here so the number can never drift again (previously
+// package.json said 1.0.0, tauri.conf.json said 0.1.1, and RolloutRecorder
+// hard-coded '1.0.0'). tauri.conf.json reads the same package.json directly via
+// its `"version": "../package.json"` reference.
+//
+// Mirrors the vite.featureFlags.mjs pattern: plain data + one helper, ZERO
+// `@/`/TypeScript/app imports, so the plain `.mjs`/`.mts` Vite configs can
+// import it at Node config-eval time. App code reads the injected value through
+// src/config/version.ts (typed `APP_VERSION`), not the bare global directly.
+
+import { readFileSync } from 'node:fs';
+
+/** Canonical app version, read from package.json (the one source of truth). */
+export const APP_VERSION = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf8'),
+).version;
+
+/**
+ * Build the Vite `define` fragment injecting the version as a bare
+ * `__APP_VERSION__` constant (JSON.stringify'd, exactly like __BUILD_MODE__).
+ *
+ * @returns {Record<string, string>}  e.g. { __APP_VERSION__: "\"3.0.0\"" }
+ */
+export function versionDefine() {
+  return { __APP_VERSION__: JSON.stringify(APP_VERSION) };
+}

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [svelte({ hot: false })],
   define: {
     __BUILD_MODE__: JSON.stringify('extension'),
+    __APP_VERSION__: JSON.stringify('0.0.0-test'),
   },
   test: {
     globals: true,


### PR DESCRIPTION
## What

Unifies the app version to a **single source of truth** (`package.json`). Part of the production-release readiness pass.

The version had drifted across three places:

| Source | Was | Now |
|--------|-----|-----|
| `package.json` | `1.0.0` | **`3.0.0`** (source of truth, matches CHANGELOG) |
| `tauri.conf.json` | `0.1.1` | reads `../package.json` |
| `RolloutRecorder` cliVersion | hard-coded `'1.0.0'` | `APP_VERSION` |

Left un-reconciled, a release would ship the wrong version in the installers, the **auto-updater manifest**, and telemetry.

## How

- **`tauri.conf.json`** `version` now references `../package.json` — [supported by the Tauri v2 config schema](https://schema.tauri.app/config/2) (*"a semver version number or a path to a `package.json` file containing the `version` field"*). Bundle + updater version now track package.json automatically.
- **`vite.version.mjs`** (new) — dependency-free `versionDefine()` that reads the canonical version from `package.json` and injects `__APP_VERSION__` at build time. Mirrors the existing `vite.featureFlags.mjs` pattern so the `.mjs`/`.mts` configs can import it at config-eval time.
- **`src/config/version.ts`** (new) — typed `APP_VERSION` with a `0.0.0-dev` fallback for non-bundled contexts (ts-node dev server, vitest).
- Wired `versionDefine()` into every build config (extension, desktop, desktop-runtime, server, web) + a test define in `vitest.config.mjs`.
- `RolloutRecorder` now stamps `APP_VERSION` instead of the hard-coded string (removes the `TODO`).

## Test

- `npm run type-check` ✅
- `npx vitest run src/storage/rollout` ✅ (220 passed)
- eslint clean on changed files (pre-existing warnings only)

To change the shipped version in future, edit **one** field: `package.json` `version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
