### PR TITLE
feat: route account-credits LLM (memory + extension) through AI Hub gateway

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,5 +1,5 @@
 /**
- * Shared constants for backend + gateway API URLs
+ * Shared constants for backend API URLs
  * These are used by both the service worker and the sidepanel
  */
 
@@ -8,24 +8,7 @@ export const BACKEND_API_BASE_URL =
   (typeof import.meta !== 'undefined' && import.meta.env?.VITE_BACKEND_API_BASE_URL) || '';
 
 // Legacy in-house LLM endpoint (ai-assistant) for backend/cookie routing.
-// DEPRECATED: superseded by the AI Hub gateway (GATEWAY_LLM_API_URL). Retained as a
-// fallback while the extension migrates account-credits LLM to the gateway.
+// DEPRECATED: superseded by the AI Hub gateway. The gateway URL + routing mode are
+// resolved via resolveRuntimeUrls() (single source of truth, used by both extension
+// chat routing and desktop memory routing) rather than a parallel copy here.
 export const LLM_API_URL = `${BACKEND_API_BASE_URL}/api/llm`;
-
-// AI Hub gateway base URL (OpenAI-compatible LLM + MCP) from environment.
-export const GATEWAY_BASE_URL =
-  (typeof import.meta !== 'undefined' && import.meta.env?.VITE_GATEWAY_BASE_URL) || '';
-
-// Gateway OpenAI-compatible LLM endpoint root (/v1). Empty when unconfigured.
-export const GATEWAY_LLM_API_URL = GATEWAY_BASE_URL
-  ? `${GATEWAY_BASE_URL.replace(/\/+$/, '')}/v1`
-  : '';
-
-// Extension LLM routing mode. 'gateway' routes account-credits LLM through the AI
-// Hub gateway (metered on the unified wallet); 'legacy' uses the deprecated
-// ai-assistant /api/llm path. Defaults to 'gateway' when a gateway URL is set.
-export const LLM_ROUTING_MODE: 'gateway' | 'legacy' =
-  ((typeof import.meta !== 'undefined' && import.meta.env?.VITE_LLM_ROUTING_MODE) as
-    | 'gateway'
-    | 'legacy'
-    | undefined) ?? (GATEWAY_LLM_API_URL ? 'gateway' : 'legacy');

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,5 +1,5 @@
 /**
- * Shared constants for backend API URLs
+ * Shared constants for backend + gateway API URLs
  * These are used by both the service worker and the sidepanel
  */
 
@@ -7,5 +7,25 @@
 export const BACKEND_API_BASE_URL =
   (typeof import.meta !== 'undefined' && import.meta.env?.VITE_BACKEND_API_BASE_URL) || '';
 
-// LLM API endpoint for backend routing
+// Legacy in-house LLM endpoint (ai-assistant) for backend/cookie routing.
+// DEPRECATED: superseded by the AI Hub gateway (GATEWAY_LLM_API_URL). Retained as a
+// fallback while the extension migrates account-credits LLM to the gateway.
 export const LLM_API_URL = `${BACKEND_API_BASE_URL}/api/llm`;
