### PR TITLE
WORKXOS-10 Missing OpenAI account connection in model config

### DIFF
--- a/src/webfront/settings/ModelSettings.svelte
+++ b/src/webfront/settings/ModelSettings.svelte
@@ -990,7 +990,7 @@
     </div>
 
     <!-- ChatGPT OAuth Section (OpenAI only, direct API mode) -->
-    {#if currentProvider === 'openai' && useOwnApiKey}
+    {#if currentProvider === 'openai' && (!isUserLoggedIn || useOwnApiKey)}
       <div class="form-group chatgpt-oauth-section">
         <label class="form-label">{t("ChatGPT Subscription")}</label>
         {#if chatgptOAuthConnected}


### PR DESCRIPTION
## Summary

The "connect your OpenAI account" option — **Sign in with ChatGPT** to use a ChatGPT Plus/Pro subscription instead of an API key — had disappeared from the model config (Settings → Model). This restores it.

Root cause: the ChatGPT OAuth section in `ModelSettings.svelte` was gated on

```
{#if currentProvider === 'openai' && useOwnApiKey}
```

`useOwnApiKey` defaults to `false`, and its toggle only renders for logged-in AI Republic users. So the section was:

- **invisible to non-logged-in OSS users** entirely (no toggle exists to flip `useOwnApiKey`), and
- **hidden for logged-in users** in the default **Backend Mode** (`useOwnApiKey = false`).

## Fix

Align the gate with the "direct / bring-your-own-credentials mode" idiom already used elsewhere in the same component (e.g. the *Remove API Key* button at line ~1227):

```
{#if currentProvider === 'openai' && (!isUserLoggedIn || useOwnApiKey)}
```

Now the section shows whenever the user is **not** routing through the AI Republic backend — i.e. non-logged-in users, and logged-in users who turned on *Use Own API Key*. It intentionally stays hidden in Backend Mode, since a personal ChatGPT subscription token isn't used when LLM traffic routes through the AI Republic gateway (that would be a separate product decision).

The OAuth handlers (`handleChatGPTSignIn` / `handleChatGPTDisconnect` / `checkChatGPTOAuthStatus`) already work independently of AI Republic login — extension goes through `ChatGPTOAuthService`, desktop through the `auth.chatgpt.*` runtime services — so showing the section to non-logged-in users is fully functional.

## Validation

- `npm run type-check` (tsc --noEmit) passes.
- Condition reasoning: true for non-logged-in (`!isUserLoggedIn`) and BYOK (`useOwnApiKey`) users; false in logged-in Backend Mode.

Pi Dash issue: WORKXOS-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
