### PR TITLE
fix(ui): show task failure reason even when token usage display is off

### DIFF
--- a/src/webfront/components/__tests__/TaskEvent.test.ts
+++ b/src/webfront/components/__tests__/TaskEvent.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import TaskEvent from '@/webfront/components/event_display/TaskEvent.svelte';
+import { showTokenUsage } from '@/webfront/stores/tokenUsageStore';
+import type { ProcessedEvent } from '@/types/ui';
+
+function makeEvent(overrides: Partial<ProcessedEvent>): ProcessedEvent {
+  return {
+    id: 'evt-1',
+    category: 'task',
+    timestamp: new Date(),
+    title: 'Task',
+    content: '',
+    style: {},
+    collapsible: false,
+    ...overrides,
+  } as ProcessedEvent;
+}
+
+describe('TaskEvent', () => {
+  it('renders the failure reason even when token usage display is off', () => {
+    showTokenUsage.setShowTokenUsage(false);
+
+    render(TaskEvent, {
+      props: {
+        event: makeEvent({
+          title: 'Task failed',
+          content: 'ModelClientError: no LLM credit account for this identity',
+          status: 'error',
+        }),
+      },
+    });
+
+    expect(
+      screen.getByText('ModelClientError: no LLM credit account for this identity'),
+    ).toBeTruthy();
+  });
+
+  it('hides the completion card when token usage display is off', () => {
+    showTokenUsage.setShowTokenUsage(false);
+
+    render(TaskEvent, {
+      props: {
+        event: makeEvent({
+          title: 'Task complete',
+          content: 'Task complete',
+          status: 'success',
+        }),
+      },
+    });
+
+    expect(screen.queryByText('Task complete')).toBeNull();
+  });
+
+  it('shows the completion card when token usage display is on', () => {
+    showTokenUsage.setShowTokenUsage(true);
+
+    render(TaskEvent, {
+      props: {
+        event: makeEvent({
+          title: 'Task complete',
+          content: 'Task complete',
+          status: 'success',
+        }),
+      },
+    });
+
+    expect(screen.getByText('Task complete')).toBeTruthy();
+  });
+});

--- a/src/webfront/components/event_display/TaskEvent.svelte
+++ b/src/webfront/components/event_display/TaskEvent.svelte
@@ -15,7 +15,9 @@
 
   let currentTheme = $derived($uiTheme);
   let shouldShowTokenUsage = $derived($showTokenUsage);
-  let shouldHideCard = $derived(!shouldShowTokenUsage);
+  // Failure cards carry the error reason in `content` — they must render even
+  // when token usage display is off (which only targets completion stats).
+  let shouldHideCard = $derived(!shouldShowTokenUsage && event.status !== 'error');
 </script>
 
 {#if !shouldHideCard}


### PR DESCRIPTION
## The third (and final) mask on task-failure reasons

After #322 (gateway 401 masking) and #323 (background-task error channel), the foreground chat still showed a bare **"Task failed"** with no reason. Live debugging against prod pinned it down:

- The sidecar emits `TaskFailed` correctly — verified live: `detail = "ModelClientError: no LLM credit account for this identity"` (the gateway's fine-grained 402 from openhub PR #12).
- `EventProcessor` maps it correctly: `content: msg.data.message`.
- **`TaskEvent.svelte` then hides the entire card body when the "show token usage" setting is off** — and `DEFAULT_SHOW_TOKEN_USAGE = false`. Only the header (title "Task failed" + red `error` pill, rendered by `EventDisplay.svelte`) survived.

The setting was meant to hide TaskComplete token statistics ("token info can be scary to users"), but it swallowed failure reasons too.

## Fix

Error-status task cards always render their content; completion cards keep the existing token-usage gating:

```svelte
let shouldHideCard = $derived(!shouldShowTokenUsage && event.status !== 'error');
```

## Tests

New `TaskEvent.test.ts` (3 cases): failure reason renders with token usage off; completion card stays hidden with it off; completion card shows with it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)