### PR TITLE
WORKXOS-2 fix the long latency of creating new thread currently take several second to successfully load

### DIFF
--- a/src/core/services/__tests__/session-services.test.ts
+++ b/src/core/services/__tests__/session-services.test.ts
@@ -242,6 +242,24 @@ describe('session-services', () => {
       });
     });
 
+    it('does not re-run refreshModelClient on the create path (initialize already composed the client)', async () => {
+      // createSession already ran agent.initialize(); a second refreshModelClient()
+      // here would re-compose the prompt + reload instructions + refresh memory on
+      // the thread-creation critical path for no behavioral gain. Guard against it.
+      const refreshSpy = vi.fn().mockResolvedValue(undefined);
+      (deps.registry.getSession as any).mockImplementation((id: string) => {
+        if (id === 's-new') {
+          return { agent: { refreshModelClient: refreshSpy } };
+        }
+        return undefined;
+      });
+
+      const result = await services['session.create']({}, ctx);
+
+      expect(result.success).toBe(true);
+      expect(refreshSpy).not.toHaveBeenCalled();
+    });
+
     it('returns error when at capacity', async () => {
       (deps.registry.canCreateSession as any).mockReturnValue(false);
 

--- a/src/core/services/session-services.ts
+++ b/src/core/services/session-services.ts
@@ -300,14 +300,18 @@ export function createSessionServices(deps: SessionServiceDeps): Record<string, 
 
       const session = await registry.createSession({ type: 'primary' });
 
-      // Ensure backend routing configured properly for this new session
-      if (session?.agent) {
-        const agentSession = registry.getSession(session.sessionId);
-        if (agentSession?.agent) {
-          await agentSession.agent.refreshModelClient();
-        }
-      }
-
+      // NOTE: no refreshModelClient() here. createSession() already ran
+      // agent.initialize(), which composes the system prompt, loads user
+      // instructions, sets up the memory service, and builds the model client
+      // using the *current* auth state. Calling refreshModelClient() right
+      // after would re-compose the prompt, reload instructions, and refresh
+      // memory a second time on the thread-creation critical path — pure
+      // duplicate work (the model client itself is a factory cache hit). It
+      // cannot even change backend routing here: the new agent's factory has
+      // no authManager wired at this point, so it resolves to the same client
+      // initialize() already produced. Auth *changes* are handled separately
+      // by agent.initAuth / agent.configUpdate, which set the authManager on
+      // the session's factory and then call refreshModelClient() themselves.
       return {
         success: true,
         sessionId: session.sessionId,

--- a/src/webfront/pages/chat/Main.svelte
+++ b/src/webfront/pages/chat/Main.svelte
@@ -1295,11 +1295,10 @@
       threadRouter.setActiveSession(sessionId);
       loadThreadState(sessionId);
 
-      // Update session limits
-      await updateSessionLimits();
-
-      // Auto-bind to active browser tab
-      await bindToActiveTab();
+      // Refresh session limits and auto-bind to the active browser tab. These
+      // are independent post-create round trips, so run them concurrently
+      // instead of serially to shave latency off thread creation.
+      await Promise.all([updateSessionLimits(), bindToActiveTab()]);
 
       console.log(`[App] Created new thread with session: ${sessionId}`);
     } catch (error) {


### PR DESCRIPTION
## Problem

Clicking **New Thread** took several seconds. `createNewThread()` (`src/webfront/pages/chat/Main.svelte`) awaits `session.create` serially, and the `session.create` handler did a **second** full agent bring-up right after the first.

## Root cause

1. **Redundant `refreshModelClient()` on the create path.** `session.create` (`src/core/services/session-services.ts`) called `registry.createSession()` — which already runs `agent.initialize()` (composes the system prompt, loads user instructions, sets up the memory service, builds the model client with current auth) — and then immediately called `agent.refreshModelClient()`, which re-composes the prompt, reloads instructions, and refreshes memory a **second** time. The model client itself is a `ModelClientFactory` cache hit, so the refresh bought nothing but duplicated the expensive prompt/instruction/memory work on the critical path. It also can't establish backend routing here: `onAgentCreated` (extension) never wires an `authManager` onto the new agent's factory, so the refresh resolves to the same direct client `initialize()` already produced. Real auth changes flow through `agent.initAuth` / `agent.configUpdate`, which set the `authManager` and then refresh themselves — untouched by this change.
2. **Serial post-create round trips.** After create, the UI awaited `updateSessionLimits()` then `bindToActiveTab()` one after the other, though they're independent.

## Changes

- **`src/core/services/session-services.ts`** — remove the redundant `refreshModelClient()` from `session.create`; document why (with pointers to the auth-change paths that legitimately refresh).
- **`src/webfront/pages/chat/Main.svelte`** — run `updateSessionLimits()` + `bindToActiveTab()` concurrently via `Promise.all`.
- **`src/core/services/__tests__/session-services.test.ts`** — regression test asserting `session.create` no longer double-composes via `refreshModelClient`.

## Validation

- `npx vitest run src/core/services src/core/registry src/core/__tests__/session-overhead.perf.test.ts` → **219 passed**
- `npx eslint src/core/services/session-services.ts` → 0 errors

## Follow-ups (not in this PR)

Higher-effort/higher-risk options left for triage: optimistic thread render (show the empty thread immediately, resolve the session in the background), lazy agent init on first message, returning `activeCount`/`canCreateSession` in the `session.create` response to drop a round trip, and making `session-overhead.perf.test.ts` drive the real path instead of mocking `initialize()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)