### PR TITLE
fix(tasks): surface failure reason in the background task UI (was a bare 'failed')

### DIFF
--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -2417,6 +2417,7 @@ export class Session {
           taskId: state.id,
           prevStatus,
           status: state.status,
+          error: state.error,
         },
       },
     });
@@ -2432,6 +2433,7 @@ export class Session {
             endTime: state.endTime ?? Date.now(),
             durationMs: (state.endTime ?? Date.now()) - state.startTime,
             summary: state.lastAgentMessage,
+            error: state.error,
           },
         },
       });

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -3192,6 +3192,12 @@ export class Session {
     if (t?.taskState && !isTerminalTaskStatus(t.taskState.status)) {
       const prevStatus = t.taskState.status;
       t.taskState.status = reason === 'user_interrupt' ? 'killed' : 'failed';
+      // Surface the failure reason here too, mirroring
+      // SubAgentRunner.markTypedTaskTerminated, so a task that threw outside
+      // the normal result flow still shows why it failed (not a bare "failed").
+      if (t.taskState.status === 'failed' && error?.message) {
+        t.taskState.error = error.message;
+      }
       t.taskState.endTime = Date.now();
       t.taskState.notified = true;
       if (!t.taskState.retain) {

--- a/src/core/protocol/events.ts
+++ b/src/core/protocol/events.ts
@@ -167,6 +167,8 @@ export interface BackgroundTaskStateChangedEvent {
   taskId: string;
   prevStatus: 'pending' | 'running' | 'completed' | 'failed' | 'killed';
   status: 'pending' | 'running' | 'completed' | 'failed' | 'killed';
+  /** Failure reason when status === 'failed' (e.g. a gateway/model error). */
+  error?: string;
 }
 
 export interface BackgroundTaskTerminatedEvent {
@@ -175,6 +177,8 @@ export interface BackgroundTaskTerminatedEvent {
   endTime: number;
   durationMs: number;
   summary?: string;
+  /** Failure reason when status === 'failed' (e.g. a gateway/model error). */
+  error?: string;
 }
 
 // Individual event payload types

--- a/src/core/tasks/types.ts
+++ b/src/core/tasks/types.ts
@@ -54,6 +54,13 @@ export interface TaskStateBase {
   id: string;
   type: TaskType;
   status: TaskStatus;
+  /**
+   * Failure detail for a terminal `failed` task — the underlying model/gateway
+   * error message (e.g. "no LLM credit account for this identity"). Undefined
+   * unless the task failed. Without this field the background-task UI has no
+   * channel for the reason and collapses every failure to a generic status.
+   */
+  error?: string;
   description: string;
   toolUseId?: string;
   startTime: number;

--- a/src/tools/AgentTool/SubAgentRunner.ts
+++ b/src/tools/AgentTool/SubAgentRunner.ts
@@ -384,6 +384,12 @@ export class SubAgentRunner implements IAgentRunner {
         ? 'killed'
         : 'failed';
     ts.endTime = Date.now();
+    // Surface the failure reason (e.g. "no LLM credit account for this
+    // identity") so the background-task UI can render it instead of a bare
+    // "failed" status. result.error carries the message on failure.
+    if (ts.status === 'failed' && result.error) {
+      ts.error = result.error;
+    }
     ts.notified = true; // safeEnqueueNotification just ran (or was suppressed)
     if (result.tokenUsage) {
       ts.tokenUsage = {

--- a/src/webfront/components/BackgroundTaskPanel.svelte
+++ b/src/webfront/components/BackgroundTaskPanel.svelte
@@ -91,6 +91,12 @@
       {/if}
       <span>started {new Date(task.startTime).toLocaleTimeString()}</span>
     </div>
+    {#if task.status === 'failed' && task.error}
+      <div class="failure" role="alert">
+        <span class="failure-label">Failed:</span>
+        <span class="failure-message">{task.error}</span>
+      </div>
+    {/if}
     <div class="chunks">
       {#each chunksReversed as chunk (chunk.chunkId)}
         <div class="chunk chunk-{chunk.kind}">
@@ -145,6 +151,22 @@
   .status-completed { background: var(--success-light, #d1fae5); }
   .status-failed { background: var(--error-light, #fee2e2); }
   .status-killed { background: var(--bg-tertiary, #f3f4f6); }
+  .failure {
+    display: flex;
+    gap: 6px;
+    padding: 8px 12px;
+    background: var(--error-light, #fee2e2);
+    color: var(--error-color, #b91c1c);
+    font-size: 12px;
+    border-bottom: 1px solid var(--border-color, #eee);
+  }
+  .failure-label {
+    font-weight: 600;
+    flex-shrink: 0;
+  }
+  .failure-message {
+    word-break: break-word;
+  }
   .close {
     background: transparent;
     border: none;

--- a/src/webfront/components/BackgroundTasksBadge.svelte
+++ b/src/webfront/components/BackgroundTasksBadge.svelte
@@ -83,6 +83,7 @@
             type="button"
             class="task-row"
             on:click={() => handleSelect(task.id)}
+            title={task.status === 'failed' && task.error ? task.error : undefined}
           >
             <span class="task-status">{statusEmoji(task.status)}</span>
             <span class="task-desc">{task.description}</span>

--- a/src/webfront/stores/backgroundTaskStore.ts
+++ b/src/webfront/stores/backgroundTaskStore.ts
@@ -107,7 +107,7 @@ export function handleBackgroundTaskEvent(msg: EventMsg): void {
           ...prev,
           tasks: {
             ...prev.tasks,
-            [msg.data.taskId]: { ...task, status: msg.data.status },
+            [msg.data.taskId]: { ...task, status: msg.data.status, error: msg.data.error ?? task.error },
           },
         };
       });
@@ -125,6 +125,7 @@ export function handleBackgroundTaskEvent(msg: EventMsg): void {
               status: msg.data.status,
               endTime: msg.data.endTime,
               lastAgentMessage: msg.data.summary,
+              error: msg.data.error ?? task.error,
             },
           },
         };


### PR DESCRIPTION
## Problem (Bug B of 2)
A failed background / sub-agent task showed only a generic **`failed`** status in the task UI — no reason — even when the underlying error was specific and actionable (e.g. `no LLM credit account for this identity`).

Traced end to end: the message survives retry, `TaskRunner.emitTaskFailed`, redaction (safe), the engine, and lands on `AgentRunResult.error`. It is then **structurally dropped at the typed task-state layer** — `TaskStateBase` had *no field* for an error, so `SubAgentRunner.markTypedTaskTerminated` set `status='failed'` and there was nowhere to put the reason. The `listTaskStates`-driven UI therefore had nothing to render. (The foreground chat stream *does* render it via `EventProcessor`; only the background/sub-agent task panel was blind.)

## Fix — an error channel from state → event → store → UI
- `TaskStateBase.error?: string` — `src/core/tasks/types.ts`.
- `SubAgentRunner.markTypedTaskTerminated` copies `result.error` onto the state when `status === 'failed'`.
- `BackgroundTaskStateChanged` / `BackgroundTaskTerminated` events carry `error` — `protocol/events.ts` + `Session.ts`.
- `backgroundTaskStore` threads it through both the poll (`tick`) and event paths.
- **`BackgroundTaskPanel`** renders a `Failed: <reason>` banner; **`BackgroundTasksBadge`** exposes it as a row tooltip.

## Pairs with #322
#322 makes the gateway's real 401 message *available* (instead of masking billing errors as "session expired"). This PR makes the background task UI *show* it. Both are needed for the user to actually see "no LLM credit account…" on a failed task.

Type-check: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)