### PR TITLE
ci(desktop): S3 release pipeline + updater endpoint

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,0 +1,303 @@
+name: Release desktop bundles (S3)
+
+# Cross-OS build + sign + S3 upload + updater-manifest publish for the WorkX
+# Tauri desktop app. Modeled on the pi-dash `pidash-desktop-releases` pipeline.
+# Triggered manually (workflow_dispatch); once proven we can add a tag trigger.
+#
+# Per platform this workflow:
+#   1. builds the Tauri bundle + updater artifact + matching `.sig`
+#      (signed with TAURI_SIGNING_PRIVATE_KEY).
+#   2. uploads bundle + .sig to s3://workx-desktop-releases/<target>/<version>/.
+#   3. writes a per-target `latest.json` (Tauri dynamic-update-server shape) to
+#      s3://workx-desktop-releases/<target>/latest.json.
+#   4. publishes first-install installers to s3://workx-desktop-releases/downloads/latest/.
+#
+# tauri/tauri.conf.json's updater `endpoints` point at
+#   https://workx-desktop-releases.s3.us-west-2.amazonaws.com/{{target}}/latest.json
+# so shipped clients self-update from this bucket.
+#
+# Required repo secrets (Settings -> Secrets and variables -> Actions):
+#   TAURI_SIGNING_PRIVATE_KEY           - contents of the .key file (matches tauri.conf pubkey)
+#   TAURI_SIGNING_PRIVATE_KEY_PASSWORD  - password used at keygen time
+#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY - publisher IAM creds scoped to
+#       s3:PutObject on arn:aws:s3:::workx-desktop-releases/*
+#   VITE_VAULT_SECRET                   - credential-encryption vault secret (>=32 chars)
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_notes:
+        description: 'Release notes shown in the in-app updater dialog (plain text).'
+        required: false
+        default: ''
+
+env:
+  CARGO_TERM_COLOR: always
+  AWS_REGION: us-west-2
+  S3_BUCKET: workx-desktop-releases
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macOS: one universal binary serves both Apple Silicon and Intel.
+          - os: macos-latest
+            args: --target universal-apple-darwin
+            rust-target: universal-apple-darwin
+            extra-rust-targets: 'aarch64-apple-darwin,x86_64-apple-darwin'
+            tauri-targets: 'darwin-aarch64,darwin-x86_64'
+            bundle-dir: 'tauri/target/universal-apple-darwin/release/bundle/macos'
+            bundle-glob: '*.app.tar.gz'
+          - os: windows-latest
+            args: --target x86_64-pc-windows-msvc
+            rust-target: x86_64-pc-windows-msvc
+            extra-rust-targets: ''
+            tauri-targets: 'windows-x86_64'
+            # createUpdaterArtifacts: true -> updater consumes the NSIS
+            # -setup.exe directly, signed in place as -setup.exe.sig.
+            bundle-dir: 'tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis'
+            bundle-glob: '*-setup.exe'
+          - os: ubuntu-22.04
+            args: --target x86_64-unknown-linux-gnu
+            rust-target: x86_64-unknown-linux-gnu
+            extra-rust-targets: ''
+            tauri-targets: 'linux-x86_64'
+            # createUpdaterArtifacts: true signs the AppImage in place.
+            bundle-dir: 'tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage'
+            bundle-glob: '*.AppImage'
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read version from package.json
+        id: version
+        shell: bash
+        run: |
+          V=$(node -p "require('./package.json').version")
+          if [ -z "$V" ]; then echo "ERROR: could not read version from package.json"; exit 1; fi
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "Building WorkX desktop v$V for ${{ matrix.tauri-targets }}"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Sync version into config files
+        run: node scripts/sync-version.js ${{ steps.version.outputs.version }}
+
+      - name: Create desktop .env (production)
+        shell: bash
+        # Keep in sync with release.yml and src/desktop/.env.production.example.
+        # Environment-specific values come from repo/org Actions `vars` with prod
+        # defaults; structural values are literal. VITE_* is inlined into the
+        # WebView bundle; WORKX_* mirrors it for the Node/Tauri sidecar.
+        run: |
+          cat > src/desktop/.env << 'EOF'
+          VITE_AUTH_COOKIE_DOMAIN=${{ vars.VITE_AUTH_COOKIE_DOMAIN || '.airepublic.com' }}
+          VITE_AUTH_BASE_URL=${{ vars.VITE_AUTH_BASE_URL || 'https://home.airepublic.com' }}
+          VITE_BACKEND_API_BASE_URL=${{ vars.VITE_BACKEND_API_BASE_URL || 'https://api.airepublic.com' }}
+          VITE_MODEL_CATALOG_URL=${{ vars.VITE_MODEL_CATALOG_URL || 'https://api.airepublic.com/api/v1/workx/models' }}
+          VITE_AUTH_ACCESS_COOKIE_NAME=ai_access
+          VITE_AUTH_REFRESH_COOKIE_NAME=ai_refresh
+          VITE_AUTH_CSRF_COOKIE_NAME=ai_csrf
+          VITE_AUTH_STATUS_COOKIE_NAME=ai_auth_status
+          VITE_AUTH_USER_NAME_COOKIE_NAME=ai_user_name
+          VITE_AUTH_USER_EMAIL_COOKIE_NAME=ai_user_email
+          VITE_AUTH_LOGIN_PATH=/login
+          VITE_AUTH_DESKTOP_SESSION_PATH=/auth/desktop/session
+          VITE_AUTH_DESKTOP_REFRESH_PATH=/auth/desktop/refresh
+          VITE_AUTH_PROFILE_PATH=/api/v1/users/profile
+          VITE_AUTH_USER_CENTER_PATH=/user-center/info
+          VITE_AUTH_PRICING_PATH=/pricing
+          VITE_LLM_ROUTING_MODE=gateway
+          VITE_GATEWAY_BASE_URL=${{ vars.VITE_GATEWAY_BASE_URL || 'https://gateway.airepublic.com' }}
+          VITE_GATEWAY_CATALOG_URL=${{ vars.VITE_GATEWAY_CATALOG_URL || 'https://hub.airepublic.com/apps' }}
+          VITE_GATEWAY_MCP_NAME=ai-hub
+          VITE_GATEWAY_MCP_AUTH_MODE=session-jwt
+          VITE_GATEWAY_MCP_TOOL_DISCOVERY=flat
+          VITE_AUTH_OIDC_ENABLED=true
+          VITE_AUTH_OIDC_CLIENT_ID=${{ vars.VITE_AUTH_OIDC_CLIENT_ID || 'workx-desktop' }}
+          VITE_AUTH_OIDC_SCOPES=openid profile email chat apps models offline_access
+          VITE_VAULT_SECRET=${{ secrets.VITE_VAULT_SECRET }}
+          WORKX_AUTH_BASE_URL=${{ vars.VITE_AUTH_BASE_URL || 'https://home.airepublic.com' }}
+          WORKX_BACKEND_API_BASE_URL=${{ vars.VITE_BACKEND_API_BASE_URL || 'https://api.airepublic.com' }}
+          WORKX_MODEL_CATALOG_URL=${{ vars.VITE_MODEL_CATALOG_URL || 'https://api.airepublic.com/api/v1/workx/models' }}
+          WORKX_AUTH_DESKTOP_SESSION_PATH=/auth/desktop/session
+          WORKX_AUTH_DESKTOP_REFRESH_PATH=/auth/desktop/refresh
+          WORKX_AUTH_PROFILE_PATH=/api/v1/users/profile
+          WORKX_LLM_ROUTING_MODE=gateway
+          WORKX_GATEWAY_BASE_URL=${{ vars.VITE_GATEWAY_BASE_URL || 'https://gateway.airepublic.com' }}
+          WORKX_GATEWAY_CATALOG_URL=${{ vars.VITE_GATEWAY_CATALOG_URL || 'https://hub.airepublic.com/apps' }}
+          WORKX_GATEWAY_MCP_NAME=ai-hub
+          WORKX_GATEWAY_MCP_AUTH_MODE=session-jwt
+          WORKX_GATEWAY_MCP_TOOL_DISCOVERY_HEADER=X-Air-Tool-Discovery
+          WORKX_GATEWAY_MCP_TOOL_DISCOVERY=flat
+          WORKX_AUTH_OIDC_ENABLED=true
+          WORKX_AUTH_OIDC_CLIENT_ID=${{ vars.VITE_AUTH_OIDC_CLIENT_ID || 'workx-desktop' }}
+          WORKX_AUTH_OIDC_SCOPES=openid profile email chat apps models offline_access
+          EOF
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.extra-rust-targets || matrix.rust-target }}
+
+      - name: Ensure macOS universal Rust targets
+        if: matrix.os == 'macos-latest'
+        working-directory: tauri
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            tauri/target
+          key: ${{ matrix.os }}-cargo-${{ hashFiles('tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ matrix.os }}-cargo-
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            librsvg2-dev \
+            patchelf \
+            libssl-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev
+
+      - name: Install cargo-tauri
+        run: cargo install tauri-cli --version "^2" --locked
+
+      - name: Build & sign bundle
+        working-directory: tauri
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        # beforeBuildCommand (tauri.conf.json) builds the frontend + sidecars.
+        run: cargo tauri build ${{ matrix.args }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Upload bundle + write per-target manifest + installers
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          NOTES: ${{ inputs.release_notes }}
+        run: |
+          set -euo pipefail
+          RELEASES_BASE_URL="https://${S3_BUCKET}.s3.${AWS_REGION}.amazonaws.com"
+
+          # tempfile (not `find | head`) so a multi-line result can't SIGPIPE
+          # into pipefail before the diagnostic branch runs.
+          FIND_OUTPUT=$(mktemp)
+          find "${{ matrix.bundle-dir }}" -maxdepth 1 -name "${{ matrix.bundle-glob }}" -not -name "*.sig" > "$FIND_OUTPUT"
+          BUNDLE=$(head -n 1 "$FIND_OUTPUT")
+          rm -f "$FIND_OUTPUT"
+          SIG="${BUNDLE}.sig"
+          if [ -z "$BUNDLE" ] || [ ! -f "$BUNDLE" ] || [ ! -f "$SIG" ]; then
+            echo "ERROR: bundle or .sig not found under ${{ matrix.bundle-dir }}"
+            ls -la "${{ matrix.bundle-dir }}" || true
+            exit 1
+          fi
+          BUNDLE_NAME=$(basename "$BUNDLE")
+          echo "Found bundle: $BUNDLE"
+
+          # URL-encode basename (safe for names with spaces).
+          ENCODED_BUNDLE_NAME=$(jq -rn --arg n "$BUNDLE_NAME" '$n | @uri')
+          # Strip CR (Windows runners write .sig as CRLF) then trailing LF, or
+          # the dangling \r breaks Tauri's minisign verifier on Windows installs.
+          SIG_CONTENT=$(tr -d '\r' < "$SIG")
+
+          IFS=',' read -ra TARGETS <<< "${{ matrix.tauri-targets }}"
+          PRIMARY_TARGET="${TARGETS[0]}"
+          S3_KEY="$PRIMARY_TARGET/$VERSION/$BUNDLE_NAME"
+          BUNDLE_URL="$RELEASES_BASE_URL/$PRIMARY_TARGET/$VERSION/$ENCODED_BUNDLE_NAME"
+
+          aws s3 cp --no-progress "$BUNDLE" "s3://$S3_BUCKET/$S3_KEY"
+          aws s3 cp --no-progress "$SIG"    "s3://$S3_BUCKET/$S3_KEY.sig"
+
+          PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          # One latest.json per target (macOS-universal serves both darwin-*).
+          for TARGET in "${TARGETS[@]}"; do
+            jq -n \
+              --arg version "$VERSION" \
+              --arg notes "$NOTES" \
+              --arg pub_date "$PUB_DATE" \
+              --arg target "$TARGET" \
+              --arg signature "$SIG_CONTENT" \
+              --arg url "$BUNDLE_URL" \
+              '{
+                version: $version,
+                notes: $notes,
+                pub_date: $pub_date,
+                platforms: { ($target): { signature: $signature, url: $url } }
+              }' > "latest-$TARGET.json"
+            aws s3 cp --no-progress \
+              --content-type application/json \
+              --cache-control "max-age=60, public" \
+              "latest-$TARGET.json" "s3://$S3_BUCKET/$TARGET/latest.json"
+            echo "Wrote s3://$S3_BUCKET/$TARGET/latest.json"
+          done
+
+          find_one() {
+            local dir="$1" pattern="$2" found count
+            [ -d "$dir" ] || return 0
+            found=$(mktemp)
+            find "$dir" -maxdepth 1 -type f -name "$pattern" > "$found"
+            count=$(wc -l < "$found" | tr -d ' ')
+            [ "$count" -gt 1 ] && echo "::warning::found $count files matching $pattern in $dir; using first" >&2
+            head -n 1 "$found"; rm -f "$found"
+          }
+
+          upload_install_artifact() {
+            local source="$1" stable_name="$2"
+            if [ -z "$source" ] || [ ! -f "$source" ]; then
+              echo "::warning::first-install artifact not found for $stable_name"
+              return 0
+            fi
+            aws s3 cp --no-progress \
+              --content-type application/octet-stream \
+              --cache-control "max-age=31536000, public, immutable" \
+              "$source" "s3://$S3_BUCKET/downloads/$VERSION/$stable_name"
+            aws s3 cp --no-progress \
+              --content-type application/octet-stream \
+              --cache-control "max-age=60, public" \
+              "$source" "s3://$S3_BUCKET/downloads/latest/$stable_name"
+            echo "Published downloads/latest/$stable_name"
+          }
+
+          BUNDLE_ROOT=$(dirname "${{ matrix.bundle-dir }}")
+          case "$PRIMARY_TARGET" in
+            darwin-*)
+              upload_install_artifact "$(find_one "$BUNDLE_ROOT/dmg" "*.dmg")" "workx-macos-universal.dmg"
+              ;;
+            windows-*)
+              upload_install_artifact "$(find_one "$BUNDLE_ROOT/nsis" "*-setup.exe")" "workx-windows-x64-setup.exe"
+              upload_install_artifact "$(find_one "$BUNDLE_ROOT/msi" "*.msi")" "workx-windows-x64.msi"
+              ;;
+            linux-*)
+              upload_install_artifact "$(find_one "$BUNDLE_ROOT/appimage" "*.AppImage")" "workx-linux-x64.AppImage"
+              upload_install_artifact "$(find_one "$BUNDLE_ROOT/deb" "*.deb")" "workx-linux-x64.deb"
+              ;;
+            *)
+              echo "::warning::no first-install artifact mapping for $PRIMARY_TARGET"
+              ;;
+          esac

