### PR TITLE
fix(desktop): prod auth base URL -> airepublic.com (was dead host home.airepublic.com)

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -128,7 +128,7 @@ jobs:
         run: |
           cat > src/desktop/.env << 'EOF'
           VITE_AUTH_COOKIE_DOMAIN=${{ vars.VITE_AUTH_COOKIE_DOMAIN || '.airepublic.com' }}
-          VITE_AUTH_BASE_URL=${{ vars.VITE_AUTH_BASE_URL || 'https://home.airepublic.com' }}
+          VITE_AUTH_BASE_URL=${{ vars.VITE_AUTH_BASE_URL || 'https://airepublic.com' }}
           VITE_BACKEND_API_BASE_URL=${{ vars.VITE_BACKEND_API_BASE_URL || 'https://api.airepublic.com' }}
           VITE_MODEL_CATALOG_URL=${{ vars.VITE_MODEL_CATALOG_URL || 'https://api.airepublic.com/api/v1/workx/models' }}
           VITE_AUTH_ACCESS_COOKIE_NAME=ai_access
@@ -153,7 +153,7 @@ jobs:
           VITE_AUTH_OIDC_CLIENT_ID=${{ vars.VITE_AUTH_OIDC_CLIENT_ID || 'workx-desktop' }}
           VITE_AUTH_OIDC_SCOPES=openid profile email chat apps models offline_access
           VITE_VAULT_SECRET=${{ secrets.VITE_VAULT_SECRET }}
-          WORKX_AUTH_BASE_URL=${{ vars.VITE_AUTH_BASE_URL || 'https://home.airepublic.com' }}
+          WORKX_AUTH_BASE_URL=${{ vars.VITE_AUTH_BASE_URL || 'https://airepublic.com' }}
           WORKX_BACKEND_API_BASE_URL=${{ vars.VITE_BACKEND_API_BASE_URL || 'https://api.airepublic.com' }}
           WORKX_MODEL_CATALOG_URL=${{ vars.VITE_MODEL_CATALOG_URL || 'https://api.airepublic.com/api/v1/workx/models' }}
           WORKX_AUTH_DESKTOP_SESSION_PATH=/auth/desktop/session

--- a/src/desktop/.env.production.example
+++ b/src/desktop/.env.production.example
@@ -22,7 +22,7 @@
 
 # --- Home-page auth / backend (environment-specific) ---
 VITE_AUTH_COOKIE_DOMAIN=.airepublic.com
-VITE_AUTH_BASE_URL=https://home.airepublic.com
+VITE_AUTH_BASE_URL=https://airepublic.com
 VITE_BACKEND_API_BASE_URL=https://api.airepublic.com
 # Public model catalog overriding the bundled default.json at startup.
 VITE_MODEL_CATALOG_URL=https://api.airepublic.com/api/v1/workx/models
@@ -54,7 +54,7 @@ VITE_AUTH_OIDC_CLIENT_ID=workx-desktop
 VITE_AUTH_OIDC_SCOPES=openid profile email chat apps models offline_access
 
 # --- Runtime-side mirror (Node/Tauri sidecar reads WORKX_*) ---
-WORKX_AUTH_BASE_URL=https://home.airepublic.com
+WORKX_AUTH_BASE_URL=https://airepublic.com
 WORKX_BACKEND_API_BASE_URL=https://api.airepublic.com
 WORKX_AUTH_DESKTOP_SESSION_PATH=/auth/desktop/session
 WORKX_AUTH_DESKTOP_REFRESH_PATH=/auth/desktop/refresh


### PR DESCRIPTION
## Problem
The shipped prod desktop 3.0.0 build could not sign in. The OIDC login window opened `https://home.airepublic.com/auth/authorize?...`, but **`home.airepublic.com` is NXDOMAIN**. Prod home/IdP is served at the apex **`airepublic.com`** (`testhome.airepublic.com` is the test analogue; prod has no `home.` prefix).

Verified:
- `home.airepublic.com` → NXDOMAIN
- `airepublic.com` `/auth/authorize` → real IdP backend (returns `invalid_redirect_uri`/`invalid_client`, i.e. it's the OIDC provider)

## Fix
Point both the WebView (`VITE_AUTH_BASE_URL`) and sidecar (`WORKX_AUTH_BASE_URL`) auth base URL **defaults** at `https://airepublic.com` in:
- `.github/workflows/release-desktop.yml`
- `src/desktop/.env.production.example`

A repo/org Actions `var VITE_AUTH_BASE_URL` still overrides the default if the host ever changes. Other prod hosts (`api`, `gateway`, `hub`) were verified correct and are unchanged.

## Follow-up (not in this PR)
Prod login also needs the running **prod home-page backend redeployed** — SSM `OIDC_CLIENTS_JSON` already contains `workx-desktop`, but `aws_config.get_parameter` caches with no TTL, so the live process (started before the client was added) still returns `invalid_client`. A prod redeploy reloads it.

After merge: re-cut the desktop release so the fixed `.env` is baked into the installers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)