+
+// AI Hub gateway base URL (OpenAI-compatible LLM + MCP) from environment.
+export const GATEWAY_BASE_URL =
+  (typeof import.meta !== 'undefined' && import.meta.env?.VITE_GATEWAY_BASE_URL) || '';
+
+// Gateway OpenAI-compatible LLM endpoint root (/v1). Empty when unconfigured.
+export const GATEWAY_LLM_API_URL = GATEWAY_BASE_URL
+  ? `${GATEWAY_BASE_URL.replace(/\/+$/, '')}/v1`
+  : '';
+
+// Extension LLM routing mode. 'gateway' routes account-credits LLM through the AI
+// Hub gateway (metered on the unified wallet); 'legacy' uses the deprecated
+// ai-assistant /api/llm path. Defaults to 'gateway' when a gateway URL is set.
+export const LLM_ROUTING_MODE: 'gateway' | 'legacy' =
+  ((typeof import.meta !== 'undefined' && import.meta.env?.VITE_LLM_ROUTING_MODE) as
+    | 'gateway'
+    | 'legacy'
+    | undefined) ?? (GATEWAY_LLM_API_URL ? 'gateway' : 'legacy');

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -1120,14 +1120,38 @@ export class Session {
 
         const openaiApiKey = await agentConfig.getProviderApiKey('openai');
 
-        // Build backend routing config if applicable
-        let backendBaseUrl: string | undefined;
+        // Build platform routing config for "account credits" memory (own-key off).
+        // Prefer the AI Hub gateway (/v1, metered on the unified credit wallet); fall
+        // back to the legacy ai-assistant /api/llm path only when the gateway is not
+        // configured (llmRoutingMode !== 'gateway'). Own-key memory is unaffected and
+        // calls the user's OpenAI key directly.
+        let backendBaseUrl: string | undefined;    // legacy ai-assistant /api/llm
+        let gatewayLlmBaseUrl: string | undefined;  // AI Hub gateway /v1
         if (useBackendForMemory) {
-          const { LLM_API_URL } = await import('../config/constants');
-          if (LLM_API_URL) {
-            backendBaseUrl = LLM_API_URL;
+          const { resolveRuntimeUrls } = await import('../config/runtimeUrls');
+          const urls = resolveRuntimeUrls();
+          if (urls.llmRoutingMode === 'gateway' && urls.gatewayLlmApiUrl) {
+            // Only route memory through the gateway when a session JWT is actually
+            // available (desktop, logged in). Otherwise fall back to the legacy path
+            // so server profiles / logged-out states keep working as before.
+            try {
+              const { getCredentialStore } = await import('@/core/storage');
+              const token = await getCredentialStore().get('auth', 'access_token');
+              if (token) {
+                gatewayLlmBaseUrl = urls.gatewayLlmApiUrl;
+              }
+            } catch {
+              // credential store unavailable — fall through to legacy backend
+            }
+          }
+          if (!gatewayLlmBaseUrl) {
+            const { LLM_API_URL } = await import('../config/constants');
+            if (LLM_API_URL) {
+              backendBaseUrl = LLM_API_URL;
+            }
           }
         }
+        const useGatewayForMemory = !!gatewayLlmBaseUrl;
 
         // Create a dedicated LLM caller for memory keyword generation and relevance filtering.
         // Prefers a cheap model (gpt-4o-mini) via OpenAI API key. Falls back to the
@@ -1140,15 +1164,32 @@ export class Session {
           ? (openaiApiKey || 'backend-routed')
           : (openaiApiKey || '');
 
+        // The gateway resolves models by "<provider>/<model>" slug; the legacy
+        // backend and own-key paths use the bare model id.
+        const memoryRequestModel = useGatewayForMemory && !extractionModel.includes('/')
+          ? `openai/${extractionModel}`
+          : extractionModel;
+
         let llmCaller = null;
 
         if (memoryApiKey) {
           // Preferred path: dedicated gpt-4o-mini client via OpenAI key.
           // Track 11 note: memory extraction is a single tool-less completion;
           // it intentionally does not take the agent's parallelToolCalls flag.
+          //
+          // Gateway account-credits memory authenticates per-request with the
+          // desktop session JWT (Bearer), same as main-chat gateway routing.
+          let memoryAuthTokenGetter: (() => Promise<string | null>) | undefined;
+          if (useGatewayForMemory) {
+            const { getCredentialStore } = await import('@/core/storage');
+            memoryAuthTokenGetter = () => getCredentialStore().get('auth', 'access_token');
+          }
+
           const memoryLLMClient = new OpenAIChatCompletionClient({
-            apiKey: memoryApiKey,
-            baseUrl: useBackendForMemory && backendBaseUrl ? backendBaseUrl + '/openai' : undefined,
+            apiKey: useGatewayForMemory ? 'gateway-routed' : memoryApiKey,
+            baseUrl: useGatewayForMemory
+              ? gatewayLlmBaseUrl
+              : (useBackendForMemory && backendBaseUrl ? backendBaseUrl + '/openai' : undefined),
             sessionId: 'memory-search',
             modelFamily: {
               family: extractionModel,
@@ -1162,13 +1203,15 @@ export class Session {
               wire_api: 'Chat' as const,
               requires_openai_auth: true,
             },
-            ...(useBackendForMemory && backendBaseUrl && { useCredentials: true }),
+            ...(useGatewayForMemory
+              ? { getAuthorizationToken: memoryAuthTokenGetter }
+              : (useBackendForMemory && backendBaseUrl ? { useCredentials: true } : {})),
           });
 
           llmCaller = {
             complete: async (systemPrompt: string, userPrompt: string) => {
               const response = await memoryLLMClient.complete({
-                model: extractionModel,
+                model: memoryRequestModel,
                 messages: [
                   { role: 'system', content: systemPrompt },
                   { role: 'user', content: userPrompt }

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -1203,8 +1203,14 @@ export class Session {
               wire_api: 'Chat' as const,
               requires_openai_auth: true,
             },
+            // refreshAuthorizationToken re-reads the credential store on 401 (the
+            // desktop runtime refreshes that token in the background), mirroring the
+            // main-chat gateway client which supplies both hooks.
             ...(useGatewayForMemory
-              ? { getAuthorizationToken: memoryAuthTokenGetter }
+              ? {
+                  getAuthorizationToken: memoryAuthTokenGetter,
+                  refreshAuthorizationToken: memoryAuthTokenGetter,
+                }
               : (useBackendForMemory && backendBaseUrl ? { useCredentials: true } : {})),
           });
 

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -1164,11 +1164,16 @@ export class Session {
           ? (openaiApiKey || 'backend-routed')
           : (openaiApiKey || '');
 
-        // The gateway resolves models by "<provider>/<model>" slug; the legacy
-        // backend and own-key paths use the bare model id.
-        const memoryRequestModel = useGatewayForMemory && !extractionModel.includes('/')
-          ? `openai/${extractionModel}`
-          : extractionModel;
+        // The gateway resolves models by "<provider>/<model>" slug; the legacy backend and
+        // own-key paths use the bare id. Only prefix a bare id; pass through an existing
+        // "owner/model" slug, and normalize the "owner:model" config form to a slash.
+        const memoryRequestModel = !useGatewayForMemory
+          ? extractionModel
+          : extractionModel.includes('/')
+            ? extractionModel
+            : extractionModel.includes(':')
+              ? extractionModel.replace(':', '/')
+              : `openai/${extractionModel}`;
 
         let llmCaller = null;
 

--- a/src/extension/auth/extensionSessionToken.ts
+++ b/src/extension/auth/extensionSessionToken.ts
@@ -1,0 +1,66 @@
+/**
+ * Extension session-token access for AI Hub gateway routing.
+ *
+ * The extension authenticates via the home-page session cookies on the
+ * *.airepublic.com domain. The legacy ai-assistant backend accepted those cookies
+ * directly (`credentials: 'include'`), but the AI Hub gateway requires a Bearer
+ * JWT. Because the `chrome.cookies` API is available in the MV3 service worker and
+ * can read the (httpOnly) access-token cookie, the service worker can read the same
+ * JWT the sidepanel uses and present it as a bearer token — no cross-context bridge
+ * or separate token store is required.
+ *
+ * @module extension/auth/extensionSessionToken
+ */
+import { resolveAuthConfig } from '@/config/authConfig';
+import { getAccessToken, getRefreshToken } from '@/webfront/lib/utils/cookie';
+
+const REFRESH_PATH = '/auth/desktop/refresh';
+
+/** Best-effort JWT expiry check (no signature verification — that's the gateway's job). */
+function isJwtUnexpired(token: string): boolean {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return false;
+    const payload = JSON.parse(atob(parts[1]));
+    return payload.exp ? payload.exp * 1000 > Date.now() : true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read the current session access token from the auth cookie, refreshing it via the
+ * home-page refresh endpoint when expired. Returns null when unauthenticated.
+ * Used as the gateway client's per-request bearer-token getter.
+ */
+export async function getSessionAccessToken(): Promise<string | null> {
+  const token = await getAccessToken();
+  if (token && isJwtUnexpired(token)) return token;
+  return refreshSessionAccessToken();
+}
+
+/**
+ * Refresh the session tokens using the refresh cookie, then re-read the (rotated)
+ * access-token cookie. `credentials: 'include'` lets the refresh response's
+ * Set-Cookie update the cookie jar. Best-effort: returns whatever access token is
+ * available afterwards (or null). Also used as the client's 401 refresh hook.
+ */
+export async function refreshSessionAccessToken(): Promise<string | null> {
+  const refreshToken = await getRefreshToken();
+  if (!refreshToken) return getAccessToken();
+
+  const authBaseUrl = resolveAuthConfig().authBaseUrl;
+  if (!authBaseUrl) return getAccessToken();
+
+  try {
+    await fetch(`${authBaseUrl}${REFRESH_PATH}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refresh_token: refreshToken }),
+      credentials: 'include',
+    });
+  } catch (error) {
+    console.warn('[ExtensionSessionToken] Token refresh failed:', error);
+  }
+  return getAccessToken();
+}

--- a/src/extension/auth/extensionSessionToken.ts
+++ b/src/extension/auth/extensionSessionToken.ts
@@ -4,10 +4,15 @@
  * The extension authenticates via the home-page session cookies on the
  * *.airepublic.com domain. The legacy ai-assistant backend accepted those cookies
  * directly (`credentials: 'include'`), but the AI Hub gateway requires a Bearer
- * JWT. Because the `chrome.cookies` API is available in the MV3 service worker and
- * can read the (httpOnly) access-token cookie, the service worker can read the same
- * JWT the sidepanel uses and present it as a bearer token — no cross-context bridge
- * or separate token store is required.
+ * JWT. `chrome.cookies` (SW-safe, reads httpOnly cookies) lets the service worker
+ * read the same access-token cookie the sidepanel uses and present it as a bearer.
+ *
+ * The `/auth/desktop/refresh` endpoint returns rotated tokens in its JSON body (it
+ * does not Set-Cookie the httpOnly access cookie), so a refreshed token can't be
+ * re-read from the cookie. We therefore cache the freshest access token in memory
+ * and prefer it over the cookie. The cache is lost when the MV3 worker is evicted,
+ * which just falls back to the cookie + a fresh refresh — correct, if slightly less
+ * efficient.
  *
  * @module extension/auth/extensionSessionToken
  */
@@ -16,12 +21,24 @@ import { getAccessToken, getRefreshToken } from '@/webfront/lib/utils/cookie';
 
 const REFRESH_PATH = '/auth/desktop/refresh';
 
-/** Best-effort JWT expiry check (no signature verification — that's the gateway's job). */
+/** Freshest known access token (from a refresh body or a valid cookie). */
+let cachedAccessToken: string | null = null;
+/** In-flight refresh, so concurrent callers share one POST (avoids refresh-token rotation races). */
+let inflightRefresh: Promise<string | null> | null = null;
+
+/**
+ * Best-effort JWT expiry check (no signature verification — that's the gateway's job).
+ * Decodes the base64url payload. Returns false on decode failure (treat as needing refresh)
+ * or when past `exp`; true when unexpired or when there is no `exp` claim.
+ */
 function isJwtUnexpired(token: string): boolean {
   try {
     const parts = token.split('.');
     if (parts.length !== 3) return false;
-    const payload = JSON.parse(atob(parts[1]));
+    // base64url → base64 (+ padding) before decoding.
+    let b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    b64 += '='.repeat((4 - (b64.length % 4)) % 4);
+    const payload = JSON.parse(atob(b64));
     return payload.exp ? payload.exp * 1000 > Date.now() : true;
   } catch {
     return false;
@@ -29,38 +46,63 @@ function isJwtUnexpired(token: string): boolean {
 }
 
 /**
- * Read the current session access token from the auth cookie, refreshing it via the
- * home-page refresh endpoint when expired. Returns null when unauthenticated.
- * Used as the gateway client's per-request bearer-token getter.
+ * Current session access token: in-memory cache → auth cookie → refresh.
+ * Returns null when unauthenticated. Used as the gateway client's bearer getter.
  */
 export async function getSessionAccessToken(): Promise<string | null> {
-  const token = await getAccessToken();
-  if (token && isJwtUnexpired(token)) return token;
+  if (cachedAccessToken && isJwtUnexpired(cachedAccessToken)) return cachedAccessToken;
+
+  const cookieToken = await getAccessToken();
+  if (cookieToken && isJwtUnexpired(cookieToken)) {
+    cachedAccessToken = cookieToken;
+    return cookieToken;
+  }
+
   return refreshSessionAccessToken();
 }
 
 /**
- * Refresh the session tokens using the refresh cookie, then re-read the (rotated)
- * access-token cookie. `credentials: 'include'` lets the refresh response's
- * Set-Cookie update the cookie jar. Best-effort: returns whatever access token is
- * available afterwards (or null). Also used as the client's 401 refresh hook.
+ * Refresh via the home-page refresh endpoint and return the rotated access token
+ * from the response BODY (the endpoint does not Set-Cookie the access cookie).
+ * Returns null on any failure (invalid refresh token, HTTP error, network error) so
+ * callers surface a real auth failure instead of retrying a stale token. Concurrent
+ * calls share one in-flight request. Also the gateway client's 401 refresh hook.
  */
-export async function refreshSessionAccessToken(): Promise<string | null> {
+export function refreshSessionAccessToken(): Promise<string | null> {
+  if (inflightRefresh) return inflightRefresh;
+  inflightRefresh = doRefresh().finally(() => {
+    inflightRefresh = null;
+  });
+  return inflightRefresh;
+}
+
+async function doRefresh(): Promise<string | null> {
   const refreshToken = await getRefreshToken();
-  if (!refreshToken) return getAccessToken();
+  if (!refreshToken) {
+    cachedAccessToken = null;
+    return null;
+  }
 
   const authBaseUrl = resolveAuthConfig().authBaseUrl;
-  if (!authBaseUrl) return getAccessToken();
+  if (!authBaseUrl) return null;
 
   try {
-    await fetch(`${authBaseUrl}${REFRESH_PATH}`, {
+    const response = await fetch(`${authBaseUrl}${REFRESH_PATH}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ refresh_token: refreshToken }),
       credentials: 'include',
     });
+    if (!response.ok) {
+      cachedAccessToken = null;
+      return null;
+    }
+    const data = await response.json();
+    const accessToken: string | null = data?.access_token ?? null;
+    cachedAccessToken = accessToken;
+    return accessToken;
   } catch (error) {
     console.warn('[ExtensionSessionToken] Token refresh failed:', error);
+    return null;
   }
-  return getAccessToken();
 }

--- a/src/extension/auth/extensionSessionToken.ts
+++ b/src/extension/auth/extensionSessionToken.ts
@@ -23,6 +23,10 @@ const REFRESH_PATH = '/auth/desktop/refresh';
 
 /** Freshest known access token (from a refresh body or a valid cookie). */
 let cachedAccessToken: string | null = null;
+/** Freshest known refresh token. /auth/desktop/refresh rotates it and returns it in the
+ * body (not Set-Cookie), so we must keep the rotated value or the next refresh reuses the
+ * now-invalidated cookie value. Lost on MV3 worker eviction, which falls back to the cookie. */
+let cachedRefreshToken: string | null = null;
 /** In-flight refresh, so concurrent callers share one POST (avoids refresh-token rotation races). */
 let inflightRefresh: Promise<string | null> | null = null;
 
@@ -77,7 +81,8 @@ export function refreshSessionAccessToken(): Promise<string | null> {
 }
 
 async function doRefresh(): Promise<string | null> {
-  const refreshToken = await getRefreshToken();
+  // Prefer the rotated refresh token from a prior refresh over the (possibly stale) cookie.
+  const refreshToken = cachedRefreshToken ?? (await getRefreshToken());
   if (!refreshToken) {
     cachedAccessToken = null;
     return null;
@@ -95,14 +100,27 @@ async function doRefresh(): Promise<string | null> {
     });
     if (!response.ok) {
       cachedAccessToken = null;
+      cachedRefreshToken = null;
       return null;
     }
     const data = await response.json();
     const accessToken: string | null = data?.access_token ?? null;
+    // Keep the rotated refresh token so the next refresh doesn't reuse the invalidated one.
+    if (data?.refresh_token) cachedRefreshToken = data.refresh_token;
     cachedAccessToken = accessToken;
     return accessToken;
   } catch (error) {
     console.warn('[ExtensionSessionToken] Token refresh failed:', error);
     return null;
   }
+}
+
+/**
+ * Cheap synchronous-ish presence check: read the access-token cookie WITHOUT triggering
+ * a network refresh. Used to decide gateway-vs-legacy routing at AuthManager build time
+ * so init never blocks on the refresh endpoint (a token that exists-but-expired still
+ * selects the gateway; the per-request getter refreshes it lazily).
+ */
+export async function peekSessionAccessToken(): Promise<string | null> {
+  return cachedAccessToken ?? (await getAccessToken());
 }

--- a/src/extension/background/service-worker.ts
+++ b/src/extension/background/service-worker.ts
@@ -33,7 +33,8 @@ import { AgentConfig } from '../../config/AgentConfig';
 import { STORAGE_KEYS } from '../../config/defaults';
 import { DEFAULT_APPROVAL_CONFIG } from '../../core/approval/types';
 import { TabManager } from '../../core/TabManager';
-import { LLM_API_URL } from '../../config/constants';
+import { LLM_API_URL, GATEWAY_LLM_API_URL, LLM_ROUTING_MODE } from '../../config/constants';
+import { getSessionAccessToken, refreshSessionAccessToken } from '../auth/extensionSessionToken';
 // Track 22: MCP/A2A are gated behind compile-time feature flags. Manager
 // classes and tool-adapter helpers load via dynamic import() inside the
 // feature-gated init blocks, so an OFF build tree-shakes core/mcp +
@@ -467,6 +468,31 @@ async function doInitialize(): Promise<void> {
 }
 
 /**
+ * Build an AuthManager for the extension service worker.
+ *
+ * In account-credits mode (`shouldUseBackend`), route account LLM through the AI Hub
+ * gateway when configured (`LLM_ROUTING_MODE === 'gateway'`), reading the session JWT
+ * from the auth cookie via chrome.cookies (SW-safe) as a per-request bearer token.
+ * When the gateway is not configured, `gatewayLlmBaseUrl` is null and routing falls
+ * back to the legacy ai-assistant /api/llm cookie path. Own-key mode is unaffected.
+ */
+function buildExtensionAuthManager(
+  shouldUseBackend: boolean,
+  backendBaseUrl: string | null,
+): AuthManager {
+  const gatewayLlmBaseUrl =
+    shouldUseBackend && LLM_ROUTING_MODE === 'gateway' && GATEWAY_LLM_API_URL
+      ? GATEWAY_LLM_API_URL
+      : null;
+  return new AuthManager(
+    shouldUseBackend,
+    backendBaseUrl,
+    shouldUseBackend ? getSessionAccessToken : undefined,
+    { gatewayLlmBaseUrl, refreshAccessToken: refreshSessionAccessToken },
+  );
+}
+
+/**
  * Initialize AuthManager from stored config preferences
  * This ensures useOwnApiKey setting is respected on service worker startup
  */
@@ -489,7 +515,7 @@ async function initializeAuthFromConfig(): Promise<void> {
       backendBaseUrl
     });
 
-    const authManager = new AuthManager(shouldUseBackend, backendBaseUrl);
+    const authManager = buildExtensionAuthManager(shouldUseBackend, backendBaseUrl);
     currentAuthManager = authManager;
 
     // Apply auth to all active sessions
@@ -787,7 +813,7 @@ async function registerServiceHandlers(): Promise<void> {
       };
 
       const shouldUseBackend = useOwnApiKey === false;
-      const authManager = new AuthManager(shouldUseBackend, shouldUseBackend ? (backendBaseUrl ?? null) : null);
+      const authManager = buildExtensionAuthManager(shouldUseBackend, shouldUseBackend ? (backendBaseUrl ?? null) : null);
       currentAuthManager = authManager;
 
       // Apply auth to all active sessions

--- a/src/extension/background/service-worker.ts
+++ b/src/extension/background/service-worker.ts
@@ -33,7 +33,8 @@ import { AgentConfig } from '../../config/AgentConfig';
 import { STORAGE_KEYS } from '../../config/defaults';
 import { DEFAULT_APPROVAL_CONFIG } from '../../core/approval/types';
 import { TabManager } from '../../core/TabManager';
-import { LLM_API_URL, GATEWAY_LLM_API_URL, LLM_ROUTING_MODE } from '../../config/constants';
+import { LLM_API_URL } from '../../config/constants';
+import { resolveRuntimeUrls } from '../../config/runtimeUrls';
 import { getSessionAccessToken, refreshSessionAccessToken } from '../auth/extensionSessionToken';
 // Track 22: MCP/A2A are gated behind compile-time feature flags. Manager
 // classes and tool-adapter helpers load via dynamic import() inside the
@@ -471,25 +472,37 @@ async function doInitialize(): Promise<void> {
  * Build an AuthManager for the extension service worker.
  *
  * In account-credits mode (`shouldUseBackend`), route account LLM through the AI Hub
- * gateway when configured (`LLM_ROUTING_MODE === 'gateway'`), reading the session JWT
- * from the auth cookie via chrome.cookies (SW-safe) as a per-request bearer token.
- * When the gateway is not configured, `gatewayLlmBaseUrl` is null and routing falls
- * back to the legacy ai-assistant /api/llm cookie path. Own-key mode is unaffected.
+ * gateway ONLY when routing mode is 'gateway', a gateway URL is configured, AND a
+ * session token is actually obtainable — reading the session JWT from the auth cookie
+ * via chrome.cookies (SW-safe) as a per-request bearer token. Routing config comes
+ * from resolveRuntimeUrls() (the single source of truth also used by memory routing),
+ * not a parallel constants copy, so chat and memory can't diverge.
+ *
+ * Otherwise (own-key mode, gateway unconfigured, or no session token) we fall back to
+ * the prior behavior exactly: a plain AuthManager with no token getter/refresher, so
+ * legacy /api/llm requests authenticate via cookies with the dummy 'backend-routed'
+ * bearer — never sending a real session JWT to the legacy endpoint.
  */
-function buildExtensionAuthManager(
+async function buildExtensionAuthManager(
   shouldUseBackend: boolean,
   backendBaseUrl: string | null,
-): AuthManager {
-  const gatewayLlmBaseUrl =
-    shouldUseBackend && LLM_ROUTING_MODE === 'gateway' && GATEWAY_LLM_API_URL
-      ? GATEWAY_LLM_API_URL
-      : null;
-  return new AuthManager(
-    shouldUseBackend,
-    backendBaseUrl,
-    shouldUseBackend ? getSessionAccessToken : undefined,
-    { gatewayLlmBaseUrl, refreshAccessToken: refreshSessionAccessToken },
-  );
+): Promise<AuthManager> {
+  if (shouldUseBackend) {
+    const urls = resolveRuntimeUrls();
+    if (urls.llmRoutingMode === 'gateway' && urls.gatewayLlmApiUrl) {
+      // Gate on an actual token so createGatewayRoutedClient never throws for a
+      // logged-out user; without one, fall through to the legacy cookie path.
+      const token = await getSessionAccessToken();
+      if (token) {
+        return new AuthManager(shouldUseBackend, backendBaseUrl, getSessionAccessToken, {
+          gatewayLlmBaseUrl: urls.gatewayLlmApiUrl,
+          refreshAccessToken: refreshSessionAccessToken,
+        });
+      }
+    }
+  }
+  // Own-key mode OR legacy fallback: preserve prior cookie-only behavior.
+  return new AuthManager(shouldUseBackend, backendBaseUrl);
 }
 
 /**
@@ -515,7 +528,7 @@ async function initializeAuthFromConfig(): Promise<void> {
       backendBaseUrl
     });
 
-    const authManager = buildExtensionAuthManager(shouldUseBackend, backendBaseUrl);
+    const authManager = await buildExtensionAuthManager(shouldUseBackend, backendBaseUrl);
     currentAuthManager = authManager;
 
     // Apply auth to all active sessions
@@ -813,7 +826,7 @@ async function registerServiceHandlers(): Promise<void> {
       };
 
       const shouldUseBackend = useOwnApiKey === false;
-      const authManager = buildExtensionAuthManager(shouldUseBackend, shouldUseBackend ? (backendBaseUrl ?? null) : null);
+      const authManager = await buildExtensionAuthManager(shouldUseBackend, shouldUseBackend ? (backendBaseUrl ?? null) : null);
       currentAuthManager = authManager;
 
       // Apply auth to all active sessions

--- a/src/extension/background/service-worker.ts
+++ b/src/extension/background/service-worker.ts
@@ -35,7 +35,7 @@ import { DEFAULT_APPROVAL_CONFIG } from '../../core/approval/types';
 import { TabManager } from '../../core/TabManager';
 import { LLM_API_URL } from '../../config/constants';
 import { resolveRuntimeUrls } from '../../config/runtimeUrls';
-import { getSessionAccessToken, refreshSessionAccessToken } from '../auth/extensionSessionToken';
+import { getSessionAccessToken, refreshSessionAccessToken, peekSessionAccessToken } from '../auth/extensionSessionToken';
 // Track 22: MCP/A2A are gated behind compile-time feature flags. Manager
 // classes and tool-adapter helpers load via dynamic import() inside the
 // feature-gated init blocks, so an OFF build tree-shakes core/mcp +
@@ -490,9 +490,11 @@ async function buildExtensionAuthManager(
   if (shouldUseBackend) {
     const urls = resolveRuntimeUrls();
     if (urls.llmRoutingMode === 'gateway' && urls.gatewayLlmApiUrl) {
-      // Gate on an actual token so createGatewayRoutedClient never throws for a
-      // logged-out user; without one, fall through to the legacy cookie path.
-      const token = await getSessionAccessToken();
+      // Gate on token PRESENCE (cheap cookie read, no network refresh at init time) so
+      // createGatewayRoutedClient never throws for a logged-out user; without one, fall
+      // through to the legacy cookie path. An expired-but-present cookie still selects the
+      // gateway — the per-request getter refreshes it lazily.
+      const token = await peekSessionAccessToken();
       if (token) {
         return new AuthManager(shouldUseBackend, backendBaseUrl, getSessionAccessToken, {
           gatewayLlmBaseUrl: urls.gatewayLlmApiUrl,


### PR DESCRIPTION
## Why
Two workx surfaces still sent logged-in **account-credits** LLM traffic to the legacy ai-assistant `/api/llm` path, which writes the old accounting the AI Hub gateway doesn't read — so that usage bypassed the unified credit wallet/metering. This brings both to parity with desktop main-chat, which already routes through the gateway.

## Changes
**Memory extraction (`src/core/Session.ts`)** — desktop/server
- Paid-user "account credits" memory now routes to the gateway `/v1` with the desktop session JWT (Bearer), model slug `openai/gpt-4o-mini`.
- Guarded: only when routing mode is `gateway`, a gateway URL exists, **and** a session token is present; otherwise falls back to legacy `/api/llm`. Own-key/BYOK memory unchanged.

**Chrome extension (`constants.ts`, `service-worker.ts`, new `extensionSessionToken.ts`)**
- The extension had **no** gateway wiring. It authenticates via cookies; `chrome.cookies` is readable in the MV3 service worker (incl. httpOnly), so the SW reads the session JWT and sends it as a Bearer to the gateway `/v1` — same `createGatewayRoutedClient` path desktop uses.
- New SW token helper reads the auth cookie and refreshes via `/auth/desktop/refresh` when expired.
- Legacy `/api/llm` remains the automatic fallback when no gateway URL/token.

## Config required
`VITE_GATEWAY_BASE_URL` (and optional `VITE_LLM_ROUTING_MODE=gateway`) must be set in the extension **build/CI env** (incl. the Chrome Web Store build). The local `src/extension/.env` is gitignored — set the deployed value in CI.

## Verification
- `tsc --noEmit`: 0 errors project-wide.
- Extension build succeeds.
- ⚠️ **Manual e2e still needed** (couldn't run a real browser/gateway here): account-mode chat lands in the gateway (`llm.requests.auth_method='jwt'`); token refresh after expiry; logged-out falls back cleanly; confirm the SW `fetch(credentials:'include')` refresh updates the cookie jar.

## Not included
Deleting the legacy `/api/llm` client + the deprecated ai-assistant code — blocked until both paths are confirmed in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)