### PR TITLE
feat(config): load LLM model list from backend at startup (private builds)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,11 @@
 # VITE_GATEWAY_CATALOG_URL origin + /api/v1/apps, or {gateway}/api/v1/apps.
 # VITE_GATEWAY_CATALOG_API_URL=https://hub.example.com/api/v1/apps
 
+# Public (no-auth) LLM model catalog. When set, the app fetches it at startup and
+# full-replaces the bundled default model list; on any failure it falls back to
+# the bundled default. Leave unset to always use the bundled default.json.
+# VITE_MODEL_CATALOG_URL=https://api.example.com/api/llm/config/catalog/workx
+
 # Vault encryption secret - used to wrap the encryption key at rest
 # MUST be 32+ characters. Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
 # VITE_VAULT_SECRET=your-secret-here-at-least-32-characters-long

--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,7 @@
 # Public (no-auth) LLM model catalog. When set, the app fetches it at startup and
 # full-replaces the bundled default model list; on any failure it falls back to
 # the bundled default. Leave unset to always use the bundled default.json.
-# VITE_MODEL_CATALOG_URL=https://api.example.com/api/llm/config/catalog/workx
+# VITE_MODEL_CATALOG_URL=https://api.example.com/api/v1/workx/models
 
 # Vault encryption secret - used to wrap the encryption key at rest
 # MUST be 32+ characters. Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"

--- a/src/config/AgentConfig.ts
+++ b/src/config/AgentConfig.ts
@@ -21,6 +21,7 @@ import {
   buildRuntimeConfig,
   extractStoredConfig
 } from './defaults';
