### PR TITLE
feat(auth): auto-reopen login when the desktop session expires

### DIFF
--- a/src/desktop-runtime/auth/__tests__/runtimeProfileFetch.test.ts
+++ b/src/desktop-runtime/auth/__tests__/runtimeProfileFetch.test.ts
@@ -3,6 +3,7 @@ import {
   fetchUserProfileServerSide,
   profileFromAccessToken,
   refreshDesktopAuthTokens,
+  refreshDesktopAuthTokensDetailed,
 } from '../runtimeProfileFetch';
 
 function jwtWithPayload(payload: Record<string, unknown>): string {
@@ -238,5 +239,78 @@ describe('refreshDesktopAuthTokens', () => {
     expect(tokens?.accessToken).toBe('new-at');
     // OIDC may omit refresh_token on rotation-less refresh; we retain ours.
     expect(tokens?.refreshToken).toBe('old-rt');
+  });
+});
+
+// The auto-relogin fallback needs to tell an expired/revoked refresh token
+// (must re-open login) apart from a transient failure (retry later, do NOT pop
+// the browser). refreshDesktopAuthTokensDetailed reports that distinction.
+describe('refreshDesktopAuthTokensDetailed', () => {
+  const oidc = {
+    clientId: 'workx-desktop-test',
+    tokenUrl: 'https://testhome.example.com/auth/token',
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('flags a 400 invalid_grant (expired/revoked refresh token) as unrecoverable', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({ error: 'invalid_grant', error_description: 'Refresh token expired' }),
+      { status: 400 },
+    )));
+
+    const result = await refreshDesktopAuthTokensDetailed('old-rt', oidc);
+
+    expect(result.tokens).toBeNull();
+    expect(result.unrecoverable).toBe(true);
+  });
+
+  it('flags a 401 from the token endpoint as unrecoverable', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 401 })));
+
+    const result = await refreshDesktopAuthTokensDetailed('old-rt', oidc);
+
+    expect(result.tokens).toBeNull();
+    expect(result.unrecoverable).toBe(true);
+  });
+
+  it('treats a 503 as transient (recoverable) — must not force re-login', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 503 })));
+
+    const result = await refreshDesktopAuthTokensDetailed('old-rt', oidc);
+
+    expect(result.tokens).toBeNull();
+    expect(result.unrecoverable).toBe(false);
+  });
+
+  it('treats a network error as transient (recoverable)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
+
+    const result = await refreshDesktopAuthTokensDetailed('old-rt', oidc);
+
+    expect(result.tokens).toBeNull();
+    expect(result.unrecoverable).toBe(false);
+  });
+
+  it('reports success with unrecoverable=false and the refreshed tokens', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      access_token: 'new-at',
+      refresh_token: 'new-rt',
+    }), { status: 200 })));
+
+    const result = await refreshDesktopAuthTokensDetailed('old-rt', oidc);
+
+    expect(result.unrecoverable).toBe(false);
+    expect(result.tokens?.accessToken).toBe('new-at');
+    expect(result.tokens?.refreshToken).toBe('new-rt');
+  });
+
+  it('treats a missing refresh token as unrecoverable (must log in)', async () => {
+    const result = await refreshDesktopAuthTokensDetailed('', oidc);
+
+    expect(result.tokens).toBeNull();
+    expect(result.unrecoverable).toBe(true);
   });
 });

--- a/src/desktop-runtime/auth/runtimeProfileFetch.ts
+++ b/src/desktop-runtime/auth/runtimeProfileFetch.ts
@@ -194,7 +194,42 @@ export async function fetchUserProfileServerSide(
   }
 }
 
