### PR TITLE
ci(desktop): also publish the Linux .rpm installer

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -323,8 +323,12 @@ jobs:
               upload_install_artifact "$(find_one "$BUNDLE_ROOT/msi" "*.msi")" "workx-windows-x64.msi"
               ;;
             linux-*)
+              # bundle.targets: "all" builds deb + rpm + AppImage; publish all
+              # three so the site can offer the right package per distro family
+              # (.deb Debian/Ubuntu, .rpm Fedora/RHEL, .AppImage universal).
               upload_install_artifact "$(find_one "$BUNDLE_ROOT/appimage" "*.AppImage")" "workx-linux-x64.AppImage"
               upload_install_artifact "$(find_one "$BUNDLE_ROOT/deb" "*.deb")" "workx-linux-x64.deb"
+              upload_install_artifact "$(find_one "$BUNDLE_ROOT/rpm" "*.rpm")" "workx-linux-x64.rpm"
               ;;
             *)
               echo "::warning::no first-install artifact mapping for $PRIMARY_TARGET"


### PR DESCRIPTION
`bundle.targets: "all"` already builds `.deb` + `.rpm` + `.AppImage` for Linux, but the release workflow only uploaded `.deb` + `.AppImage` to `downloads/latest/` — the `.rpm` was built and discarded. Publish it too as `workx-linux-x64.rpm`.

This lets the WorkX product page offer the native package per distro family (browsers can't detect the distro, so the page presents the choice):
- `.deb` — Debian/Ubuntu
- `.rpm` — Fedora/RHEL/openSUSE
- `.AppImage` — universal fallback

One added upload line in the Linux artifact case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)