+import { fetchRemoteCatalog } from './remoteCatalog';
 import { validateConfig, validateModelConfig, validateProviderConfig, detectProviderFromKey } from './validators';
 import {
   applyPolicy,
@@ -87,6 +88,11 @@ export class AgentConfig implements IConfigService {
     try {
       const storedConfig = await this.storage.get();
       console.log('[AgentConfig] initialize - storedConfig from storage:', storedConfig?.selectedModelKey);
+
+      // Private builds: load the model catalog from the backend and cache it so
+      // getDefaultProviders() (used by buildRuntimeConfig below) full-replaces the
+      // bundled default.json. No-op + fallback to default when unconfigured/failed.
+      await fetchRemoteCatalog();
 
       // Build full runtime config by merging stored data with default.json providers/models
       this.currentConfig = buildRuntimeConfig(storedConfig);

--- a/src/config/__tests__/remoteCatalog.test.ts
+++ b/src/config/__tests__/remoteCatalog.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchRemoteCatalog, getRemoteProviders, clearRemoteCatalog } from '../remoteCatalog';
-import { getDefaultProviders } from '../defaults';
+import { getDefaultProviders, buildRuntimeConfig, getDefaultStoredConfig } from '../defaults';
 
 const CATALOG_URL = 'https://api.example.com/api/v1/workx/models';
 
@@ -93,6 +93,27 @@ describe('remoteCatalog', () => {
     mockFetchOnce(() => { throw new Error('boom'); });
     expect(await fetchRemoteCatalog()).toBeNull();
     expect(getRemoteProviders()).toBeNull();
+  });
+
+  it('buildRuntimeConfig falls back to the first available model when the hardcoded default is absent from a replaced catalog', async () => {
+    process.env.WORKX_MODEL_CATALOG_URL = CATALOG_URL;
+    // Remote catalog has only anthropic:remote-opus-x — the hardcoded default
+    // deepseek:deepseek-v4-flash is NOT present.
+    mockFetchOnce(() => jsonResponse(VALID_CATALOG));
+    await fetchRemoteCatalog();
+
+    const stored = { ...getDefaultStoredConfig(), selectedModelKey: 'deepseek:deepseek-v4-flash' };
+    const config = buildRuntimeConfig(stored);
+
+    // Must not keep a key that isn't in the replaced catalog.
+    expect(config.selectedModelKey).toBe('anthropic:remote-opus-x');
+  });
+
+  it('buildRuntimeConfig keeps the default when it IS present in the catalog', async () => {
+    // No remote catalog -> bundled default.json, which contains the default.
+    const stored = { ...getDefaultStoredConfig(), selectedModelKey: 'deepseek:deepseek-v4-flash' };
+    const config = buildRuntimeConfig(stored);
+    expect(config.selectedModelKey).toBe('deepseek:deepseek-v4-flash');
   });
 
   it('dedupes concurrent fetches into a single request', async () => {

--- a/src/config/__tests__/remoteCatalog.test.ts
+++ b/src/config/__tests__/remoteCatalog.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchRemoteCatalog, getRemoteProviders, clearRemoteCatalog } from '../remoteCatalog';
+import { getDefaultProviders } from '../defaults';
+
+const CATALOG_URL = 'https://api.example.com/api/llm/config/catalog/workx';
+
+const VALID_CATALOG = {
+  anthropic: {
+    id: 'anthropic',
+    name: 'Anthropic',
+    apiKey: '',
+    timeout: 30000,
+    models: [{ name: 'Remote Opus', modelKey: 'remote-opus-x' }],
+  },
+};
+
+function mockFetchOnce(impl: () => Promise<Response> | Response) {
+  const fn = vi.fn(impl);
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('remoteCatalog', () => {
+  const original = process.env.WORKX_MODEL_CATALOG_URL;
+
+  beforeEach(() => {
+    clearRemoteCatalog();
+    delete process.env.WORKX_MODEL_CATALOG_URL;
+  });
+
+  afterEach(() => {
+    clearRemoteCatalog();
+    vi.unstubAllGlobals();
+    if (original === undefined) delete process.env.WORKX_MODEL_CATALOG_URL;
+    else process.env.WORKX_MODEL_CATALOG_URL = original;
+  });
+
+  it('is a no-op and makes no request when no catalog URL is configured', async () => {
+    const fetchFn = mockFetchOnce(() => jsonResponse(VALID_CATALOG));
+    const result = await fetchRemoteCatalog();
+    expect(result).toBeNull();
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(getRemoteProviders()).toBeNull();
+  });
+
+  it('caches a valid catalog and makes getDefaultProviders() return it (full replace)', async () => {
+    process.env.WORKX_MODEL_CATALOG_URL = CATALOG_URL;
+    mockFetchOnce(() => jsonResponse(VALID_CATALOG));
+
+    const result = await fetchRemoteCatalog();
+    expect(result).not.toBeNull();
+    expect(getRemoteProviders()).toMatchObject({ anthropic: { id: 'anthropic' } });
+
+    const providers = getDefaultProviders();
+    expect(Object.keys(providers)).toEqual(['anthropic']);
+    expect(providers.anthropic.models[0].modelKey).toBe('remote-opus-x');
+  });
+
+  it('falls back (null cache) on a non-ok response', async () => {
+    process.env.WORKX_MODEL_CATALOG_URL = CATALOG_URL;
+    mockFetchOnce(() => jsonResponse({}, false, 503));
+
+    expect(await fetchRemoteCatalog()).toBeNull();
+    expect(getRemoteProviders()).toBeNull();
+    // bundled default still used
+    expect(getDefaultProviders().anthropic.models.some((m: { modelKey: string }) => m.modelKey === 'remote-opus-x')).toBe(false);
+  });
+
+  it('rejects a malformed payload (no models with modelKey) and keeps the bundled default', async () => {
+    process.env.WORKX_MODEL_CATALOG_URL = CATALOG_URL;
+    mockFetchOnce(() => jsonResponse({ anthropic: { id: 'anthropic', models: [{ name: 'x' }] } }));
+
+    expect(await fetchRemoteCatalog()).toBeNull();
+    expect(getRemoteProviders()).toBeNull();
+  });
+
+  it('rejects a non-object payload', async () => {
+    process.env.WORKX_MODEL_CATALOG_URL = CATALOG_URL;
+    mockFetchOnce(() => jsonResponse([1, 2, 3]));
+    expect(await fetchRemoteCatalog()).toBeNull();
+  });
+
+  it('swallows network errors and falls back', async () => {
+    process.env.WORKX_MODEL_CATALOG_URL = CATALOG_URL;
+    mockFetchOnce(() => { throw new Error('boom'); });
+    expect(await fetchRemoteCatalog()).toBeNull();
+    expect(getRemoteProviders()).toBeNull();
+  });
+
+  it('dedupes concurrent fetches into a single request', async () => {
+    process.env.WORKX_MODEL_CATALOG_URL = CATALOG_URL;
+    const fetchFn = mockFetchOnce(async () => jsonResponse(VALID_CATALOG));
+
+    const [a, b] = await Promise.all([fetchRemoteCatalog(), fetchRemoteCatalog()]);
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/config/__tests__/remoteCatalog.test.ts
+++ b/src/config/__tests__/remoteCatalog.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchRemoteCatalog, getRemoteProviders, clearRemoteCatalog } from '../remoteCatalog';
 import { getDefaultProviders } from '../defaults';
 
-const CATALOG_URL = 'https://api.example.com/api/llm/config/catalog/workx';
+const CATALOG_URL = 'https://api.example.com/api/v1/workx/models';
 
 const VALID_CATALOG = {
   anthropic: {

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -7,6 +7,7 @@ import { DEFAULT_APPROVAL_CONFIG } from '../core/approval/types';
 import { DEFAULT_MODE } from '../prompts/PromptComposer';
 import defaultProviders from '../core/models/providers/default.json';
 import { applyPolicy, getActivePolicySync } from '../core/config/policy';
+import { getRemoteProviders } from './remoteCatalog';
 
 export const DEFAULT_USER_PREFERENCES: IUserPreferences = {
   autoSync: true,
@@ -353,6 +354,13 @@ export function mergeWithDefaults(partial: Partial<IAgentConfig>): IAgentConfig 
  * Loaded from JSON configuration file
  */
 export function getDefaultProviders(): Record<string, IProviderConfig> {
+  // Private builds may override the bundled catalog with one fetched from the
+  // backend at startup (see remoteCatalog + AgentConfig.initialize). When present
+  // it full-replaces default.json; otherwise we fall back to the bundled copy.
+  const remote = getRemoteProviders();
+  if (remote) {
+    return remote;
+  }
   // Return a deep copy to avoid mutation of the imported JSON
   return JSON.parse(JSON.stringify(defaultProviders));
 }

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -427,24 +427,36 @@ export function buildRuntimeConfig(stored: IStoredConfig | null): IAgentConfig {
     }
   }
 
+  // True when `key` is a "providerId:modelKey" that exists in the current
+  // providers. Also rejects malformed keys (no colon).
+  const modelKeyExists = (key: string): boolean => {
+    const colonIndex = key.indexOf(':');
+    if (colonIndex <= 0) return false;
+    const providerId = key.slice(0, colonIndex);
+    const modelKey = key.slice(colonIndex + 1);
+    return !!providers[providerId]?.models?.some((m: { modelKey: string }) => m.modelKey === modelKey);
+  };
+
   // Validate stored selectedModelKey exists in providers, fallback to default if not
   let selectedModelKey = stored.selectedModelKey || '';
-  if (selectedModelKey) {
-    const colonIndex = selectedModelKey.indexOf(':');
-    if (colonIndex > 0) {
-      const providerId = selectedModelKey.slice(0, colonIndex);
-      const modelKey = selectedModelKey.slice(colonIndex + 1);
-      const provider = providers[providerId];
-      const modelExists = provider?.models?.some((m: { modelKey: string }) => m.modelKey === modelKey);
-      if (!modelExists) {
-        console.warn(`[buildRuntimeConfig] Stored selectedModelKey "${selectedModelKey}" not found, falling back to default`);
-        selectedModelKey = defaults.selectedModelKey;
+  if (selectedModelKey && !modelKeyExists(selectedModelKey)) {
+    console.warn(`[buildRuntimeConfig] Stored selectedModelKey "${selectedModelKey}" not found, falling back to default`);
+    selectedModelKey = defaults.selectedModelKey;
+  }
+  // The hardcoded default can itself be absent from a backend-replaced catalog
+  // (full-replace via remoteCatalog). Guard so we never hand downstream a key
+  // that isn't in the catalog: use the first available provider model instead.
+  if (selectedModelKey && !modelKeyExists(selectedModelKey)) {
+    let fallback = '';
+    for (const [providerId, provider] of Object.entries(providers)) {
+      const firstModel = provider?.models?.[0]?.modelKey;
+      if (firstModel) {
+        fallback = `${providerId}:${firstModel}`;
+        break;
       }
-    } else {
-      // Invalid format (no colon), use default
-      console.warn(`[buildRuntimeConfig] Invalid selectedModelKey format "${selectedModelKey}", falling back to default`);
-      selectedModelKey = defaults.selectedModelKey;
     }
+    console.warn(`[buildRuntimeConfig] Fallback selectedModelKey "${selectedModelKey}" not in catalog; using first available "${fallback || '(none)'}"`);
+    selectedModelKey = fallback;
   }
 
   const merged: IAgentConfig = {

--- a/src/config/remoteCatalog.ts
+++ b/src/config/remoteCatalog.ts
@@ -1,0 +1,131 @@
+/**
+ * Remote LLM model catalog (private WorkX builds).
+ *
+ * When `modelCatalogUrl` is configured (VITE_/WORKX_MODEL_CATALOG_URL), the app
+ * fetches a provider-keyed catalog from the backend at startup and uses it to
+ * full-replace the bundled `default.json` model list. The endpoint is public
+ * (no auth) and returns the same JSON shape as
+ * `src/core/models/providers/default.json`.
+ *
+ * Fallback: if the URL is unset, the request fails/times out, or the payload is
+ * malformed, the cache stays null and `getDefaultProviders()` keeps serving the
+ * bundled default. This module never throws to its callers.
+ */
+
+import type { IProviderConfig } from './types';
+import { resolveRuntimeUrls } from './runtimeUrls';
+
+/** Provider-keyed catalog, identical in shape to default.json. */
+export type RemoteProviders = Record<string, IProviderConfig>;
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+// Cached override, set once a successful fetch validates. Read synchronously by
+// getDefaultProviders() so both buildRuntimeConfig() and reload() pick it up.
+let cachedRemoteProviders: RemoteProviders | null = null;
+// Guards against concurrent/duplicate fetches (multiple getInstance() callers).
+let inFlight: Promise<RemoteProviders | null> | null = null;
+
+/**
+ * The validated remote catalog, or null when none has been loaded. Returns a
+ * deep copy so callers cannot mutate the cache.
+ */
+export function getRemoteProviders(): RemoteProviders | null {
+  return cachedRemoteProviders
+    ? (JSON.parse(JSON.stringify(cachedRemoteProviders)) as RemoteProviders)
+    : null;
+}
+
+/** Test/reset hook. */
+export function clearRemoteCatalog(): void {
+  cachedRemoteProviders = null;
+  inFlight = null;
+}
+
+/**
+ * Validate that a parsed payload is a provider-keyed catalog with at least one
+ * provider carrying a non-empty `models` array of entries with a `modelKey`.
+ * Rejecting here means we keep the bundled default rather than wipe the list.
+ */
+function isValidCatalog(payload: unknown): payload is RemoteProviders {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return false;
+  }
+  const providers = Object.values(payload as Record<string, unknown>);
+  if (providers.length === 0) {
+    return false;
+  }
+  let sawModel = false;
+  for (const provider of providers) {
+    if (!provider || typeof provider !== 'object') {
+      return false;
+    }
+    const models = (provider as { models?: unknown }).models;
+    if (models === undefined) {
+      continue;
+    }
+    if (!Array.isArray(models)) {
+      return false;
+    }
+    for (const model of models) {
+      if (!model || typeof model !== 'object' || typeof (model as { modelKey?: unknown }).modelKey !== 'string') {
+        return false;
+      }
+      sawModel = true;
+    }
+  }
+  return sawModel;
+}
+
+/**
+ * Fetch and cache the remote catalog. No-op (returns null) when no catalog URL
+ * is configured. Swallows all network/parse/validation errors and leaves the
+ * cache untouched so startup always proceeds on the bundled default.
+ */
+export async function fetchRemoteCatalog(
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<RemoteProviders | null> {
+  if (cachedRemoteProviders) {
+    return cachedRemoteProviders;
+  }
+  if (inFlight) {
+    return inFlight;
+  }
+
+  const url = resolveRuntimeUrls().modelCatalogUrl;
+  if (!url) {
+    return null;
+  }
+
+  inFlight = (async () => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(url, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        console.warn(`[remoteCatalog] catalog fetch failed (${res.status}); using bundled default.json`);
+        return null;
+      }
+      const payload = await res.json();
+      if (!isValidCatalog(payload)) {
+        console.warn('[remoteCatalog] catalog payload invalid; using bundled default.json');
+        return null;
+      }
+      cachedRemoteProviders = payload;
+      console.log(`[remoteCatalog] loaded ${Object.keys(payload).length} providers from ${url}`);
+      return cachedRemoteProviders;
+    } catch (error) {
+      console.warn('[remoteCatalog] catalog fetch errored; using bundled default.json:', error);
+      return null;
+    } finally {
+      clearTimeout(timer);
+      inFlight = null;
+    }
+  })();
+
+  return inFlight;
+}

--- a/src/config/runtimeUrls.ts
+++ b/src/config/runtimeUrls.ts
@@ -11,6 +11,12 @@ export interface RuntimeUrlConfig {
   gatewayMcpUrl: string | null;
   gatewayCatalogUrl: string | null;
   gatewayCatalogApiBaseUrl: string | null;
+  /**
+   * Public LLM model catalog endpoint (private WorkX builds). When set, the app
+   * fetches it at startup and full-replaces the bundled default.json model list.
+   * Opt-in: unset means the bundled default is used and no request is made.
+   */
+  modelCatalogUrl: string | null;
   gatewayMcpName: string;
   gatewayMcpAuthMode: 'none' | 'api-key' | 'session-jwt';
   gatewayMcpApiKey: string | null;
@@ -27,6 +33,7 @@ export interface RuntimeUrlConfig {
     gatewayMcpUrl: RuntimeUrlSource;
     gatewayCatalogUrl: RuntimeUrlSource;
     gatewayCatalogApiBaseUrl: RuntimeUrlSource;
+    modelCatalogUrl: RuntimeUrlSource;
     gatewayMcpName: RuntimeUrlSource;
     gatewayMcpAuthMode: RuntimeUrlSource;
     gatewayMcpApiKey: RuntimeUrlSource;
@@ -131,6 +138,13 @@ export function resolveRuntimeUrls(): RuntimeUrlConfig {
     gatewayCatalogApiFromEnv ??
     (gatewayCatalogUrl ? joinUrl(originOf(gatewayCatalogUrl) ?? gatewayCatalogUrl, 'api/v1/apps') : null) ??
     (gatewayBaseUrl ? joinUrl(gatewayBaseUrl, 'api/v1/apps') : null);
+  // Opt-in public model catalog. Only fetched when explicitly configured, so
+  // public/OSS builds keep using the bundled default.json.
+  const modelCatalogUrl = firstNonEmpty(
+    env.WORKX_MODEL_CATALOG_URL,
+    env.VITE_MODEL_CATALOG_URL,
+    vite.VITE_MODEL_CATALOG_URL,
+  ) ?? null;
   const gatewayMcpNameFromEnv = firstNonEmpty(
     env.WORKX_GATEWAY_MCP_NAME,
     env.VITE_GATEWAY_MCP_NAME,
@@ -174,6 +188,7 @@ export function resolveRuntimeUrls(): RuntimeUrlConfig {
     gatewayMcpUrl,
     gatewayCatalogUrl,
     gatewayCatalogApiBaseUrl,
+    modelCatalogUrl,
     gatewayMcpName: gatewayMcpNameFromEnv ?? 'gateway',
     gatewayMcpAuthMode,
     gatewayMcpApiKey,
@@ -190,6 +205,7 @@ export function resolveRuntimeUrls(): RuntimeUrlConfig {
       gatewayMcpUrl: gatewayMcpFromEnv || gatewayBaseUrl ? 'env' : 'default',
       gatewayCatalogUrl: gatewayCatalogUrl ? 'env' : 'default',
       gatewayCatalogApiBaseUrl: gatewayCatalogApiFromEnv ? 'env' : 'default',
+      modelCatalogUrl: modelCatalogUrl ? 'env' : 'default',
       gatewayMcpName: gatewayMcpNameFromEnv ? 'env' : 'default',
       gatewayMcpAuthMode: requestedMcpAuthMode ? 'env' : 'default',
       gatewayMcpApiKey: gatewayMcpApiKey ? 'env' : 'default',

--- a/src/desktop/.env.production.example
+++ b/src/desktop/.env.production.example
@@ -24,6 +24,9 @@
 VITE_AUTH_COOKIE_DOMAIN=.airepublic.com
 VITE_AUTH_BASE_URL=https://home.airepublic.com
 VITE_BACKEND_API_BASE_URL=https://api.airepublic.com
+# Public model catalog overriding the bundled default.json at startup.
+VITE_MODEL_CATALOG_URL=https://api.airepublic.com/api/llm/config/catalog/workx
+WORKX_MODEL_CATALOG_URL=https://api.airepublic.com/api/llm/config/catalog/workx
 VITE_AUTH_ACCESS_COOKIE_NAME=ai_access
 VITE_AUTH_REFRESH_COOKIE_NAME=ai_refresh
 VITE_AUTH_CSRF_COOKIE_NAME=ai_csrf

--- a/src/desktop/.env.production.example
+++ b/src/desktop/.env.production.example
@@ -25,8 +25,8 @@ VITE_AUTH_COOKIE_DOMAIN=.airepublic.com
 VITE_AUTH_BASE_URL=https://home.airepublic.com
 VITE_BACKEND_API_BASE_URL=https://api.airepublic.com
 # Public model catalog overriding the bundled default.json at startup.
-VITE_MODEL_CATALOG_URL=https://api.airepublic.com/api/llm/config/catalog/workx
-WORKX_MODEL_CATALOG_URL=https://api.airepublic.com/api/llm/config/catalog/workx
+VITE_MODEL_CATALOG_URL=https://api.airepublic.com/api/v1/workx/models
+WORKX_MODEL_CATALOG_URL=https://api.airepublic.com/api/v1/workx/models
 VITE_AUTH_ACCESS_COOKIE_NAME=ai_access
 VITE_AUTH_REFRESH_COOKIE_NAME=ai_refresh
 VITE_AUTH_CSRF_COOKIE_NAME=ai_csrf

--- a/src/webfront/lib/constants.ts
+++ b/src/webfront/lib/constants.ts
@@ -36,6 +36,8 @@ export const GATEWAY_MCP_URL = runtimeUrls.gatewayMcpUrl ?? '';
 export const GATEWAY_CATALOG_URL = runtimeUrls.gatewayCatalogUrl ?? '';
 /** Hub Apps catalog JSON API root, e.g. `https://hub.example.com/api/v1/apps`. */
 export const GATEWAY_CATALOG_API_BASE_URL = runtimeUrls.gatewayCatalogApiBaseUrl ?? '';
+/** Public LLM model catalog endpoint (private builds); '' when not configured. */
+export const MODEL_CATALOG_URL = runtimeUrls.modelCatalogUrl ?? '';
 export const LLM_ROUTING_MODE = runtimeUrls.llmRoutingMode;
 
 export function buildHostedAuthUrl(path: string | null): string | null {


### PR DESCRIPTION
## What

Private WorkX builds load their LLM model list from the backend at startup, overriding the bundled `src/core/models/providers/default.json`. The list is controlled centrally instead of shipped in the app.

**Pairs with** ai-assistant PR #388, which serves the list at `GET /api/v1/workx/models` (general backend — LLM *inference* runs on the Hub gateway/OpenHub; this endpoint is general-backend support serving WorkX's adopted model list). That endpoint must be deployed for this to take effect; until then WorkX falls back to the bundled default.

> Re-opens the closed #309 (its base branch `feat/workx-gateway-migration` was deleted). This branch is cut fresh from `main` and contains **only** the model-catalog change — the gateway-migration commits are not included.

## How

- **Opt-in env** `VITE_MODEL_CATALOG_URL` / `WORKX_MODEL_CATALOG_URL` (`runtimeUrls.ts`, exposed via `constants.ts`). Unset ⇒ bundled default, no request. Public/OSS builds untouched.
- **`src/config/remoteCatalog.ts`** (new): fetch with a 5s timeout, validate the provider-keyed shape, cache. Any failure (unset URL, timeout, non-2xx, malformed) falls back to `default.json` and never throws.
- **`getDefaultProviders()`** prefers the cached remote catalog (full replace), else `default.json`.
- **`AgentConfig.initialize()`** awaits `fetchRemoteCatalog()` before `buildRuntimeConfig()` — the single funnel used by extension/desktop/server. BYOK custom providers and stored API keys are still overlaid on top.

## Semantics

- **Full replace** on success; **bundled default** on any failure.
- **No auth** (public endpoint), so it works before login resolves at startup.

## Test plan

- `tsc --noEmit`: 0 errors.
- New `src/config/__tests__/remoteCatalog.test.ts` (7 cases: no-op / success / non-ok / malformed / non-object / network-error / concurrent-dedupe) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)