### PR TITLE
feat(errors): redact secrets from user- and LLM-facing error messages

### DIFF
--- a/src/core/TaskRunner.ts
+++ b/src/core/TaskRunner.ts
@@ -7,6 +7,7 @@
 import { Session } from './Session';
 import { TurnManager } from './TurnManager';
 import { TurnContext } from './TurnContext';
+import { redactSecretsInText } from '@/core/diagnostics/redact';
 import type { ProcessedResponseItem, TurnRunResult } from './TurnManager';
 import type { InputItem, Event, ResponseItem } from './protocol/types';
 import type {
@@ -125,6 +126,13 @@ interface LoopOutcomeInit {
  * cause when present.
  */
 export function describeTaskError(error: unknown): string {
+  // Single exit through the secret redactor: whatever reason we build below,
+  // it must never surface a credential (a Bearer token, api key, etc.) in the
+  // TaskFailed message shown to the user.
+  return redactSecretsInText(describeTaskErrorRaw(error));
+}
+
+function describeTaskErrorRaw(error: unknown): string {
   if (error instanceof Error) {
     const name = error.name && error.name !== 'Error' ? error.name : '';
     const message = (error.message ?? '').trim();

--- a/src/core/TurnManager.ts
+++ b/src/core/TurnManager.ts
@@ -4,6 +4,7 @@
  */
 
 import { Session } from './Session';
+import { safeErrorMessage } from './errors/sanitizeError';
 import type { ToolDefinition } from '../tools/BaseTool';
 import { SUBMIT_PLAN_TOOL_NAME } from '../tools/planReview/types';
 import { TurnContext } from './TurnContext';
@@ -815,7 +816,7 @@ export class TurnManager {
         return {
           type: 'function_call_output',
           call_id,
-          output: `Error: ${error instanceof Error ? error.message : String(error)}`,
+          output: `Error: ${safeErrorMessage(error)}`,
         };
       }
     } else if (item.type === 'message' || item.type === 'reasoning' || item.type === 'web_search_call') {
@@ -858,7 +859,7 @@ export class TurnManager {
               return {
                 type: 'function_call_output',
                 call_id: call.id,
-                output: `Error: ${error instanceof Error ? error.message : String(error)}`,
+                output: `Error: ${safeErrorMessage(error)}`,
               };
             }
           },
@@ -910,7 +911,7 @@ export class TurnManager {
             return {
               type: 'function_call_output',
               call_id: callId,
-              output: `Error: ${error instanceof Error ? error.message : String(error)}`,
+              output: `Error: ${safeErrorMessage(error)}`,
             };
           }
         }
@@ -1058,7 +1059,7 @@ export class TurnManager {
       };
 
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
+      const errorMsg = safeErrorMessage(error);
 
       // Handle approval denial with a descriptive message for the LLM
       // Check this first — denials are normal control flow, not tool failures.
@@ -1194,7 +1195,7 @@ export class TurnManager {
           return {
             type: 'function_call_output',
             call_id: call.id,
-            output: `Error: ${error instanceof Error ? error.message : String(error)}`,
+            output: `Error: ${safeErrorMessage(error)}`,
           };
         }
       },

--- a/src/core/__tests__/TaskRunner.test.ts
+++ b/src/core/__tests__/TaskRunner.test.ts
@@ -1227,4 +1227,15 @@ describe('describeTaskError', () => {
     expect(describeTaskError({ code: 402 })).toBe('{"code":402}');
     expect(describeTaskError(undefined)).toBe('Unknown error');
   });
+
+  it('redacts secrets so a credential never reaches the TaskFailed message', () => {
+    const withBearer = describeTaskError(new Error('request failed: Authorization: Bearer abc.def.ghi'));
+    expect(withBearer).not.toContain('abc.def.ghi');
+    expect(withBearer).toContain('***');
+
+    const withKey = describeTaskError(new Error('auth failed for sk-ant-secret0123456789abcdef'));
+    expect(withKey).not.toContain('sk-ant-secret0123456789abcdef');
+    // The non-secret part of the reason is preserved.
+    expect(withKey).toContain('auth failed for');
+  });
 });

--- a/src/core/diagnostics/redact.ts
+++ b/src/core/diagnostics/redact.ts
@@ -54,6 +54,16 @@ function redactString(input: string): string {
   return out;
 }
 
