### PR TITLE
fix(desktop): stage both macOS arches for ripgrep sidecar

### DIFF
--- a/scripts/build-ripgrep-sidecar.mjs
+++ b/scripts/build-ripgrep-sidecar.mjs
@@ -7,6 +7,14 @@
  * copies the `@vscode/ripgrep` binary to tauri/binaries/rg-<triple><ext>
  * so Tauri's bundler picks it up.
  *
+ * macOS universal builds (`--target universal-apple-darwin`) compile BOTH
+ * arches and Tauri resolves the externalBin per concrete target, so it needs
+ * rg-aarch64-apple-darwin AND rg-x86_64-apple-darwin present. @vscode/ripgrep
+ * ships one platform package per arch and npm only installs the host arch, so
+ * on macOS we force-install both arch packages and stage each (plus a lipo'd
+ * universal, mirroring build-sidecar.mjs). Staging only the host arch is what
+ * broke the v3.0.0 macOS release: `resource path rg-x86_64-apple-darwin doesn't exist`.
+ *
  * Run:  node scripts/build-ripgrep-sidecar.mjs   (or npm run build:ripgrep-sidecar)
  */
 
@@ -20,45 +28,76 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 const require = createRequire(import.meta.url);
 
-const { rgPath } = require('@vscode/ripgrep');
-if (!rgPath || !fs.existsSync(rgPath)) {
-  console.error(`@vscode/ripgrep binary not found at ${rgPath}. Run npm install.`);
-  process.exit(1);
-}
-
-const PLATFORM_MAP = {
-  'win32-x64': { triple: 'x86_64-pc-windows-msvc', ext: '.exe' },
-  'darwin-arm64': { triple: 'aarch64-apple-darwin', ext: '' },
-  'darwin-x64': { triple: 'x86_64-apple-darwin', ext: '' },
-  'linux-x64': { triple: 'x86_64-unknown-linux-gnu', ext: '' },
-};
-
-const key = `${process.platform}-${process.arch}`;
-const mapping = PLATFORM_MAP[key];
-if (!mapping) {
-  console.error(`Unsupported platform: ${key}. Supported: ${Object.keys(PLATFORM_MAP).join(', ')}`);
-  process.exit(1);
-}
-
 const binDir = path.resolve(root, 'tauri/binaries');
 fs.mkdirSync(binDir, { recursive: true });
 