+/**
+ * Outcome of a desktop token refresh attempt.
+ *
+ * `unrecoverable` distinguishes "the server definitively rejected the refresh
+ * token" (expired/revoked — only a fresh interactive login can recover) from a
+ * transient failure (network error, 5xx) where a later retry may still succeed.
+ * Callers use this to decide whether to auto-open the login flow: we must NOT
+ * re-trigger login on a transient blip or we'd repeatedly pop the browser.
+ */
+export interface DesktopTokenRefreshResult {
+  tokens: RuntimeDesktopTokens | null;
+  unrecoverable: boolean;
+}
+
+/**
+ * HTTP statuses from the token endpoint that mean the refresh token itself is
+ * bad (expired/revoked/invalid client) — the standard OAuth `invalid_grant`
+ * family. These are unrecoverable without a new interactive login. 5xx / 429 /
+ * network errors are transient and deliberately excluded.
+ */
+function isUnrecoverableAuthStatus(status: number): boolean {
+  return status === 400 || status === 401 || status === 403;
+}
+
 export async function refreshDesktopAuthTokens(
+  refreshToken: string,
+  oidcOverride?: { clientId?: string | null; tokenUrl?: string | null },
+): Promise<RuntimeDesktopTokens | null> {
+  return (await refreshDesktopAuthTokensDetailed(refreshToken, oidcOverride)).tokens;
+}
+
+/**
+ * Like {@link refreshDesktopAuthTokens} but also reports whether a failure is
+ * unrecoverable (expired/revoked refresh token → needs interactive re-login).
+ */
+export async function refreshDesktopAuthTokensDetailed(
   refreshToken: string,
   // OIDC client config captured at login and persisted by the runtime. The
   // sidecar's process.env does NOT carry the WebView-only auth vars
@@ -203,8 +238,9 @@ export async function refreshDesktopAuthTokens(
   // to legacy. Passing the login-time clientId+tokenUrl makes refresh rebuild
   // the exact OIDC request login used.
   oidcOverride?: { clientId?: string | null; tokenUrl?: string | null },
-): Promise<RuntimeDesktopTokens | null> {
-  if (!refreshToken) return null;
+): Promise<DesktopTokenRefreshResult> {
+  // No refresh token at all → nothing to refresh; only a login recovers.
+  if (!refreshToken) return { tokens: null, unrecoverable: true };
   // OIDC sessions MUST refresh at the OIDC token endpoint (RFC 6749
   // refresh_token grant). The legacy /auth/desktop/refresh endpoint mints legacy
   // session tokens WITHOUT the gateway (svc:hub) audience, so refreshing an OIDC
@@ -227,16 +263,17 @@ export async function refreshDesktopAuthTokens(
 async function refreshViaOidc(
   refreshToken: string,
   oidcOverride?: { clientId?: string | null; tokenUrl?: string | null },
-): Promise<RuntimeDesktopTokens | null> {
+): Promise<DesktopTokenRefreshResult> {
   // Prefer the login-time OIDC config (persisted by the runtime) over env: the
   // sidecar's process.env lacks the WebView auth vars, so resolveAuthConfig()
-  // would yield null here in a real desktop session.
+  // would yield null here in a real desktop session. A missing config is
+  // recoverable by re-login (the WebView holds the config), so flag it as such.
   const tokenUrl = oidcOverride?.tokenUrl || resolveHostedAuthUrl('token');
-  if (!tokenUrl) return null;
+  if (!tokenUrl) return { tokens: null, unrecoverable: true };
   const clientId = oidcOverride?.clientId || resolveAuthConfig().oidcClientId;
   if (!clientId) {
     console.warn('[runtime-auth] OIDC token refresh skipped: no oidcClientId configured');
-    return null;
+    return { tokens: null, unrecoverable: true };
   }
   try {
     const response = await fetch(tokenUrl, {
@@ -253,33 +290,37 @@ async function refreshViaOidc(
     });
     if (!response.ok) {
       console.warn(`[runtime-auth] OIDC token refresh failed from ${tokenUrl}: ${response.status} ${response.statusText}`);
-      return null;
+      return { tokens: null, unrecoverable: isUnrecoverableAuthStatus(response.status) };
     }
     const data = await response.json() as Record<string, unknown>;
     const accessToken = pickString(data.access_token);
     if (!accessToken) {
       console.warn(`[runtime-auth] OIDC token refresh from ${tokenUrl} returned no access_token`);
-      return null;
+      return { tokens: null, unrecoverable: false };
     }
     return {
-      accessToken,
-      // OIDC may rotate the refresh token; if the response omits it, keep ours.
-      refreshToken: pickString(data.refresh_token) ?? refreshToken,
-      tokenType: pickString(data.token_type),
-      expiresIn: typeof data.expires_in === 'number' ? data.expires_in : undefined,
+      tokens: {
+        accessToken,
+        // OIDC may rotate the refresh token; if the response omits it, keep ours.
+        refreshToken: pickString(data.refresh_token) ?? refreshToken,
+        tokenType: pickString(data.token_type),
+        expiresIn: typeof data.expires_in === 'number' ? data.expires_in : undefined,
+      },
+      unrecoverable: false,
     };
   } catch (error) {
+    // Network/transport error — transient, do NOT force re-login.
     console.warn(`[runtime-auth] OIDC token refresh threw from ${tokenUrl}:`, error);
-    return null;
+    return { tokens: null, unrecoverable: false };
   }
 }
 
 /** Legacy desktop-session refresh (`/auth/desktop/refresh`). Non-OIDC only. */
 async function refreshViaLegacyDesktop(
   refreshToken: string,
-): Promise<RuntimeDesktopTokens | null> {
+): Promise<DesktopTokenRefreshResult> {
   const desktopRefreshUrl = resolveHostedAuthUrl('desktopRefresh');
-  if (!desktopRefreshUrl) return null;
+  if (!desktopRefreshUrl) return { tokens: null, unrecoverable: false };
   try {
     const response = await fetch(desktopRefreshUrl, {
       method: 'POST',
@@ -291,23 +332,26 @@ async function refreshViaLegacyDesktop(
     });
     if (!response.ok) {
       console.warn(`[runtime-auth] desktop token refresh failed from ${desktopRefreshUrl}: ${response.status} ${response.statusText}`);
-      return null;
+      return { tokens: null, unrecoverable: isUnrecoverableAuthStatus(response.status) };
     }
     const data = await response.json() as Record<string, unknown>;
     const accessToken = pickString(data.access_token);
     const nextRefreshToken = pickString(data.refresh_token);
     if (!accessToken || !nextRefreshToken) {
       console.warn(`[runtime-auth] desktop token refresh from ${desktopRefreshUrl} returned incomplete tokens`);
-      return null;
+      return { tokens: null, unrecoverable: false };
     }
     return {
-      accessToken,
-      refreshToken: nextRefreshToken,
-      tokenType: pickString(data.token_type),
-      expiresIn: typeof data.expires_in === 'number' ? data.expires_in : undefined,
+      tokens: {
+        accessToken,
+        refreshToken: nextRefreshToken,
+        tokenType: pickString(data.token_type),
+        expiresIn: typeof data.expires_in === 'number' ? data.expires_in : undefined,
+      },
+      unrecoverable: false,
     };
   } catch (error) {
     console.warn(`[runtime-auth] desktop token refresh threw from ${desktopRefreshUrl}:`, error);
-    return null;
+    return { tokens: null, unrecoverable: false };
   }
 }

--- a/src/server/agent/ServerAgentBootstrap.ts
+++ b/src/server/agent/ServerAgentBootstrap.ts
@@ -1377,9 +1377,23 @@ export class ServerAgentBootstrap {
     if (!refreshToken) return null;
 
     try {
-      const { refreshDesktopAuthTokens } = await import('@/desktop-runtime/auth/runtimeProfileFetch');
-      const refreshed = await refreshDesktopAuthTokens(refreshToken, await this.readPersistedOidcConfig());
+      const { refreshDesktopAuthTokensDetailed } = await import('@/desktop-runtime/auth/runtimeProfileFetch');
+      const result = await refreshDesktopAuthTokensDetailed(refreshToken, await this.readPersistedOidcConfig());
+      const refreshed = result.tokens;
       if (!refreshed?.accessToken || !refreshed.refreshToken) {
+        if (result.unrecoverable) {
+          // The refresh token is expired/revoked — no silent recovery is
+          // possible. Signal the WebView (via access state) to re-open login
+          // instead of surfacing a dead "Invalid JWT" task failure. The
+          // `session_expired` reason is a stable sentinel the UI matches on to
+          // auto-trigger the login flow exactly once.
+          await this.runtimeState?.setAccessState({
+            status: 'needs_login',
+            mode: 'login',
+            ready: false,
+            reason: 'session_expired',
+          }).catch(() => undefined);
+        }
         return null;
       }
       await Promise.all([

--- a/src/webfront/pages/chat/Main.svelte
+++ b/src/webfront/pages/chat/Main.svelte
@@ -58,6 +58,11 @@
   let healthStatus: { ready: boolean; message?: string; provider?: string; model?: string; authMode?: 'login' | 'api_key' | 'none' } = $state({ ready: false, authMode: 'none' });
   let zoomLevel: number = $state(parseInt(document.documentElement.style.fontSize) || 100);
 
+  // Guards the auto-relogin so an expired desktop session opens the login flow
+  // exactly once per expiry (reset when access returns to ready), rather than
+  // popping the browser on every subsequent access-state emission.
+  let sessionReloginPrompted = false;
+
   function applyAccessState(access: AgentAccessState): void {
     isConnected = true;
     agentReady = access.ready;
@@ -69,6 +74,20 @@
       authMode: access.mode,
     };
     agentStore.updateFromAccessState(access);
+
+    // Auto-relogin: when the runtime reports the desktop session expired
+    // (refresh token revoked/expired), re-open the login flow instead of
+    // leaving the user on a dead "Invalid JWT" error. The `session_expired`
+    // reason is the runtime's stable sentinel for "must re-login" (as opposed
+    // to a fresh logout or a transient failure, which must not auto-pop login).
+    if (access.status === 'needs_login' && access.reason === 'session_expired') {
+      if (!sessionReloginPrompted) {
+        sessionReloginPrompted = true;
+        requestLogin();
+      }
+    } else if (access.ready) {
+      sessionReloginPrompted = false;
+    }
   }
 
   function onZoomChanged(e: Event) {


### PR DESCRIPTION
## What

Implements the deferred **auto-relogin fallback**. Previously, once the desktop OIDC refresh token expired or was revoked (30-day lifetime), a mid-task token refresh failed and the task died with a bare **`ModelClientError: Invalid JWT`** — with no way for the user to recover. Now the app re-opens the login flow instead of showing a dead error.

> This is the "pop login automatically in the external browser instead of showing an error" behavior requested earlier.

## How

**Runtime — distinguish unrecoverable vs transient (`src/desktop-runtime/auth/runtimeProfileFetch.ts`):**
- `refreshDesktopAuthTokensDetailed()` (new) returns `{ tokens, unrecoverable }`.
  - **Unrecoverable** = server rejected the refresh token: HTTP `400/401/403` (the OAuth `invalid_grant` family) or no refresh token at all → only a fresh interactive login recovers.
  - **Transient** = network error / `5xx` → retrying later can work, so we must **not** pop the browser.
- `refreshDesktopAuthTokens()` is kept as a thin wrapper (`.tokens`) so every existing caller and test is unaffected.

**Runtime — signal the UI (`src/server/agent/ServerAgentBootstrap.ts`):**
- On an unrecoverable mid-session refresh, flip runtime access state to `needs_login` with a stable `session_expired` reason (emitted as `agent.accessChanged`).

**WebView — react once (`src/webfront/pages/chat/Main.svelte`):**
- `applyAccessState()` sees `needs_login` + `session_expired` → fires the existing `requestLogin()` (→ `workx:request-login` → opens the system browser to OIDC login), **guarded to fire exactly once** per expiry and reset when access returns to `ready`. Fresh logout / transient failures use different reasons and never auto-open login.

## Why this design

- Reuses the already-wired login path (`workx:request-login` listener in `UserLoginStatus.svelte`) and existing access-state event plumbing — no new IPC.
- The recoverable/transient split is the safety mechanism: it prevents a network blip from repeatedly launching the browser.

## Test

- 6 new unit tests for the classification (invalid_grant 400, 401, 503, network error, success, missing token). `npx vitest run src/desktop-runtime/auth` → **15 passed**.
- `type-check` ✅, eslint ✅ (0 errors).

Note: the WebView auto-open path is exercised via the `session_expired` sentinel; end-to-end browser-pop behavior should be smoke-tested in a packaged desktop build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
