### PR TITLE
fix(models): surface gateway billing 401s (no credit / quota) instead of masking as auth error

### DIFF
--- a/src/core/models/client/OpenAIChatCompletionClient.ts
+++ b/src/core/models/client/OpenAIChatCompletionClient.ts
@@ -321,9 +321,13 @@ export class OpenAIChatCompletionClient extends OpenAIResponsesClient {
             continue;
           }
 
-          // Check for auth errors
+          // Check for auth errors. A 401 from the gateway is not always an
+          // auth failure — it also signals billing conditions (no credit
+          // account / insufficient balance / exhausted quota) with an
+          // actionable message. Preserve those; only mask genuine auth
+          // failures. See reclassifyGateway401 on the base class.
           if (error.statusCode === 401) {
-            throw new ModelClientError('Authentication failed - check API key', 401, this.provider.name);
+            throw this.reclassifyGateway401(error);
           }
 
           // Non-retryable errors

--- a/src/core/models/client/OpenAIResponsesClient.ts
+++ b/src/core/models/client/OpenAIResponsesClient.ts
@@ -31,6 +31,27 @@ import { SSEEventParser } from '../SSEEventParser';
 import { get_full_instructions, get_formatted_input } from '../PromptHelpers';
 
 /**
+ * Heuristic: does a 401 body message describe a billing/credit/quota problem
+ * (which must be surfaced to the user verbatim) rather than an expired
+ * session/token/key? The AI Hub gateway returns 401 with `type: "auth_error"`
+ * for both, so the message text is the only discriminator available client-side.
+ * Defaults to `false` (treat as auth failure) when there is no message.
+ */
+export function isGatewayBillingMessage(message?: string): boolean {
+  if (!message) return false;
+  const m = message.toLowerCase();
+  return (
+    m.includes('credit account') ||
+    m.includes('credit balance') ||
+    m.includes('insufficient') ||
+    m.includes('quota') ||
+    m.includes('free tokens') ||
+    m.includes('free app call') ||
+    m.includes('daily free')
+  );
+}
+
+/**
  * SSE Event structure from OpenAI Responses API
  */
 interface SseEvent {
@@ -522,20 +543,7 @@ export class OpenAIResponsesClient extends ModelClient {
       yield* this.processSDKStream(sdkStream);
     } catch (error) {
       if (error instanceof ModelClientError && error.statusCode === 401) {
-        if (this.useCredentials) {
-          throw new ModelClientError(
-            'Session expired - please log in again to continue using the AI agent',
-            401,
-            'Backend',
-            false // Not retryable
-          );
-        }
-        throw new ModelClientError(
-          'Authentication failed - check API key',
-          401,
-          this.provider.name,
-          false // Not retryable
-        );
+        throw this.reclassifyGateway401(error);
       }
       throw error;
     }
@@ -1104,6 +1112,39 @@ export class OpenAIResponsesClient extends ModelClient {
       statusCode,
       this.provider.name,
       this.isRetryableHttpError(statusCode)
+    );
+  }
+
+  /**
+   * Map a 401 from a gateway-routed request to the user-facing error to throw.
+   *
+   * A 401 here is NOT always an expired session/API key. The AI Hub gateway
+   * returns 401 for billing conditions too — "no LLM credit account for this
+   * identity", "insufficient LLM credit balance", exhausted daily quota —
+   * each with a specific, actionable message and `type: "auth_error"`. The
+   * previous behavior masked all of them as "Session expired" / "check API
+   * key", hiding the real reason from the user and sending them into a
+   * pointless re-login. Preserve any gateway billing/credit/quota message so
+   * it reaches the UI; only fall back to the generic auth copy for a 401 that
+   * carries no such detail (i.e. a genuine session/token/key failure).
+   */
+  protected reclassifyGateway401(error: ModelClientError): ModelClientError {
+    if (isGatewayBillingMessage(error.message)) {
+      return error; // surface the real, actionable reason unchanged
+    }
+    if (this.useCredentials) {
+      return new ModelClientError(
+        'Session expired - please log in again to continue using the AI agent',
+        401,
+        'Backend',
+        false // Not retryable
+      );
+    }
+    return new ModelClientError(
+      'Authentication failed - check API key',
+      401,
+      this.provider.name,
+      false // Not retryable
     );
   }
 


### PR DESCRIPTION
## Problem (Bug A of 2)
When the AI Hub gateway rejects an LLM request with **401**, WorkX blanket-rewrote the message:
- Responses path (`OpenAIResponsesClient.streamResponsesInternal`) → `"Session expired - please log in again"`
- Chat Completions path (`OpenAIChatCompletionClient.streamChatInternal`) → `"Authentication failed - check API key"`

But the gateway returns 401 for **billing** conditions too — `no LLM credit account for this identity`, `insufficient LLM credit balance`, exhausted daily quota — all with `type: "auth_error"` and a specific, actionable message. Masking them:
- hides the real reason from the user, and
- for a session-JWT user, tells them to "log in again" / "check API key" — neither applies. Re-logging-in appears to "work" but the task still fails, because the session was never actually expired.

Observed live (dev build against prod): request carried a valid JWT, gateway returned `401 {"error":{"message":"no LLM credit account for this identity","type":"auth_error"}}`, user saw a generic failure.

## Fix
Add `reclassifyGateway401()` on `OpenAIResponsesClient` (inherited by the Chat Completions subclass) and route both 401 sites through it:
- **Preserve** the gateway message when it looks like a billing/credit/quota error (`isGatewayBillingMessage`), so it reaches the UI verbatim.
- Only fall back to the generic session/API-key copy for a 401 with no such detail (a genuine token/key failure).

Discrimination is by message text because the gateway uses `type: "auth_error"` for both billing and auth 401s. The genuine session-expiry relogin flow is unaffected — it's driven by the separate `BackendRoutingError('session_expired')` / `session_expired` sentinel, not this cosmetic string.

## Scope / follow-up
This makes the correct text *available*. A companion PR (Bug B) gives the **background/sub-agent task UI** a field to actually render an error message — today that panel collapses every failure to a generic status regardless of the message. Both are needed end-to-end.

Type-check: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)