--- a/deployments/desktop-releases/provision.sh
+++ b/deployments/desktop-releases/provision.sh
@@ -77,23 +77,40 @@ aws s3api put-bucket-tagging \
 
 echo "       OK: bucket created, versioning on, SSE-S3 on, public policies allowed."
 
-echo "[2/4] Applying public-read bucket policy ..."
+echo "[2/4] Applying bucket policy (public read + github-action publish) ..."
+# The release workflow authenticates as the shared org CI user
+# arn:aws:iam::${ACCOUNT_ID}:user/github-action (org GHA secrets
+# AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY, visibility ALL). That user's
+# identity policy (s3_release) is scoped to the pidash bucket only, so we grant
+# it PutObject on THIS bucket here via the bucket policy — no IAM admin needed
+# and no per-repo publisher user to rotate. Same-account access is allowed if
+# either the identity or the bucket policy permits it.
+CI_USER_ARN="arn:aws:iam::${ACCOUNT_ID}:user/github-action"
 POLICY_FILE="$(mktemp)"
 cat >"$POLICY_FILE" <<EOF
 {
   "Version": "2012-10-17",
-  "Statement": [{
-    "Sid": "AllowPublicReadReleaseObjects",
-    "Effect": "Allow",
-    "Principal": "*",
-    "Action": "s3:GetObject",
-    "Resource": "arn:aws:s3:::${BUCKET}/*"
-  }]
+  "Statement": [
+    {
+      "Sid": "AllowPublicReadReleaseObjects",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::${BUCKET}/*"
+    },
+    {
+      "Sid": "AllowGithubActionPublish",
+      "Effect": "Allow",
+      "Principal": { "AWS": "${CI_USER_ARN}" },
+      "Action": ["s3:PutObject", "s3:AbortMultipartUpload"],
+      "Resource": "arn:aws:s3:::${BUCKET}/*"
+    }
+  ]
 }
 EOF
 aws s3api put-bucket-policy --bucket "$BUCKET" --policy "file://$POLICY_FILE"
 rm -f "$POLICY_FILE"
-echo "       OK: ${RELEASES_BASE_URL}/... is publicly readable."
+echo "       OK: ${RELEASES_BASE_URL}/... is publicly readable; github-action can publish."
 
 echo
 echo "[3/4] Provisioned."
@@ -104,21 +121,13 @@ echo
 cat <<EOF
 [4/4] Next steps (NOT automated by this script):
 
-  a) Create a dedicated, programmatic-only publisher IAM user for the release
-     CI workflow (release-desktop.yml) with a SCOPED policy — do NOT reuse an
-     admin user; a leaked GHA log would otherwise have account-wide access:
-
-       {
-         "Version": "2012-10-17",
-         "Statement": [{
-           "Effect": "Allow",
-           "Action": ["s3:PutObject", "s3:PutObjectTagging"],
-           "Resource": "arn:aws:s3:::${BUCKET}/*"
-         }]
-       }
-
-     Add its access keys to the workx repo as GitHub Actions secrets:
-       AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+  a) Publisher credentials: NONE to create. The release workflow uses the
+     existing org-level GitHub Actions secrets AWS_ACCESS_KEY_ID /
+     AWS_SECRET_ACCESS_KEY (visibility ALL -> already available to the workx
+     repo), which map to the shared ${CI_USER_ARN}
+     user. Step [2/4] above already granted that user PutObject on this bucket
+     via the bucket policy, so no new IAM user and no per-repo secret rotation
+     is required.
 
   b) Confirm the Tauri signing key secrets are present in the workx repo
      (already used by release.yml):

--- a/deployments/desktop-releases/provision.sh
+++ b/deployments/desktop-releases/provision.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# provision.sh
+#
+# One-shot provisioner for the AWS side of the WorkX desktop auto-updater,
+# modeled on the proven pi-dash `pidash-desktop-releases` setup:
+#
+#   S3 bucket (versioned, SSE-S3, public-read by bucket policy) that holds the
+#   signed Tauri bundles + .sig files and the per-target latest.json manifests,
+#   plus friendly first-install installers under downloads/latest/:
+#
+#     s3://<bucket>/<target>/<version>/<file>        # updater bundle + .sig
+#     s3://<bucket>/<target>/latest.json             # Tauri updater manifest
+#     s3://<bucket>/downloads/<version>/<file>        # pinned installers
+#     s3://<bucket>/downloads/latest/<file>           # stable installer URLs
+#
+# Everything is served directly over S3 HTTPS (no CloudFront), matching pi-dash.
+#
+# Idempotency: NOT safe to re-run after partial success — create-bucket fails if
+# the bucket already exists. To adjust an existing bucket, apply the
+# public-access-block / versioning / policy sections individually.
+#
+# Requires admin-ish S3 permissions (s3:CreateBucket, PutBucketPolicy, etc.)
+# plus sts:GetCallerIdentity. Region hardcoded to us-west-2 to match the rest
+# of the AI Republic infra.
+set -euo pipefail
+
+AWS_REGION="us-west-2"
+BUCKET="workx-desktop-releases"
+RELEASES_BASE_URL="https://${BUCKET}.s3.${AWS_REGION}.amazonaws.com"
+
+ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+if ! [[ "$ACCOUNT_ID" =~ ^[0-9]{12}$ ]]; then
+    echo "ERROR: aws sts get-caller-identity returned '$ACCOUNT_ID' (not a 12-digit account ID)."
+    echo "       Configure AWS credentials with S3 admin permissions and retry."
+    exit 1
+fi
+echo "Account: $ACCOUNT_ID  Region: $AWS_REGION  Bucket: $BUCKET"
+echo
+
+echo "[1/4] Creating S3 bucket s3://$BUCKET ..."
+aws s3api create-bucket \
+    --bucket "$BUCKET" \
+    --region "$AWS_REGION" \
+    --create-bucket-configuration "LocationConstraint=$AWS_REGION" \
+    >/dev/null
+
+# ACLs disabled, but allow an explicit public-read bucket policy below.
+aws s3api put-public-access-block \
+    --bucket "$BUCKET" \
+    --public-access-block-configuration \
+        "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=false,RestrictPublicBuckets=false"
+
+# Versioning guards against an accidental overwrite of an already-released
+# bundle: the old signature is baked into the manifest clients already fetched,
+# so a re-upload without versioning could brick the update flow.
+aws s3api put-bucket-versioning \
+    --bucket "$BUCKET" \
+    --versioning-configuration Status=Enabled
+
+aws s3api put-bucket-encryption \
+    --bucket "$BUCKET" \
+    --server-side-encryption-configuration '{
+        "Rules": [{
+            "ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"},
+            "BucketKeyEnabled": true
+        }]
+    }'
+
+aws s3api put-bucket-tagging \
+    --bucket "$BUCKET" \
+    --tagging 'TagSet=[
+        {Key=Project,Value=workx},
+        {Key=Component,Value=desktop-updates},
+        {Key=ManagedBy,Value=manual}
+    ]'
+
+echo "       OK: bucket created, versioning on, SSE-S3 on, public policies allowed."
+
+echo "[2/4] Applying public-read bucket policy ..."
+POLICY_FILE="$(mktemp)"
+cat >"$POLICY_FILE" <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "AllowPublicReadReleaseObjects",
+    "Effect": "Allow",
+    "Principal": "*",
+    "Action": "s3:GetObject",
+    "Resource": "arn:aws:s3:::${BUCKET}/*"
+  }]
+}
+EOF
+aws s3api put-bucket-policy --bucket "$BUCKET" --policy "file://$POLICY_FILE"
+rm -f "$POLICY_FILE"
+echo "       OK: ${RELEASES_BASE_URL}/... is publicly readable."
+
+echo
+echo "[3/4] Provisioned."
+echo "       Bucket:             s3://${BUCKET}"
+echo "       Public release URL: ${RELEASES_BASE_URL}"
+echo
+
+cat <<EOF
+[4/4] Next steps (NOT automated by this script):
+
+  a) Create a dedicated, programmatic-only publisher IAM user for the release
+     CI workflow (release-desktop.yml) with a SCOPED policy — do NOT reuse an
+     admin user; a leaked GHA log would otherwise have account-wide access:
+
+       {
+         "Version": "2012-10-17",
+         "Statement": [{
+           "Effect": "Allow",
+           "Action": ["s3:PutObject", "s3:PutObjectTagging"],
+           "Resource": "arn:aws:s3:::${BUCKET}/*"
+         }]
+       }
+
+     Add its access keys to the workx repo as GitHub Actions secrets:
+       AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+
+  b) Confirm the Tauri signing key secrets are present in the workx repo
+     (already used by release.yml):
+       TAURI_SIGNING_PRIVATE_KEY / TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+     The matching pubkey must be the one in tauri/tauri.conf.json.
+
+  c) Point home-page / marketing download links at:
+       ${RELEASES_BASE_URL}/downloads/latest/
+
+  d) Run the "Release desktop bundles (S3)" workflow (workflow_dispatch) to
+     publish the first signed release. tauri.conf.json updater endpoints already
+     point at ${RELEASES_BASE_URL}/{{target}}/latest.json.
+EOF

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -74,7 +74,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDUwNEQyMTEzQzc3OTI0MzEKUldReEpIbkhFeUZOVUZBa01rK0s1RVlvYXVFc0EzNExaK2loUFhhbVR3TGszUUwvcFBkRG84V1cK",
       "endpoints": [
-        "https://github.com/The-AI-Republic/workx/releases/latest/download/latest.json"
+        "https://workx-desktop-releases.s3.us-west-2.amazonaws.com/{{target}}/latest.json"
       ],
       "windows": {
         "installMode": "passive"


### PR DESCRIPTION
## What

Publish signed Tauri desktop bundles to a dedicated **`workx-desktop-releases`** S3 bucket and self-update shipped clients from it. Modeled on the proven pi-dash `pidash-desktop-releases` pipeline.

## Changes

- **`.github/workflows/release-desktop.yml`** — `workflow_dispatch` matrix build (macOS universal, Windows x64, Linux x64). Per target it:
  1. builds + signs the bundle with the existing `TAURI_SIGNING_PRIVATE_KEY` / `_PASSWORD` secrets,
  2. uploads bundle + `.sig` to `s3://workx-desktop-releases/<target>/<version>/`,
  3. writes a per-target `latest.json` updater manifest (Tauri dynamic-update-server shape),
  4. publishes friendly first-install installers to `downloads/latest/`.
  The desktop `.env` block mirrors `release.yml` and **adds `VITE_MODEL_CATALOG_URL` / `WORKX_MODEL_CATALOG_URL`** so production builds wire the backend model-catalog override shipped earlier.
- **`tauri/tauri.conf.json`** — updater `endpoints` repointed from the GitHub Releases URL to `https://workx-desktop-releases.s3.us-west-2.amazonaws.com/{{target}}/latest.json`.
- **`deployments/desktop-releases/provision.sh`** — one-shot bucket provisioner (versioned, SSE-S3, public-read policy) with documented follow-ups.

## Before this can run (manual, needs AWS admin)

1. Run `deployments/desktop-releases/provision.sh` with an admin credential — my `mrc@airepublic.com` credential is **denied `s3:CreateBucket`**, so the bucket must be created by an admin.
2. Create a scoped publisher IAM user (`s3:PutObject` on `arn:aws:s3:::workx-desktop-releases/*`) and add `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` to the workx repo secrets.
3. Confirm `TAURI_SIGNING_PRIVATE_KEY` / `_PASSWORD` + `VITE_VAULT_SECRET` secrets exist (already used by `release.yml`).
4. Trigger **Release desktop bundles (S3)** via workflow_dispatch to publish the first release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)