### PR TITLE
Update default model catalog

### DIFF
--- a/src/config/AgentConfig.ts
+++ b/src/config/AgentConfig.ts
@@ -275,10 +275,10 @@ export class AgentConfig implements IConfigService {
 
   /**
    * Set the selected model by composite key
-   * @param compositeKey - Model key in format "providerId:modelKey" (e.g., "openai:gpt-5.1")
+   * @param compositeKey - Model key in format "providerId:modelKey" (e.g., "openai:gpt-5.6-sol")
    * @throws Error if model is not found
    * @example
-   * await agentConfig.setSelectedModel('openai:gpt-5.1');
+   * await agentConfig.setSelectedModel('openai:gpt-5.6-sol');
    */
   async setSelectedModel(compositeKey: string): Promise<void> {
     this.ensureInitialized();
@@ -624,11 +624,11 @@ export class AgentConfig implements IConfigService {
   /**
    * Create a composite model key from provider ID and model key
    * @param providerId - Provider identifier (e.g., 'openai', 'xai')
-   * @param modelKey - Model's API identifier (e.g., 'gpt-5.1', 'grok-4-1-fast-reasoning')
+   * @param modelKey - Model's API identifier (e.g., 'gpt-5.6-sol', 'grok-4.5')
    * @returns Composite key in format "providerId:modelKey"
    * @example
-   * const key = AgentConfig.createModelKey('openai', 'gpt-5.1');
-   * console.log(key); // "openai:gpt-5.1"
+   * const key = AgentConfig.createModelKey('openai', 'gpt-5.6-sol');
+   * console.log(key); // "openai:gpt-5.6-sol"
    */
   static createModelKey(providerId: string, modelKey: string): string {
     return `${providerId}:${modelKey}`;
@@ -636,12 +636,12 @@ export class AgentConfig implements IConfigService {
 
   /**
    * Get model by composite key
-   * @param compositeKey - Model key in format "providerId:modelKey" (e.g., "openai:gpt-5.1")
+   * @param compositeKey - Model key in format "providerId:modelKey" (e.g., "openai:gpt-5.6-sol")
    * @returns Model config with provider context, or null if not found
    * @example
-   * const result = agentConfig.getModelByKey('openai:gpt-5.1');
+   * const result = agentConfig.getModelByKey('openai:gpt-5.6-sol');
    * if (result) {
-   *   console.log(result.model.name); // "GPT-5.1"
+   *   console.log(result.model.name); // "GPT-5.6 Sol"
    *   console.log(result.provider.name); // "OpenAI"
    * }
    */

--- a/src/config/__tests__/AgentConfig.test.ts
+++ b/src/config/__tests__/AgentConfig.test.ts
@@ -417,8 +417,8 @@ describe('AgentConfig', () => {
     });
 
     it('should create composite model key via static method', () => {
-      const key = AgentConfig.createModelKey('openai', 'gpt-5.1');
-      expect(key).toBe('openai:gpt-5.1');
+      const key = AgentConfig.createModelKey('openai', 'gpt-5.6-sol');
+      expect(key).toBe('openai:gpt-5.6-sol');
     });
 
     it('should set selected model via setSelectedModel', async () => {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -30,7 +30,7 @@ export interface IAgentConfig {
 
   /**
    * Currently selected model key
-   * Format: "providerId:modelKey" (e.g., "openai:gpt-5.1", "xai:grok-4-1-fast-reasoning")
+   * Format: "providerId:modelKey" (e.g., "openai:gpt-5.6-sol", "xai:grok-4.5")
    * Uniquely identifies a model across all providers
    */
   selectedModelKey: string;
@@ -260,7 +260,7 @@ export interface IModelConfig {
    * Track 12: fallback model key (optional).
    * When sustained provider overload (consecutive 529s) is detected, the
    * retry orchestrator downgrades to this model and retries. Must be a
-   * composite key (`provider:modelKey`, e.g. `openai:gpt-5.1`) of a
+   * composite key (`provider:modelKey`, e.g. `openai:gpt-5.6-sol`) of a
    * generally-available model. Undefined ⇒ no downgrade (the run fails
    * after the retry budget instead).
    */

--- a/src/core/models/__tests__/ModelClientFactory.test.ts
+++ b/src/core/models/__tests__/ModelClientFactory.test.ts
@@ -279,7 +279,7 @@ describe('ModelClientFactory', () => {
       const client1 = await factory.createClient('openai');
 
       // Simulate config change without clearing cache
-      (factory as any).config = createMockAgentConfig({ selectedModelKey: 'openai:gpt-5.1' });
+      (factory as any).config = createMockAgentConfig({ selectedModelKey: 'openai:gpt-5.6-sol' });
       const client2 = await factory.createClient('openai');
       expect(client1).not.toBe(client2);
     });
@@ -646,10 +646,10 @@ describe('ModelClientFactory', () => {
       const config = createMockAgentConfig();
       config.getProvider.mockReturnValue({
         id: 'openai', name: 'OpenAI',
-        models: [{ modelKey: 'gpt-5' }, { modelKey: 'gpt-5.1' }],
+        models: [{ modelKey: 'gpt-5.6-sol' }, { modelKey: 'gpt-5.6-terra' }],
       });
       await factory.initialize(config);
-      expect(factory.getSupportedModels('openai')).toEqual(['gpt-5', 'gpt-5.1']);
+      expect(factory.getSupportedModels('openai')).toEqual(['gpt-5.6-sol', 'gpt-5.6-terra']);
     });
   });
 

--- a/src/core/models/client/AnthropicClient.ts
+++ b/src/core/models/client/AnthropicClient.ts
@@ -51,6 +51,7 @@ const THINKING_BUDGET_BY_EFFORT: Record<ReasoningEffortConfig, number> = {
 /** Models where Anthropic supports adaptive thinking through thinking.type=adaptive. */
 const ADAPTIVE_THINKING_MODELS = new Set([
   'claude-opus-4-8',
+  'claude-sonnet-5',
   'claude-sonnet-4-6',
 ]);
 

--- a/src/core/models/cost/modelCostTable.ts
+++ b/src/core/models/cost/modelCostTable.ts
@@ -35,10 +35,15 @@ export interface ModelRate {
  * accepted approximation (see design Risks).
  */
 export const MODEL_COST_TABLE: Record<string, ModelRate> = {
-  // xai — flat, no cache discount
+  // xai
+  'xai:grok-4.5': { inputPer1M: 2.0, outputPer1M: 6.0, cachedInputPer1M: 0.5 },
+  // legacy
   'xai:grok-4-1-fast-reasoning': { inputPer1M: 0.2, outputPer1M: 0.5, cachedInputPer1M: 0.2 },
 
   // openai — Default tier (Priority tier intentionally not modeled)
+  'openai:gpt-5.6-sol': { inputPer1M: 5.0, outputPer1M: 30.0, cachedInputPer1M: 0.5 },
+  'openai:gpt-5.6-terra': { inputPer1M: 2.5, outputPer1M: 15.0, cachedInputPer1M: 0.25 },
+  'openai:gpt-5.6-luna': { inputPer1M: 1.0, outputPer1M: 6.0, cachedInputPer1M: 0.1 },
   'openai:gpt-5.5': { inputPer1M: 5.0, outputPer1M: 30.0, cachedInputPer1M: 0.5 },
   'openai:gpt-5.4': { inputPer1M: 2.5, outputPer1M: 15.0, cachedInputPer1M: 0.25 },
   // legacy (retired from picker; retained so historical usage records cost correctly)
@@ -46,13 +51,16 @@ export const MODEL_COST_TABLE: Record<string, ModelRate> = {
   'openai:gpt-5.2': { inputPer1M: 1.75, outputPer1M: 14.0, cachedInputPer1M: 0.175 },
 
   // google-ai-studio — ≤200K base tier; client always reports cached=0
-  'google-ai-studio:gemini-3.1-pro': { inputPer1M: 2.0, outputPer1M: 12.0, cachedInputPer1M: 0.2 },
+  'google-ai-studio:gemini-3.5-flash': { inputPer1M: 1.5, outputPer1M: 9.0, cachedInputPer1M: 0.15 },
+  'google-ai-studio:gemini-3.1-pro-preview': { inputPer1M: 2.0, outputPer1M: 12.0, cachedInputPer1M: 0.2 },
   // legacy
+  'google-ai-studio:gemini-3.1-pro': { inputPer1M: 2.0, outputPer1M: 12.0, cachedInputPer1M: 0.2 },
   'google-ai-studio:gemini-3-pro-preview': { inputPer1M: 2.0, outputPer1M: 12.0, cachedInputPer1M: 2.0 },
   'google-ai-studio:gemini-2.5-pro': { inputPer1M: 1.25, outputPer1M: 10.0, cachedInputPer1M: 1.25 },
 
   // deepseek — Cache Miss = input rate, Cache Hit = cached rate (free-tier default)
   'deepseek:deepseek-v4-flash': { inputPer1M: 0.14, outputPer1M: 0.28, cachedInputPer1M: 0.0028 },
+  'deepseek:deepseek-v4-pro': { inputPer1M: 0.435, outputPer1M: 0.87, cachedInputPer1M: 0.003625 },
 
   // legacy — Kimi (moonshot/fireworks/together) retired from the picker; rows
   // retained so historical usage records still cost correctly.
@@ -67,6 +75,7 @@ export const MODEL_COST_TABLE: Record<string, ModelRate> = {
 
   // anthropic — cache hit/refresh rate used for cached input
   'anthropic:claude-opus-4-8': { inputPer1M: 5.0, outputPer1M: 25.0, cachedInputPer1M: 0.5 },
+  'anthropic:claude-sonnet-5': { inputPer1M: 3.0, outputPer1M: 15.0, cachedInputPer1M: 0.3 },
   'anthropic:claude-sonnet-4-6': { inputPer1M: 3.0, outputPer1M: 15.0, cachedInputPer1M: 0.3 },
   'anthropic:claude-fable-5': { inputPer1M: 10.0, outputPer1M: 50.0, cachedInputPer1M: 1.0 },
   'anthropic:claude-haiku-4-5-20251001': { inputPer1M: 1.0, outputPer1M: 5.0, cachedInputPer1M: 0.1 },

--- a/src/core/models/providers/default.json
+++ b/src/core/models/providers/default.json
@@ -16,27 +16,25 @@
     },
     "models": [
       {
-        "name": "Grok 4.1 Fast Reasoning",
-        "modelKey": "grok-4-1-fast-reasoning",
+        "name": "Grok 4.5",
+        "modelKey": "grok-4.5",
         "creator": "xAI",
-        "contextWindow": 2000000,
+        "contextWindow": 500000,
         "maxOutputTokens": 16384,
         "supportsReasoning": true,
         "reasoningEfforts": [
-          "minimal",
           "low",
           "medium",
-          "high",
-          "ultra"
+          "high"
         ],
         "supportsReasoningSummaries": false,
         "supportsVerbosity": false,
         "supportsImage": true,
-        "releaseDate": "2024-11-15",
+        "releaseDate": "2026-07-08",
         "deprecated": false,
         "pricing": {
-          "inputToken": "$0.20 / 1M tokens",
-          "outputToken": "$0.50 / 1M tokens",
+          "inputToken": "$2.00 / 1M tokens, Cached: $0.50 / 1M tokens",
+          "outputToken": "$6.00 / 1M tokens",
           "link": "https://docs.x.ai/docs/models"
         },
         "supportBackendMode": 1
@@ -59,6 +57,105 @@
       "backoffMultiplier": 2
     },
     "models": [
+      {
+        "name": "GPT-5.6 Sol",
+        "modelKey": "gpt-5.6-sol",
+        "creator": "OpenAI",
+        "contextWindow": 1050000,
+        "maxOutputTokens": 128000,
+        "fallbackModelKey": "openai:gpt-5.6-terra",
+        "supportsReasoning": true,
+        "reasoningEfforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ],
+        "supportsReasoningSummaries": true,
+        "supportsVerbosity": true,
+        "verbosityLevels": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "supportsImage": true,
+        "supportsWebSearch": true,
+        "releaseDate": "2026-07-09",
+        "deprecated": false,
+        "serviceTier": "default",
+        "pricing": {
+          "inputToken": "Default: $5.00 / 1M tokens, Cached: $0.50 / 1M tokens",
+          "outputToken": "Default: $30.00 / 1M tokens",
+          "link": "https://openai.com/api/pricing/"
+        },
+        "supportBackendMode": 1
+      },
+      {
+        "name": "GPT-5.6 Terra",
+        "modelKey": "gpt-5.6-terra",
+        "creator": "OpenAI",
+        "contextWindow": 1050000,
+        "maxOutputTokens": 128000,
+        "fallbackModelKey": "openai:gpt-5.6-luna",
+        "supportsReasoning": true,
+        "reasoningEfforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ],
+        "supportsReasoningSummaries": true,
+        "supportsVerbosity": true,
+        "verbosityLevels": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "supportsImage": true,
+        "supportsWebSearch": true,
+        "releaseDate": "2026-07-09",
+        "deprecated": false,
+        "serviceTier": "default",
+        "pricing": {
+          "inputToken": "Default: $2.50 / 1M tokens, Cached: $0.25 / 1M tokens",
+          "outputToken": "Default: $15.00 / 1M tokens",
+          "link": "https://openai.com/api/pricing/"
+        },
+        "supportBackendMode": 1
+      },
+      {
+        "name": "GPT-5.6 Luna",
+        "modelKey": "gpt-5.6-luna",
+        "creator": "OpenAI",
+        "contextWindow": 1050000,
+        "maxOutputTokens": 128000,
+        "fallbackModelKey": "openai:gpt-5.5",
+        "supportsReasoning": true,
+        "reasoningEfforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ],
+        "supportsReasoningSummaries": true,
+        "supportsVerbosity": true,
+        "verbosityLevels": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "supportsImage": true,
+        "supportsWebSearch": true,
+        "releaseDate": "2026-07-09",
+        "deprecated": false,
+        "serviceTier": "default",
+        "pricing": {
+          "inputToken": "Default: $1.00 / 1M tokens, Cached: $0.10 / 1M tokens",
+          "outputToken": "Default: $6.00 / 1M tokens",
+          "link": "https://openai.com/api/pricing/"
+        },
+        "supportBackendMode": 1
+      },
       {
         "name": "GPT-5.5",
         "modelKey": "gpt-5.5",
@@ -143,11 +240,32 @@
     },
     "models": [
       {
-        "name": "Gemini 3.1 Pro",
-        "modelKey": "gemini-3.1-pro",
+        "name": "Gemini 3.5 Flash",
+        "modelKey": "gemini-3.5-flash",
         "creator": "Google",
-        "contextWindow": 2000000,
-        "maxOutputTokens": 16384,
+        "contextWindow": 1048576,
+        "maxOutputTokens": 65536,
+        "supportsReasoning": true,
+        "reasoningEfforts": [],
+        "supportsReasoningSummaries": false,
+        "supportsVerbosity": false,
+        "supportsImage": true,
+        "supportsWebSearch": true,
+        "releaseDate": "2026-05-01",
+        "deprecated": false,
+        "pricing": {
+          "inputToken": "$1.50 / 1M tokens, Cached: $0.15 / 1M tokens",
+          "outputToken": "$9.00 / 1M tokens",
+          "link": "https://ai.google.dev/gemini-api/docs/pricing"
+        },
+        "supportBackendMode": 3
+      },
+      {
+        "name": "Gemini 3.1 Pro Preview",
+        "modelKey": "gemini-3.1-pro-preview",
+        "creator": "Google",
+        "contextWindow": 1048576,
+        "maxOutputTokens": 65536,
         "supportsReasoning": true,
         "reasoningEfforts": [],
         "supportsReasoningSummaries": false,
@@ -186,7 +304,7 @@
         "modelKey": "deepseek-v4-flash",
         "creator": "DeepSeek",
         "contextWindow": 1000000,
-        "maxOutputTokens": 65536,
+        "maxOutputTokens": 384000,
         "supportsReasoning": true,
         "reasoningEfforts": [],
         "supportsReasoningSummaries": false,
@@ -197,6 +315,26 @@
         "pricing": {
           "inputToken": "Cache Hit: $0.0028 / 1M tokens, Cache Miss: $0.14 / 1M tokens",
           "outputToken": "$0.28 / 1M tokens",
+          "link": "https://api-docs.deepseek.com/quick_start/pricing"
+        },
+        "supportBackendMode": 2
+      },
+      {
+        "name": "DeepSeek V4 Pro",
+        "modelKey": "deepseek-v4-pro",
+        "creator": "DeepSeek",
+        "contextWindow": 1000000,
+        "maxOutputTokens": 384000,
+        "supportsReasoning": true,
+        "reasoningEfforts": [],
+        "supportsReasoningSummaries": false,
+        "supportsVerbosity": false,
+        "supportsImage": false,
+        "releaseDate": null,
+        "deprecated": false,
+        "pricing": {
+          "inputToken": "Cache Hit: $0.003625 / 1M tokens, Cache Miss: $0.435 / 1M tokens",
+          "outputToken": "$0.87 / 1M tokens",
           "link": "https://api-docs.deepseek.com/quick_start/pricing"
         },
         "supportBackendMode": 2
@@ -219,6 +357,30 @@
       "backoffMultiplier": 2
     },
     "models": [
+      {
+        "name": "Claude Fable 5",
+        "modelKey": "claude-fable-5",
+        "creator": "Anthropic",
+        "contextWindow": 1000000,
+        "maxOutputTokens": 128000,
+        "supportsReasoning": true,
+        "reasoningEfforts": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "supportsReasoningSummaries": false,
+        "supportsVerbosity": false,
+        "supportsImage": true,
+        "releaseDate": "2026-06-09",
+        "deprecated": false,
+        "pricing": {
+          "inputToken": "$10.00 / 1M tokens, Cached: $1.00 / 1M tokens",
+          "outputToken": "$50.00 / 1M tokens",
+          "link": "https://platform.claude.com/docs/en/about-claude/pricing"
+        },
+        "supportBackendMode": 0
+      },
       {
         "name": "Claude Opus 4.8",
         "modelKey": "claude-opus-4-8",
@@ -244,6 +406,30 @@
         "supportBackendMode": 0
       },
       {
+        "name": "Claude Sonnet 5",
+        "modelKey": "claude-sonnet-5",
+        "creator": "Anthropic",
+        "contextWindow": 1000000,
+        "maxOutputTokens": 128000,
+        "supportsReasoning": true,
+        "reasoningEfforts": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "supportsReasoningSummaries": false,
+        "supportsVerbosity": false,
+        "supportsImage": true,
+        "releaseDate": "2026-06-09",
+        "deprecated": false,
+        "pricing": {
+          "inputToken": "$3.00 / 1M tokens, Cached: $0.30 / 1M tokens",
+          "outputToken": "$15.00 / 1M tokens",
+          "link": "https://platform.claude.com/docs/en/about-claude/pricing"
+        },
+        "supportBackendMode": 0
+      },
+      {
         "name": "Claude Sonnet 4.6",
         "modelKey": "claude-sonnet-4-6",
         "creator": "Anthropic",
@@ -263,30 +449,6 @@
         "pricing": {
           "inputToken": "$3.00 / 1M tokens, Cached: $0.30 / 1M tokens",
           "outputToken": "$15.00 / 1M tokens",
-          "link": "https://platform.claude.com/docs/en/about-claude/pricing"
-        },
-        "supportBackendMode": 0
-      },
-      {
-        "name": "Claude Fable 5",
-        "modelKey": "claude-fable-5",
-        "creator": "Anthropic",
-        "contextWindow": 1000000,
-        "maxOutputTokens": 128000,
-        "supportsReasoning": true,
-        "reasoningEfforts": [
-          "low",
-          "medium",
-          "high"
-        ],
-        "supportsReasoningSummaries": false,
-        "supportsVerbosity": false,
-        "supportsImage": true,
-        "releaseDate": "2026-06-09",
-        "deprecated": false,
-        "pricing": {
-          "inputToken": "$10.00 / 1M tokens, Cached: $1.00 / 1M tokens",
-          "outputToken": "$50.00 / 1M tokens",
           "link": "https://platform.claude.com/docs/en/about-claude/pricing"
         },
         "supportBackendMode": 0

--- a/src/core/services/__tests__/models-services.test.ts
+++ b/src/core/services/__tests__/models-services.test.ts
@@ -133,7 +133,7 @@ describe('models.testConnection', () => {
         providerId: 'google-ai-studio',
         baseUrl: 'https://generativelanguage.googleapis.com',
         apiKey: 'AIza-test',
-        model: 'gemini-3.1-pro',
+        model: 'gemini-3.5-flash',
       },
       context,
     );
@@ -155,7 +155,7 @@ describe('models.testConnection', () => {
         providerId: 'google-ai-studio',
         baseUrl: 'https://generativelanguage.googleapis.com',
         apiKey: 'bad',
-        model: 'gemini-3.1-pro',
+        model: 'gemini-3.5-flash',
       },
       context,
     )).toEqual({ valid: false, error: 'Invalid API key' });


### PR DESCRIPTION
## Summary

- Refresh the bundled default model catalog with the latest provider model IDs from xAI, OpenAI, Google, DeepSeek, and Anthropic.
- Add matching numeric cost-table entries while retaining legacy rows for historical usage records.
- Enable Anthropic adaptive thinking for `claude-sonnet-5` and update stale model examples/test fixtures.

## Validation

- Parsed `src/core/models/providers/default.json` successfully and verified every default model has a cost-table row.
- `git diff --check`
- `npx vitest run src/core/models/cost/__tests__/cost.test.ts src/core/services/__tests__/models-services.test.ts src/config/__tests__/AgentConfig.test.ts src/core/models/__tests__/ModelClientFactory.test.ts`
- `npm run type-check`