-const out = path.join(binDir, `rg-${mapping.triple}${mapping.ext}`);
-fs.copyFileSync(rgPath, out);
-if (mapping.ext === '') fs.chmodSync(out, 0o755);
-console.log(`✓ ripgrep sidecar staged: ${out}`);
-
-// macOS: Tauri's universal build expects the universal-apple-darwin triple.
-// @vscode/ripgrep only ships the host arch, so duplicate it under the
-// universal name (functional on the host arch; cross-arch packaging would
-// need both @vscode/ripgrep-darwin-{arm64,x64} present).
-if (process.platform === 'darwin') {
-  const universal = path.join(binDir, 'rg-universal-apple-darwin');
+/** Resolve a platform package's `rg` binary, or null if not installed. */
+function resolveRg(pkg) {
   try {
-    execSync(`lipo -create -output "${universal}" "${out}"`, { stdio: 'inherit' });
+    return require.resolve(`${pkg}/bin/rg`);
   } catch {
-    fs.copyFileSync(out, universal);
+    return null;
   }
+}
+
+/** Copy an rg binary to tauri/binaries/rg-<triple><ext> and mark it executable. */
+function stage(srcRgPath, triple, ext = '') {
+  const out = path.join(binDir, `rg-${triple}${ext}`);
+  fs.copyFileSync(srcRgPath, out);
+  if (ext === '') fs.chmodSync(out, 0o755);
+  console.log(`✓ ripgrep sidecar staged: ${out}`);
+  return out;
+}
+
+if (process.platform === 'darwin') {
+  const arches = [
+    { pkg: '@vscode/ripgrep-darwin-arm64', triple: 'aarch64-apple-darwin' },
+    { pkg: '@vscode/ripgrep-darwin-x64', triple: 'x86_64-apple-darwin' }
+  ];
+
+  // npm installs only the host arch's optional package; pull in whichever arch
+  // packages are missing (force past the os/cpu guard) so both are on disk.
+  if (arches.some((a) => !resolveRg(a.pkg))) {
+    // Pin to the installed @vscode/ripgrep version so the arch binaries match.
+    const hostRg = require('@vscode/ripgrep').rgPath;
+    const version = JSON.parse(
+      fs.readFileSync(path.resolve(path.dirname(hostRg), '..', 'package.json'), 'utf8')
+    ).version;
+    const spec = arches.map((a) => `${a.pkg}@${version}`).join(' ');
+    console.log(`Installing ripgrep arch packages: ${spec}`);
+    execSync(`npm install --no-save --force ${spec}`, { cwd: root, stdio: 'inherit' });
+  }
+
+  const outs = arches.map((a) => {
+    const src = resolveRg(a.pkg);
+    if (!src) {
+      console.error(`Could not resolve ${a.pkg}/bin/rg after install.`);
+      process.exit(1);
+    }
+    return stage(src, a.triple);
+  });
+
+  // Universal binary for Tauri's universal-apple-darwin bundler path.
+  const universal = path.join(binDir, 'rg-universal-apple-darwin');
+  execSync(`lipo -create -output "${universal}" "${outs[0]}" "${outs[1]}"`, { stdio: 'inherit' });
   fs.chmodSync(universal, 0o755);
   console.log(`✓ ripgrep universal sidecar: ${universal}`);
+} else {
+  // Windows / Linux: single arch, host binary is sufficient.
+  const PLATFORM_MAP = {
+    'win32-x64': { triple: 'x86_64-pc-windows-msvc', ext: '.exe' },
+    'linux-x64': { triple: 'x86_64-unknown-linux-gnu', ext: '' }
+  };
+  const key = `${process.platform}-${process.arch}`;
+  const mapping = PLATFORM_MAP[key];
+  if (!mapping) {
+    console.error(`Unsupported platform: ${key}. Supported: ${Object.keys(PLATFORM_MAP).join(', ')}, darwin-*`);
+    process.exit(1);
+  }
+  const { rgPath } = require('@vscode/ripgrep');
+  if (!rgPath || !fs.existsSync(rgPath)) {
+    console.error(`@vscode/ripgrep binary not found at ${rgPath}. Run npm install.`);
+    process.exit(1);
+  }
+  stage(rgPath, mapping.triple, mapping.ext);
 }


### PR DESCRIPTION
## Why

The v3.0.0 desktop release **failed on macOS** (Windows + Linux shipped fine). The universal build compiles `aarch64-apple-darwin` and `x86_64-apple-darwin` separately, and Tauri resolves the `rg` `externalBin` per concrete target — so it needs **both** `rg-aarch64-apple-darwin` and `rg-x86_64-apple-darwin`. The script only staged the host arch (aarch64 on GitHub's Apple-Silicon `macos-latest`) plus a mis-named `rg-universal-apple-darwin`, so the x86_64 sub-build aborted:

```
resource path `binaries/rg-x86_64-apple-darwin` doesn't exist
Error failed to build x86_64-apple-darwin binary: failed to build app
```

Regression: `v0.0.49` shipped `Apple.Pi_0.0.49_universal.dmg`, and the sibling `build-sidecar.mjs` (chrome-devtools-mcp) already handles both arches — which is why *its* x86_64 file was present in the same failed run.

## Fix

`@vscode/ripgrep` 1.18.0 ships one platform package per arch (`@vscode/ripgrep-darwin-arm64`, `@vscode/ripgrep-darwin-x64`), each with `bin/rg`, and npm installs only the host arch's. On macOS the script now:
1. force-installs both arch packages (`npm install --no-save --force …@<pinned-version>`), bypassing the os/cpu guard,
2. stages `rg-aarch64-apple-darwin` + `rg-x86_64-apple-darwin`,
3. `lipo`s a universal (mirrors `build-sidecar.mjs`).

Windows/Linux keep the single host-arch path unchanged.

## Verified
- Linux path still stages its sidecar with no error.
- `npm install --no-save --force @vscode/ripgrep-darwin-{arm64,x64}@1.18.0` pulls both packages on a **non-Mac** box, and both `bin/rg` resolve — confirmed as Mach-O **arm64** and **x86_64** respectively.

After merge: dispatch **Release desktop bundles (S3)** (workflow_dispatch, v3.0.0 from package.json) to re-cut the macOS `.dmg` + `darwin-*/latest.json` into S3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)