### PR TITLE
fix(desktop): keep test-only fake-runtime-child out of the app bundle

### DIFF
--- a/tauri/Cargo.toml
+++ b/tauri/Cargo.toml
@@ -43,13 +43,21 @@ dirs = "5"
 default = ["custom-protocol", "dark-icon"]
 custom-protocol = ["tauri/custom-protocol"]
 dark-icon = []
+# Gates test-only helper binaries. `tauri build` uses default features, so the
+# fake-runtime-child bin below is neither built nor bundled in a release; the
+# Rust test runner (tauri/scripts/test-rust.sh) enables it. Without the gate the
+# universal macOS bundler tries to copy fake-runtime-child and fails:
+#   "Failed to copy binary from .../fake-runtime-child": does not exist
+test-support = []
 
 # Track 45 Goal 2: fake desktop-runtime child used by the supervisor
 # lifecycle tests. Wired in via WORKX_NODE_BIN=env!(CARGO_BIN_EXE_fake-runtime-child)
 # so the supervisor invokes this binary in place of `node`. The fake reads
 # stdio frames and is driven by env knobs documented in the source file.
+# required-features keeps it out of production builds (see `test-support` above).
 [[bin]]
 name = "fake-runtime-child"
 path = "tests/bin/fake_runtime_child.rs"
 test = false
 bench = false
+required-features = ["test-support"]

--- a/tauri/scripts/test-rust.sh
+++ b/tauri/scripts/test-rust.sh
@@ -38,4 +38,7 @@ for bin in chrome-devtools-mcp rg; do
 done
 
 echo "Running Rust tests..."
-cargo test --manifest-path "$MANIFEST" 2>&1
+# --features test-support builds the fake-runtime-child helper bin that the
+# supervisor lifecycle integration test references via CARGO_BIN_EXE_*. The bin
+# is gated out of production builds (see tauri/Cargo.toml), so tests must opt in.
+cargo test --manifest-path "$MANIFEST" --features test-support 2>&1

--- a/tauri/tests/runtime_supervisor_lifecycle.rs
+++ b/tauri/tests/runtime_supervisor_lifecycle.rs
@@ -11,6 +11,12 @@
 //! `env!("CARGO_BIN_EXE_<name>")` for integration tests under
 //! `tests/`. Pure unit tests (backoff math, ring buffer) live inline
 //! in `runtime_supervisor.rs` where they can access private items.
+//!
+//! Gated on the `test-support` feature, which builds the fake-runtime-child
+//! bin this file references via `CARGO_BIN_EXE_fake-runtime-child`. Without the
+//! feature (e.g. a bare `cargo test`) the bin isn't built and this file compiles
+//! to nothing rather than failing the `env!`. The test runner enables it.
+#![cfg(feature = "test-support")]
 
 use serde_json::{json, Value};
 use std::process::Stdio as StdStdio;


### PR DESCRIPTION
## Why

With the ripgrep (#314) and icon (#315) fixes in, the macOS universal build now compiles and passes icon bundling, then fails on a **test-only binary**:

```
Error failed to bundle project: Failed to copy binary from
  ".../universal-apple-darwin/release/fake-runtime-child": does not exist
```

`fake-runtime-child` is a `[[bin]]` used only by the supervisor lifecycle integration test, but it was declared as an ungated binary, so `tauri build` treated it as an app binary and the universal bundler tried to copy it (it isn't produced for the universal target).

## Fix

Gate it behind a new `test-support` feature — Tauri's documented way to exclude helper binaries:
- `tauri/Cargo.toml`: add `test-support` feature; `required-features = ["test-support"]` on the bin. Default `tauri build` no longer builds/bundles it.
- `tauri/scripts/test-rust.sh`: run `cargo test --features test-support` so the test still gets the bin (via `CARGO_BIN_EXE_fake-runtime-child`).
- `tauri/tests/runtime_supervisor_lifecycle.rs`: `#![cfg(feature = "test-support")]` so a bare `cargo test` compiles it to nothing instead of failing the `env!`.

## Verified
- `cargo build --bin fake-runtime-child` (default features) is **refused**: `requires the features: test-support` — confirming it's excluded from production builds.
- Windows/Linux unaffected (single-arch builds succeeded throughout; the bin is now excluded there too).

After merge: re-dispatch **Release desktop bundles (S3)** to finish the macOS `.dmg` + `darwin-*/latest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)