+/**
+ * Redact secrets (provider API keys, Bearer/JWT tokens, `key=value` secrets,
+ * URL userinfo) from a free-text string. Shared beyond diagnostics so a thrown
+ * error message never surfaces a credential to the user, the LLM, or a stored
+ * rollout — see {@link module:core/errors/sanitizeError}. Pure; never mutates.
+ */
+export function redactSecretsInText(input: string): string {
+  return redactString(input);
+}
+
 function redactValue(value: unknown, keyIsSensitive = false): unknown {
   if (typeof value === 'string') {
     return keyIsSensitive ? REPLACEMENT : redactString(value);

--- a/src/core/errors/__tests__/sanitizeError.test.ts
+++ b/src/core/errors/__tests__/sanitizeError.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { errorMessage, safeErrorMessage } from '../sanitizeError';
+
+describe('errorMessage', () => {
+  it('extracts the message from an Error', () => {
+    expect(errorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('stringifies a non-Error throw', () => {
+    expect(errorMessage('plain')).toBe('plain');
+    expect(errorMessage(42)).toBe('42');
+  });
+});
+
+describe('safeErrorMessage', () => {
+  it('redacts a Bearer token', () => {
+    const out = safeErrorMessage(new Error('GET /v1 -> 401 (Authorization: Bearer eyJabc.def.ghi)'));
+    expect(out).not.toContain('eyJabc.def.ghi');
+    expect(out).toContain('***');
+  });
+
+  it('redacts a provider API key', () => {
+    const out = safeErrorMessage(new Error('bad key sk-ant-abcdef0123456789ghijkl'));
+    expect(out).not.toContain('sk-ant-abcdef0123456789ghijkl');
+    expect(out).toContain('***');
+  });
+
+  it('redacts a key=value secret', () => {
+    const out = safeErrorMessage('connect failed password=hunter2trustno1');
+    expect(out).not.toContain('hunter2trustno1');
+  });
+
+  it('redacts credentials embedded in a URL', () => {
+    const out = safeErrorMessage(new Error('dial postgres://user:s3cretpw@db.internal:5432 failed'));
+    expect(out).not.toContain('s3cretpw');
+    // The host stays so the failure is still diagnosable.
+    expect(out).toContain('db.internal');
+  });
+
+  it('leaves a secret-free message untouched', () => {
+    const msg = 'ENOTFOUND api.example.com: getaddrinfo failed';
+    expect(safeErrorMessage(new Error(msg))).toBe(msg);
+  });
+});

--- a/src/core/errors/sanitizeError.ts
+++ b/src/core/errors/sanitizeError.ts
@@ -1,0 +1,33 @@
+/**
+ * Error message sanitization for surfaces that DISPLAY or PERSIST errors.
+ *
+ * A thrown error's `message` can carry secrets — a Bearer token in a failed
+ * request, an API key echoed back by a provider, a `password=…` in a
+ * connection string. Those messages flow to three places we do not control:
+ * the `TaskFailed` event shown in the UI, tool-call `output` fed back to the
+ * LLM, and the rollout recording persisted to disk. This module strips secrets
+ * before an error string reaches any of them.
+ *
+ * It is intentionally conservative: it removes only high-confidence secrets
+ * (reusing the diagnostics redaction rules) and preserves the rest of the
+ * message — URLs, file paths, and the failure reason — so both the user and
+ * the agent keep enough context to understand what went wrong.
+ *
+ * @module core/errors/sanitizeError
+ */
+
+import { redactSecretsInText } from '@/core/diagnostics/redact';
+
+/** Extract a plain message from an unknown thrown value (no redaction). */
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Secret-redacted message for an unknown thrown value. Use at every point an
+ * error string is written into a tool output, an event shown to the user, or a
+ * persisted record.
+ */
+export function safeErrorMessage(error: unknown): string {
+  return redactSecretsInText(errorMessage(error));
+}


### PR DESCRIPTION
## What

Stops error messages from leaking **secrets** to the three surfaces we don't control: the **`TaskFailed`** event shown in the UI, tool-call **`output`** fed back to the LLM, and the persisted **rollout recording**.

A thrown error's `message` can contain a Bearer token from a failed request, a provider API key echoed back by an upstream, or a `password=…` in a connection string. Today those reach the user and get stored verbatim.

## How

- **Reuse** the conservative redactor already used for diagnostics (`src/core/diagnostics/redact.ts`) — provider keys (`sk-…`, `xai-…`, `AIza…`), `Bearer …`, JWT triples, `key=value` secrets, and URL userinfo — exported as `redactSecretsInText()`.
- **New `src/core/errors/sanitizeError.ts`** (`errorMessage` / `safeErrorMessage`) — the single place error strings get sanitized.
- **`describeTaskError()`** now funnels its result through the redactor → every `TaskFailed` reason shown to the user is scrubbed (single exit point; existing logic unchanged).
- **TurnManager** tool-failure outputs (`function_call_output`, 5 sites) use `safeErrorMessage()` → a secret can't be persisted to a rollout or sent back to the model.

## Design notes

- **Conservative by design:** only high-confidence secrets are removed; URLs, hosts, file paths and the failure reason are preserved so the user and the agent keep enough context to diagnose. (This is why URL/path redaction — which the review floated — was deliberately *not* included: it would blind the agent and add behavioral risk for little security gain.)
- **Console logging left out of scope:** the review flagged ~1,100 `console.*` calls, but the sensitive paths (credentials handler, auth refresh) log only IDs / URLs / status codes — **not secret values** — and no general logger exists. Introducing a logging framework belongs in its own change.

## Test

- New `sanitizeError` suite (Bearer, API key, `key=value`, URL creds, passthrough of secret-free messages).
- New `describeTaskError` redaction case. Existing `describeTaskError` tests unchanged and still green (redaction is a no-op on secret-free messages).
- `type-check` ✅ · `vitest` TaskRunner (53) + TurnManager (126) + diagnostics ✅ · eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
