### PR TITLE
Hide empty chat drafts from history

### DIFF
--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -2853,6 +2853,11 @@ export class Session {
     input: InputItem[],
     clientMessageId?: string,
   ): Promise<void> {
+    // Capture the writer used by the commit below. Session initialization may
+    // intentionally degrade to memory-only operation when rollout storage is
+    // unavailable; that path must not publish an index row as durable history.
+    const durableRollout = this.services?.rollout;
+
     // One accepted submission becomes one durable user item. Preserve typed
     // multimodal content; JSON-stringifying each InputItem created phantom
     // messages and forced every display consumer to reverse-parse storage.
@@ -2880,10 +2885,12 @@ export class Session {
     // Empty sessions are drafts, not history. Publish only after the exact
     // user item above is durable; publication failure must not turn that
     // already-persisted message into a failed model submission.
-    try {
-      await this.services?.onUserMessagePersisted?.(this.sessionId);
-    } catch (error) {
-      console.warn('[Session] Failed to publish persisted conversation:', error);
+    if (durableRollout) {
+      try {
+        await this.services?.onUserMessagePersisted?.(this.sessionId);
+      } catch (error) {
+        console.warn('[Session] Failed to publish persisted conversation:', error);
+      }
     }
 
     // Title generation is NOT triggered here: it runs exclusively from the

--- a/src/core/Session.ts
+++ b/src/core/Session.ts
@@ -2877,6 +2877,15 @@ export class Session {
     // Record to SessionState history
     await this.recordConversationItemsDual(responseItems, { requireDurable: true });
 
+    // Empty sessions are drafts, not history. Publish only after the exact
+    // user item above is durable; publication failure must not turn that
+    // already-persisted message into a failed model submission.
+    try {
+      await this.services?.onUserMessagePersisted?.(this.sessionId);
+    } catch (error) {
+      console.warn('[Session] Failed to publish persisted conversation:', error);
+    }
+
     // Title generation is NOT triggered here: it runs exclusively from the
     // TaskRunner completion checkpoint (maybeGenerateTitle), after the AI
     // response has landed. The typed response_item above is the sole durable

--- a/src/core/__tests__/Session.test.ts
+++ b/src/core/__tests__/Session.test.ts
@@ -366,6 +366,21 @@ describe('Session', () => {
       expect(onUserMessagePersisted).not.toHaveBeenCalled();
     });
 
+    it('does not publish memory-only input when rollout storage is unavailable', async () => {
+      const onUserMessagePersisted = vi.fn().mockResolvedValue(undefined);
+      const typed = new Session(undefined, false, makeMockServices({
+        rollout: null,
+        onUserMessagePersisted,
+      }));
+
+      await typed.recordInputAndRolloutUsermsg([
+        { type: 'text', text: 'memory only' },
+      ], 'client-memory-only');
+
+      expect(typed.getConversationHistory().items).toHaveLength(1);
+      expect(onUserMessagePersisted).not.toHaveBeenCalled();
+    });
+
     describe('getMessageCount()', () => {
       it('should reflect the number of history items', async () => {
         expect(session.getMessageCount()).toBe(0);

--- a/src/core/__tests__/Session.test.ts
+++ b/src/core/__tests__/Session.test.ts
@@ -324,8 +324,10 @@ describe('Session', () => {
 
     it('records one typed multimodal user item with the stable client id', async () => {
       const recordItems = vi.fn().mockResolvedValue(undefined);
+      const onUserMessagePersisted = vi.fn().mockResolvedValue(undefined);
       const typed = new Session(undefined, false, makeMockServices({
         rollout: { recordItems } as any,
+        onUserMessagePersisted,
       }));
       await typed.recordInputAndRolloutUsermsg([
         { type: 'text', text: 'hello' },
@@ -344,19 +346,24 @@ describe('Session', () => {
         ],
       });
       expect(JSON.stringify(history)).not.toContain('"type":"text","text"');
+      expect(onUserMessagePersisted).toHaveBeenCalledOnce();
+      expect(onUserMessagePersisted).toHaveBeenCalledWith(typed.sessionId);
     });
 
     it('does not expose accepted input in memory when its durable write fails', async () => {
+      const onUserMessagePersisted = vi.fn().mockResolvedValue(undefined);
       const typed = new Session(undefined, false, makeMockServices({
         rollout: {
           recordItems: vi.fn().mockRejectedValue(new Error('storage unavailable')),
         } as any,
+        onUserMessagePersisted,
       }));
 
       await expect(typed.recordInputAndRolloutUsermsg([
         { type: 'text', text: 'do not become a phantom' },
       ], 'client-failed')).rejects.toThrow('storage unavailable');
       expect(typed.getConversationHistory().items).toEqual([]);
+      expect(onUserMessagePersisted).not.toHaveBeenCalled();
     });
 
     describe('getMessageCount()', () => {

--- a/src/core/registry/SessionManager.ts
+++ b/src/core/registry/SessionManager.ts
@@ -149,6 +149,7 @@ export class SessionManager {
   private readonly _surfaceLeases: SurfaceLeaseStore;
   private readonly _eventStreams = new Map<string, SwitchableEventGate>();
   private readonly _sessionOperations = new PerKeyOperationQueue();
+  private readonly _draftOpenOperations = new PerKeyOperationQueue();
   private readonly _submissionEnqueueOperations = new PerKeyOperationQueue();
   private readonly _capacityOperations = new PerKeyOperationQueue();
   private readonly _capacityReservations = new Map<string, { replacing?: string }>();
@@ -189,6 +190,9 @@ export class SessionManager {
   }>();
   private _threadIndexReconcileFlight: Promise<void> | null = null;
   private _threadIndexReconciled = false;
+  private readonly _pendingThreadPublications = new Set<string>();
+  private _draftPublicationRepairFlight: Promise<void> | null = null;
+  private _draftPublicationRepairCompleted = false;
 
   /**
    * Create a new SessionManager
@@ -589,11 +593,25 @@ export class SessionManager {
     agentMode?: import('../../prompts/PromptComposer').AgentMode;
     origin?: ThreadIndexEntry['origin'];
     publishedAt?: number | null;
+    surfaceId?: string;
   } = {}): Promise<{
     sessionId: string;
     state: 'SUSPENDED' | 'IDLE';
     entry?: ThreadIndexEntry;
   }> {
+    if (
+      !options.sessionId
+      && options.surfaceId
+      && options.origin === undefined
+      && options.publishedAt === undefined
+      && this.lifecycleMode === 'client'
+      && this._registryConfig.threadIndexStore
+    ) {
+      return this._draftOpenOperations.run(
+        'user-facing-draft',
+        () => this.openOrReuseSurfaceDraft(options.surfaceId!, options),
+      );
+    }
     const sessionId = options.sessionId ?? uuidv4();
     const existing = this._indexOpenFlights.get(sessionId);
     if (existing) return existing;
@@ -632,6 +650,66 @@ export class SessionManager {
     };
     void flight.then(clearFlight, clearFlight);
     return flight;
+  }
+
+  private async openOrReuseSurfaceDraft(
+    surfaceId: string,
+    options: {
+      title?: string;
+      agentMode?: import('../../prompts/PromptComposer').AgentMode;
+      surfaceId?: string;
+    },
+  ): Promise<{
+    sessionId: string;
+    state: 'SUSPENDED' | 'IDLE';
+    entry?: ThreadIndexEntry;
+  }> {
+    const index = this._registryConfig.threadIndexStore!;
+    const loadSnapshot = this._registryConfig.loadRolloutSnapshot
+      ?? this._registryConfig.loadModelContextSnapshot;
+    let reusableSessionId: string | undefined;
+    if (loadSnapshot) {
+      const currentLease = this._surfaceLeases.forSurface(surfaceId);
+      const drafts = await index.listDrafts();
+      drafts.sort((left, right) => (
+        Number(right.sessionId === currentLease?.sessionId)
+        - Number(left.sessionId === currentLease?.sessionId)
+      ) || right.lastActiveAt - left.lastActiveAt || left.sessionId.localeCompare(right.sessionId));
+      for (const draft of drafts) {
+        if (this._sessions.has(draft.sessionId)) continue;
+        const claimedByAnotherSurface = this._surfaceLeases
+          .activeForSession(draft.sessionId)
+          .some((lease) => lease.surfaceId !== surfaceId);
+        if (claimedByAnotherSurface) continue;
+        try {
+          const status = await this._sessionOperations.run(
+            draft.sessionId,
+            () => this.recoverDraftPublicationLocked(
+              draft.sessionId,
+              this._pendingThreadPublications.has(draft.sessionId),
+            ),
+          );
+          if (status === 'not-durable') {
+            reusableSessionId = draft.sessionId;
+            break;
+          }
+        } catch (error) {
+          // A draft cannot be proven empty while its rollout read is failing.
+          console.warn(
+            `[SessionManager] Skipping unverifiable draft ${draft.sessionId}:`,
+            error,
+          );
+        }
+      }
+    }
+    const opened = await this.openSession({
+      ...options,
+      sessionId: reusableSessionId ?? uuidv4(),
+    });
+    // Reserve the returned draft immediately so concurrent surfaces cannot
+    // reuse it before the caller completes its normal setViewed/attach flow.
+    await this._surfaceLeases.setViewed(surfaceId, opened.sessionId);
+    return opened;
   }
 
   hydrateSession(sessionId: string): Promise<AgentSession> {
@@ -1281,6 +1359,14 @@ export class SessionManager {
         console.warn(`[SessionManager] Deferred config impact failed for ${sessionId}:`, error);
       });
       await this.applyPendingModeLocked(sessionId, session);
+      if (this._pendingThreadPublications.has(sessionId)) {
+        try {
+          await this.publishThreadLocked(sessionId);
+          this._pendingThreadPublications.delete(sessionId);
+        } catch (error) {
+          console.warn(`[SessionManager] Draft publication retry failed for ${sessionId}:`, error);
+        }
+      }
     }
     this.transitionRuntime(sessionId, busy ? 'running' : 'idle');
     return !busy;
@@ -1437,15 +1523,27 @@ export class SessionManager {
   }
 
   private publishThread(sessionId: string): Promise<void> {
-    return this._sessionOperations.run(sessionId, async () => {
-      const index = this._registryConfig.threadIndexStore;
-      if (!index) return;
-      const current = await index.get(sessionId, true);
-      if (!current || current.deletedAt !== null || current.publishedAt !== null) return;
-      const now = Date.now();
-      const entry = await index.patch(sessionId, { publishedAt: now, lastActiveAt: now });
-      this.emitIndexChanged(sessionId, 'upsert', entry);
-    });
+    const publication = this._sessionOperations.run(
+      sessionId,
+      () => this.publishThreadLocked(sessionId),
+    );
+    return publication.then(
+      () => { this._pendingThreadPublications.delete(sessionId); },
+      (error) => {
+        this._pendingThreadPublications.add(sessionId);
+        throw error;
+      },
+    );
+  }
+
+  private async publishThreadLocked(sessionId: string): Promise<void> {
+    const index = this._registryConfig.threadIndexStore;
+    if (!index) return;
+    const current = await index.get(sessionId, true);
+    if (!current || current.deletedAt !== null || current.publishedAt !== null) return;
+    const now = Date.now();
+    const entry = await index.patch(sessionId, { publishedAt: now, lastActiveAt: now });
+    this.emitIndexChanged(sessionId, 'upsert', entry);
   }
 
   async listThreads(request: ThreadListRequest = {}) {
@@ -1453,6 +1551,7 @@ export class SessionManager {
       return { entries: [], nextCursor: null };
     }
     await this.ensureThreadIndexReconciled();
+    if (!(request.includeDrafts ?? false)) await this.reconcileDraftPublications();
     const page = await this._registryConfig.threadIndexStore.list(request);
     return {
       ...page,
@@ -1464,6 +1563,86 @@ export class SessionManager {
         };
       }),
     };
+  }
+
+  /**
+   * Repair drafts whose durable user item outlived a publication failure.
+   * The first user-facing list performs one startup scan; later scans are
+   * limited to publication attempts known to have failed in this process.
+   */
+  private reconcileDraftPublications(): Promise<void> {
+    const index = this._registryConfig.threadIndexStore;
+    if (!index || (
+      this._draftPublicationRepairCompleted
+      && this._pendingThreadPublications.size === 0
+    )) return Promise.resolve();
+    if (this._draftPublicationRepairFlight) return this._draftPublicationRepairFlight;
+
+    const scanAllDrafts = !this._draftPublicationRepairCompleted;
+    const flight = (async () => {
+      const candidates = new Set(this._pendingThreadPublications);
+      if (scanAllDrafts) {
+        for (const entry of await index.listDrafts()) candidates.add(entry.sessionId);
+      }
+      await Promise.all([...candidates].map((sessionId) => this._sessionOperations.run(
+        sessionId,
+        async () => {
+          const expectedDurable = this._pendingThreadPublications.has(sessionId);
+          try {
+            const status = await this.recoverDraftPublicationLocked(
+              sessionId,
+              expectedDurable,
+            );
+            if (status !== 'retry') this._pendingThreadPublications.delete(sessionId);
+          } catch (error) {
+            this._pendingThreadPublications.add(sessionId);
+            console.warn(
+              `[SessionManager] Failed to reconcile draft publication for ${sessionId}:`,
+              error,
+            );
+          }
+        },
+      )));
+      if (scanAllDrafts) this._draftPublicationRepairCompleted = true;
+    })().catch((error) => {
+      // History listing remains available while a best-effort recovery scan
+      // retries on the next request.
+      console.warn('[SessionManager] Failed to scan unpublished drafts:', error);
+    }).finally(() => {
+      if (this._draftPublicationRepairFlight === flight) {
+        this._draftPublicationRepairFlight = null;
+      }
+    });
+    this._draftPublicationRepairFlight = flight;
+    return flight;
+  }
+
+  private async recoverDraftPublicationLocked(
+    sessionId: string,
+    expectedDurable: boolean,
+  ): Promise<'published' | 'not-needed' | 'not-durable' | 'retry'> {
+    const index = this._registryConfig.threadIndexStore;
+    if (!index) return 'not-needed';
+    const current = await index.get(sessionId, true);
+    if (!current || current.deletedAt !== null || current.publishedAt !== null) {
+      return 'not-needed';
+    }
+    const loadSnapshot = this._registryConfig.loadRolloutSnapshot
+      ?? this._registryConfig.loadModelContextSnapshot;
+    if (!loadSnapshot) return expectedDurable ? 'retry' : 'not-durable';
+    const snapshot = await loadSnapshot(sessionId);
+    if (!containsDurableUserMessage(snapshot.items)) {
+      // A just-written rollout snapshot may remain cached until the terminal
+      // turn boundary invalidates it, so known failures stay queued.
+      return expectedDurable ? 'retry' : 'not-durable';
+    }
+    const now = Date.now();
+    const entry = await index.patch(sessionId, {
+      publishedAt: now,
+      lastActiveAt: Math.max(current.lastActiveAt, now),
+    });
+    this.emitIndexChanged(sessionId, 'upsert', entry);
+    return 'published';
   }
 
   private ensureThreadIndexReconciled(): Promise<void> {
@@ -2510,6 +2689,8 @@ export class SessionManager {
     this._deletionClaims.clear();
     this._forceSuspendClaims.clear();
     this._recoveryLoaded.clear();
+    this._pendingThreadPublications.clear();
+    this._draftPublicationRepairCompleted = false;
     for (const stream of this._eventStreams.values()) stream.close();
     this._eventStreams.clear();
     this._usedLetters.clear();

--- a/src/core/registry/SessionManager.ts
+++ b/src/core/registry/SessionManager.ts
@@ -405,6 +405,7 @@ export class SessionManager {
       const services = {
         ...baseServices,
         onBackgroundWorkChanged: (sessionId: string) => this.handleBackgroundWorkChanged(sessionId),
+        onUserMessagePersisted: (sessionId: string) => this.publishThread(sessionId),
         onDurabilityChanged: (
           sessionId: string,
           durability: 'ok' | 'degraded',
@@ -468,6 +469,7 @@ export class SessionManager {
           origin: sessionConfig.fork
             ? { kind: 'fork', sourceSessionId: sessionConfig.fork.sourceConversationId }
             : { kind: 'new' },
+          publishedAt: initialHistory.mode === 'new' ? null : Date.now(),
         }),
       );
 
@@ -586,6 +588,7 @@ export class SessionManager {
     title?: string;
     agentMode?: import('../../prompts/PromptComposer').AgentMode;
     origin?: ThreadIndexEntry['origin'];
+    publishedAt?: number | null;
   } = {}): Promise<{
     sessionId: string;
     state: 'SUSPENDED' | 'IDLE';
@@ -611,6 +614,9 @@ export class SessionManager {
             options.agentMode ?? this._config?.getConfig().preferences?.defaultMode,
           ),
           origin: options.origin,
+          publishedAt: options.publishedAt === undefined
+            ? options.origin?.kind === 'fork' ? Date.now() : null
+            : options.publishedAt,
         }),
       ).then((entry) => {
         this.transitionRuntime(sessionId, 'suspended', 'opened');
@@ -692,6 +698,16 @@ export class SessionManager {
           ? await this._registryConfig.loadRolloutSnapshot(sessionId)
           : { sessionId, revision: 0, items: [] };
       const items = structuredClone(snapshot.items) as unknown[];
+      // A prior publication write may have failed after the user item became
+      // durable. Repair that narrow split-brain on the next hydration.
+      if (entry?.publishedAt === null && containsDurableUserMessage(items)) {
+        const now = Date.now();
+        entry = await this._registryConfig.threadIndexStore!.patch(sessionId, {
+          publishedAt: now,
+          lastActiveAt: Math.max(entry.lastActiveAt, now),
+        });
+        this.emitIndexChanged(sessionId, 'upsert', entry);
+      }
       failureCode = 'assembly';
       let session: AgentSession;
       if (entry?.origin.kind === 'fork') {
@@ -1420,6 +1436,18 @@ export class SessionManager {
     }
   }
 
+  private publishThread(sessionId: string): Promise<void> {
+    return this._sessionOperations.run(sessionId, async () => {
+      const index = this._registryConfig.threadIndexStore;
+      if (!index) return;
+      const current = await index.get(sessionId, true);
+      if (!current || current.deletedAt !== null || current.publishedAt !== null) return;
+      const now = Date.now();
+      const entry = await index.patch(sessionId, { publishedAt: now, lastActiveAt: now });
+      this.emitIndexChanged(sessionId, 'upsert', entry);
+    });
+  }
+
   async listThreads(request: ThreadListRequest = {}) {
     if (!this._registryConfig.threadIndexStore) {
       return { entries: [], nextCursor: null };
@@ -1766,7 +1794,10 @@ export class SessionManager {
       }
     }
     if (this._registryConfig.threadIndexStore) {
-      const newest = await this._registryConfig.threadIndexStore.list({ limit: 1 });
+      const newest = await this._registryConfig.threadIndexStore.list({
+        limit: 1,
+        includeDrafts: true,
+      });
       if (newest.entries[0]) return newest.entries[0].sessionId;
       return (await this.openSession()).sessionId;
     }
@@ -2499,6 +2530,18 @@ async function sha256(value: string): Promise<string> {
   return [...new Uint8Array(digest)]
     .map((byte) => byte.toString(16).padStart(2, '0'))
     .join('');
+}
+
+function containsDurableUserMessage(items: readonly unknown[]): boolean {
+  return items.some((item) => {
+    if (!item || typeof item !== 'object') return false;
+    const rolloutItem = item as { type?: unknown; payload?: unknown };
+    if (rolloutItem.type !== 'response_item'
+      || !rolloutItem.payload
+      || typeof rolloutItem.payload !== 'object') return false;
+    const responseItem = rolloutItem.payload as { type?: unknown; role?: unknown };
+    return responseItem.type === 'message' && responseItem.role === 'user';
+  });
 }
 
 class ManagedCapacityUnavailableError extends Error {

--- a/src/core/registry/SessionManager.ts
+++ b/src/core/registry/SessionManager.ts
@@ -622,6 +622,14 @@ export class SessionManager {
     state: 'SUSPENDED' | 'IDLE';
     entry?: ThreadIndexEntry;
   }> {
+    const configuredWorkingDirectory = this._config?.getConfig().preferences?.workspaceRoot?.trim();
+    const fallbackWorkingDirectory = this._registryConfig.defaultWorkingDirectory?.trim();
+    const selectedWorkingDirectory = options.workspace?.workingDirectory?.trim()
+      ?? configuredWorkingDirectory
+      ?? fallbackWorkingDirectory;
+    const workspace = isAbsoluteWorkingDirectory(selectedWorkingDirectory)
+      ? { workingDirectory: selectedWorkingDirectory }
+      : undefined;
     if (
       !options.sessionId
       && options.surfaceId
@@ -632,18 +640,13 @@ export class SessionManager {
     ) {
       return this._draftOpenOperations.run(
         'user-facing-draft',
-        () => this.openOrReuseSurfaceDraft(options.surfaceId!, options),
+        () => this.openOrReuseSurfaceDraft(options.surfaceId!, {
+          ...options,
+          ...(workspace ? { workspace } : {}),
+        }),
       );
     }
     const sessionId = options.sessionId ?? uuidv4();
-    const configuredWorkingDirectory = this._config?.getConfig().preferences?.workspaceRoot?.trim();
-    const fallbackWorkingDirectory = this._registryConfig.defaultWorkingDirectory?.trim();
-    const selectedWorkingDirectory = options.workspace?.workingDirectory?.trim()
-      ?? configuredWorkingDirectory
-      ?? fallbackWorkingDirectory;
-    const workspace = isAbsoluteWorkingDirectory(selectedWorkingDirectory)
-      ? { workingDirectory: selectedWorkingDirectory }
-      : undefined;
     const existing = this._indexOpenFlights.get(sessionId);
     if (existing) return existing;
     let flight: Promise<{
@@ -689,6 +692,7 @@ export class SessionManager {
     options: {
       title?: string;
       agentMode?: import('../../prompts/PromptComposer').AgentMode;
+      workspace?: import('../TurnExecutionContext').SessionWorkspace;
       surfaceId?: string;
     },
   ): Promise<{
@@ -708,6 +712,7 @@ export class SessionManager {
         - Number(left.sessionId === currentLease?.sessionId)
       ) || right.lastActiveAt - left.lastActiveAt || left.sessionId.localeCompare(right.sessionId));
       for (const draft of drafts) {
+        if (draft.workspace?.workingDirectory !== options.workspace?.workingDirectory) continue;
         if (this._sessions.has(draft.sessionId)) continue;
         const claimedByAnotherSurface = this._surfaceLeases
           .activeForSession(draft.sessionId)

--- a/src/core/registry/__tests__/SessionManager.lifecycle.test.ts
+++ b/src/core/registry/__tests__/SessionManager.lifecycle.test.ts
@@ -148,8 +148,48 @@ describe('SessionManager lifecycle manager', () => {
     expect(assembler.inputs).toHaveLength(0);
     expect(await registry.getThread('thread')).toMatchObject({
       title: 'Draft',
+      publishedAt: null,
       runtime: { state: 'suspended' },
     });
+    expect((await registry.listThreads()).entries).toEqual([]);
+  });
+
+  it('publishes a draft only after the session reports a durable user message', async () => {
+    await registry.openSession({ sessionId: 'publish-after-user-message' });
+    await registry.hydrateSession('publish-after-user-message');
+
+    expect((await registry.listThreads()).entries).toEqual([]);
+    await assembler.inputs[0]?.services.onUserMessagePersisted?.('publish-after-user-message');
+
+    expect((await registry.listThreads()).entries).toMatchObject([
+      { sessionId: 'publish-after-user-message', publishedAt: expect.any(Number) },
+    ]);
+  });
+
+  it('repairs a draft whose durable user message outlived a failed publication write', async () => {
+    await registry.openSession({ sessionId: 'publication-recovery' });
+    await registry.cleanup();
+    registry = new SessionManager({
+      lifecycleMode: 'client',
+      threadIndexStore: index,
+      agentAssembler: assembler,
+      assemblyServicesFactory: async () => ({} as never),
+      loadModelContextSnapshot: async (sessionId) => ({
+        sessionId,
+        revision: 1,
+        items: [{
+          type: 'response_item',
+          payload: { type: 'message', role: 'user', content: [] },
+        }],
+      }),
+    });
+    registry.initialize(agentConfig as never);
+
+    await registry.hydrateSession('publication-recovery');
+
+    expect((await registry.listThreads()).entries).toMatchObject([
+      { sessionId: 'publication-recovery', publishedAt: expect.any(Number) },
+    ]);
   });
 
   it('runs the lazy index reconciliation once before serving list pages', async () => {

--- a/src/core/registry/__tests__/SessionManager.lifecycle.test.ts
+++ b/src/core/registry/__tests__/SessionManager.lifecycle.test.ts
@@ -107,6 +107,24 @@ class FakeAssembler implements AgentAssembler {
   }
 }
 
+class FailOncePublicationAdapter extends MemoryStorageAdapter {
+  failPublicationWrites = 0;
+
+  override async put<T>(storeName: string, value: T): Promise<void> {
+    const publishedAt = (value as { publishedAt?: unknown }).publishedAt;
+    if (
+      storeName === 'thread_index'
+      && publishedAt !== null
+      && publishedAt !== undefined
+      && this.failPublicationWrites > 0
+    ) {
+      this.failPublicationWrites -= 1;
+      throw new Error('publication unavailable');
+    }
+    await super.put(storeName, value);
+  }
+}
+
 describe('SessionManager lifecycle manager', () => {
   let assembler: FakeAssembler;
   let index: ThreadIndexStore;
@@ -154,6 +172,23 @@ describe('SessionManager lifecycle manager', () => {
     expect((await registry.listThreads()).entries).toEqual([]);
   });
 
+  it('reuses an unclaimed empty draft without sharing it across surfaces', async () => {
+    const first = await registry.openSession({ surfaceId: 'surface-a' });
+    await index.createIfMissing((await import('../../thread/ThreadIndexStore')).createThreadIndexEntry({
+      sessionId: 'published-selection',
+    }));
+    await registry.setViewed('surface-a', 'published-selection');
+
+    const reused = await registry.openSession({ surfaceId: 'surface-a' });
+    const otherSurface = await registry.openSession({ surfaceId: 'surface-b' });
+
+    expect(reused.sessionId).toBe(first.sessionId);
+    expect(otherSurface.sessionId).not.toBe(first.sessionId);
+    expect((await index.listDrafts()).map((entry) => entry.sessionId).sort()).toEqual(
+      [first.sessionId, otherSurface.sessionId].sort(),
+    );
+  });
+
   it('publishes a draft only after the session reports a durable user message', async () => {
     await registry.openSession({ sessionId: 'publish-after-user-message' });
     await registry.hydrateSession('publish-after-user-message');
@@ -189,6 +224,47 @@ describe('SessionManager lifecycle manager', () => {
 
     expect((await registry.listThreads()).entries).toMatchObject([
       { sessionId: 'publication-recovery', publishedAt: expect.any(Number) },
+    ]);
+  });
+
+  it('recovers a failed publication through normal history listing while the graph is live', async () => {
+    await registry.cleanup();
+    const adapter = new FailOncePublicationAdapter();
+    let durableMessageAvailable = false;
+    index = new ThreadIndexStore(adapter);
+    registry = new SessionManager({
+      lifecycleMode: 'client',
+      threadIndexStore: index,
+      agentAssembler: assembler,
+      assemblyServicesFactory: async () => ({} as never),
+      loadRolloutSnapshot: async (sessionId) => ({
+        sessionId,
+        revision: durableMessageAvailable ? 1 : 0,
+        items: durableMessageAvailable
+          ? [{
+              type: 'response_item',
+              payload: { type: 'message', role: 'user', content: [] },
+            }]
+          : [],
+      }),
+    });
+    registry.initialize(agentConfig as never);
+
+    await registry.openSession({ sessionId: 'live-publication-recovery' });
+    const live = await registry.hydrateSession('live-publication-recovery');
+    durableMessageAvailable = true;
+    adapter.failPublicationWrites = 1;
+
+    await expect(
+      assembler.inputs[0]?.services.onUserMessagePersisted?.('live-publication-recovery'),
+    ).rejects.toThrow('publication unavailable');
+    expect(await index.require('live-publication-recovery')).toMatchObject({
+      publishedAt: null,
+    });
+    await expect(registry.hydrateSession('live-publication-recovery')).resolves.toBe(live);
+
+    expect((await registry.listThreads()).entries).toMatchObject([
+      { sessionId: 'live-publication-recovery', publishedAt: expect.any(Number) },
     ]);
   });
 

--- a/src/core/services/session-services.ts
+++ b/src/core/services/session-services.ts
@@ -273,7 +273,10 @@ export function createSessionServices(deps: SessionServiceDeps): Record<string, 
       }
 
       if (registry.openSession && registry.hydrateSession) {
-        await registry.openSession({ sessionId: rolloutData.sessionId });
+        await registry.openSession({
+          sessionId: rolloutData.sessionId,
+          publishedAt: Date.now(),
+        });
         const hydrated = await registry.hydrateSession(rolloutData.sessionId);
         const history = hydrated.agent?.getSession().getConversationHistory();
         return { sessionId: rolloutData.sessionId, history: history?.items ?? [] };

--- a/src/core/session/state/SessionServices.ts
+++ b/src/core/session/state/SessionServices.ts
@@ -95,6 +95,9 @@ export interface SessionServices {
   /** Internal lifecycle edge notification. Never sent over the wire. */
   onBackgroundWorkChanged?: (sessionId: string) => void | Promise<void>;
 
+  /** Publish an empty draft after its first user message is durably recorded. */
+  onUserMessagePersisted?: (sessionId: string) => void | Promise<void>;
+
   /**
    * Serialize a generated-title commit with the durable thread index. A false
    * result means a user rename won and the generated title must be discarded.
@@ -177,6 +180,7 @@ export async function createSessionServices(
     sessionCache: config.sessionCache,
     serverRootDir: config.serverRootDir,
     onBackgroundWorkChanged: config.onBackgroundWorkChanged,
+    onUserMessagePersisted: config.onUserMessagePersisted,
     commitGeneratedTitle: config.commitGeneratedTitle,
     onDurabilityChanged: config.onDurabilityChanged,
   };

--- a/src/core/thread/SessionDeletionCoordinator.ts
+++ b/src/core/thread/SessionDeletionCoordinator.ts
@@ -34,7 +34,12 @@ export class SessionDeletionCoordinator {
     let cursor: string | undefined;
     let purged = 0;
     do {
-      const page = await this.deps.index.list({ includeDeleted: true, limit: 100, cursor });
+      const page = await this.deps.index.list({
+        includeDeleted: true,
+        includeDrafts: true,
+        limit: 100,
+        cursor,
+      });
       const due = page.entries.filter((entry) => (
         entry.deletedAt !== null && entry.purgeAfter !== null && entry.purgeAfter <= now
       ));

--- a/src/core/thread/ThreadIndexStore.ts
+++ b/src/core/thread/ThreadIndexStore.ts
@@ -13,6 +13,8 @@ export interface ThreadIndexEntry {
   titleUpdatedAt: number;
   createdAt: number;
   lastActiveAt: number;
+  /** Null while the thread is an empty draft hidden from chat history. */
+  publishedAt: number | null;
   pinned: boolean;
   deletedAt: number | null;
   purgeAfter: number | null;
@@ -26,6 +28,8 @@ export interface ThreadIndexEntry {
 
 export interface ThreadListRequest {
   includeDeleted?: boolean;
+  /** Internal maintenance/routing read; user-facing history leaves this false. */
+  includeDrafts?: boolean;
   query?: string;
   limit?: number;
   cursor?: string;
@@ -40,6 +44,7 @@ interface ThreadCursor {
   v: 1;
   query: string;
   includeDeleted: boolean;
+  includeDrafts: boolean;
   pinned: boolean;
   lastActiveAt: number;
   sessionId: string;
@@ -69,6 +74,7 @@ export function createThreadIndexEntry(input: {
   now?: number;
   agentMode?: AgentMode;
   origin?: ThreadIndexEntry['origin'];
+  publishedAt?: number | null;
 }): ThreadIndexEntry {
   const now = input.now ?? Date.now();
   const title = input.title?.trim() ?? '';
@@ -80,6 +86,7 @@ export function createThreadIndexEntry(input: {
     titleUpdatedAt: now,
     createdAt: now,
     lastActiveAt: now,
+    publishedAt: input.publishedAt === undefined ? now : input.publishedAt,
     pinned: false,
     deletedAt: null,
     purgeAfter: null,
@@ -281,8 +288,13 @@ export class ThreadIndexStore {
     }
     const query = normalizeSearchTitle(request.query ?? '');
     const includeDeleted = request.includeDeleted ?? false;
+    const includeDrafts = request.includeDrafts ?? false;
     const cursor = request.cursor ? this.decodeCursor(request.cursor) : null;
-    if (cursor && (cursor.query !== query || cursor.includeDeleted !== includeDeleted)) {
+    if (cursor && (
+      cursor.query !== query
+      || cursor.includeDeleted !== includeDeleted
+      || cursor.includeDrafts !== includeDrafts
+    )) {
       throw new ThreadIndexError('INVALID_ARGUMENT', 'Cursor does not match the list request');
     }
 
@@ -297,6 +309,7 @@ export class ThreadIndexStore {
     }
     const rows = repaired
       .filter((entry) => includeDeleted || entry.deletedAt === null)
+      .filter((entry) => includeDrafts || entry.publishedAt !== null)
       .filter((entry) => !query || entry.searchTitle.includes(query))
       .sort(compareEntries);
     const cursorStart = cursor
@@ -313,6 +326,7 @@ export class ThreadIndexStore {
             v: 1,
             query,
             includeDeleted,
+            includeDrafts,
             pinned: last.pinned,
             lastActiveAt: last.lastActiveAt,
             sessionId: last.sessionId,
@@ -412,14 +426,19 @@ export class ThreadIndexStore {
 
   private repair(entry: ThreadIndexEntry): ThreadIndexEntry {
     const expected = normalizeSearchTitle(entry.title ?? '');
+    // Rows created before draft publication existed are real history entries.
+    // Treat them as published rather than hiding an existing user's history.
+    const publishedAt = entry.publishedAt === undefined ? entry.createdAt : entry.publishedAt;
     if (
       entry.searchTitle === expected
       && entry.schemaVersion === 1
+      && entry.publishedAt === publishedAt
       && (entry.historyMode === 'legacy' || entry.historyMode === 'paginated')
     ) return entry;
     return {
       ...entry,
       searchTitle: expected,
+      publishedAt,
       historyMode: entry.historyMode === 'paginated' ? 'paginated' : 'legacy',
       schemaVersion: 1,
     };
@@ -443,16 +462,17 @@ export class ThreadIndexStore {
       const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
       const binary = atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, '='));
       const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
-      const cursor = JSON.parse(new TextDecoder().decode(bytes)) as ThreadCursor;
+      const decoded = JSON.parse(new TextDecoder().decode(bytes)) as Partial<ThreadCursor>;
       if (
-        cursor.v !== 1
-        || typeof cursor.query !== 'string'
-        || typeof cursor.includeDeleted !== 'boolean'
-        || typeof cursor.pinned !== 'boolean'
-        || !Number.isFinite(cursor.lastActiveAt)
-        || typeof cursor.sessionId !== 'string'
+        decoded.v !== 1
+        || typeof decoded.query !== 'string'
+        || typeof decoded.includeDeleted !== 'boolean'
+        || (decoded.includeDrafts !== undefined && typeof decoded.includeDrafts !== 'boolean')
+        || typeof decoded.pinned !== 'boolean'
+        || !Number.isFinite(decoded.lastActiveAt)
+        || typeof decoded.sessionId !== 'string'
       ) throw new Error('invalid cursor');
-      return cursor;
+      return { ...decoded, includeDrafts: decoded.includeDrafts ?? false } as ThreadCursor;
     } catch {
       throw new ThreadIndexError('INVALID_ARGUMENT', 'Invalid list cursor');
     }

--- a/src/core/thread/ThreadIndexStore.ts
+++ b/src/core/thread/ThreadIndexStore.ts
@@ -298,15 +298,7 @@ export class ThreadIndexStore {
       throw new ThreadIndexError('INVALID_ARGUMENT', 'Cursor does not match the list request');
     }
 
-    const raw = await this.adapter.getAll<ThreadIndexEntry>(THREAD_INDEX_STORE);
-    const repaired = raw.map((entry) => this.repair(entry));
-    const repairs = repaired.filter((entry, index) => entry !== raw[index]);
-    if (repairs.length > 0) {
-      // Re-read and repair in the same per-session lane as every other write.
-      // Persisting the stale row returned by getAll() could otherwise overwrite
-      // a rename or activity update that completed while list() was running.
-      await Promise.all(repairs.map((entry) => this.repairStored(entry.sessionId)));
-    }
+    const repaired = await this.readAllRepaired();
     const rows = repaired
       .filter((entry) => includeDeleted || entry.deletedAt === null)
       .filter((entry) => includeDrafts || entry.publishedAt !== null)
@@ -333,6 +325,27 @@ export class ThreadIndexStore {
           })
         : null,
     };
+  }
+
+  /** Internal recovery read for unpublished, non-deleted drafts. */
+  async listDrafts(): Promise<ThreadIndexEntry[]> {
+    await this.initialize();
+    return (await this.readAllRepaired())
+      .filter((entry) => entry.deletedAt === null && entry.publishedAt === null)
+      .sort(compareEntries);
+  }
+
+  private async readAllRepaired(): Promise<ThreadIndexEntry[]> {
+    const raw = await this.adapter.getAll<ThreadIndexEntry>(THREAD_INDEX_STORE);
+    const repaired = raw.map((entry) => this.repair(entry));
+    const repairs = repaired.filter((entry, index) => entry !== raw[index]);
+    if (repairs.length > 0) {
+      // Re-read and repair in the same per-session lane as every other write.
+      // Persisting the stale row returned by getAll() could otherwise overwrite
+      // a rename or activity update that completed while list() was running.
+      await Promise.all(repairs.map((entry) => this.repairStored(entry.sessionId)));
+    }
+    return repaired;
   }
 
   private repairStored(sessionId: string): Promise<void> {

--- a/src/core/thread/__tests__/ThreadIndexStore.test.ts
+++ b/src/core/thread/__tests__/ThreadIndexStore.test.ts
@@ -14,8 +14,32 @@ describe('ThreadIndexStore', () => {
     expect(createThreadIndexEntry({ sessionId: 'new' }).historyMode).toBe('paginated');
     const legacy = { ...createThreadIndexEntry({ sessionId: 'legacy' }) };
     delete legacy.historyMode;
+    delete (legacy as Partial<typeof legacy>).publishedAt;
     await adapter.put('thread_index', legacy);
-    expect(await store.require('legacy')).toMatchObject({ historyMode: 'legacy' });
+    expect(await store.require('legacy')).toMatchObject({
+      historyMode: 'legacy',
+      publishedAt: legacy.createdAt,
+    });
+  });
+
+  it('keeps empty drafts addressable while excluding them from history pages', async () => {
+    const store = new ThreadIndexStore(new MemoryStorageAdapter(), () => 50);
+    await store.createIfMissing(createThreadIndexEntry({
+      sessionId: 'draft',
+      now: 10,
+      publishedAt: null,
+    }));
+
+    expect(await store.require('draft')).toMatchObject({ publishedAt: null });
+    expect((await store.list()).entries).toEqual([]);
+    expect((await store.list({ includeDrafts: true })).entries).toMatchObject([
+      { sessionId: 'draft', publishedAt: null },
+    ]);
+
+    await store.patch('draft', { publishedAt: 50 });
+    expect((await store.list()).entries).toMatchObject([
+      { sessionId: 'draft', publishedAt: 50 },
+    ]);
   });
 
   it('normalizes titles, preserves manual title precedence, and serializes mutations', async () => {

--- a/src/core/thread/__tests__/ThreadIndexStore.test.ts
+++ b/src/core/thread/__tests__/ThreadIndexStore.test.ts
@@ -42,6 +42,24 @@ describe('ThreadIndexStore', () => {
     ]);
   });
 
+  it('returns only non-deleted unpublished rows for internal recovery', async () => {
+    const store = new ThreadIndexStore(new MemoryStorageAdapter());
+    await store.createIfMissing(createThreadIndexEntry({
+      sessionId: 'draft',
+      publishedAt: null,
+    }));
+    await store.createIfMissing(createThreadIndexEntry({ sessionId: 'published' }));
+    await store.createIfMissing(createThreadIndexEntry({
+      sessionId: 'deleted-draft',
+      publishedAt: null,
+    }));
+    await store.softDelete('deleted-draft');
+
+    expect(await store.listDrafts()).toMatchObject([
+      { sessionId: 'draft', publishedAt: null, deletedAt: null },
+    ]);
+  });
+
   it('normalizes titles, preserves manual title precedence, and serializes mutations', async () => {
     let now = 100;
     const store = new ThreadIndexStore(new MemoryStorageAdapter(), () => ++now);

--- a/src/webfront/components/layout/ChatHistorySection.svelte
+++ b/src/webfront/components/layout/ChatHistorySection.svelte
@@ -95,11 +95,16 @@
   }
 
   async function newConversation(): Promise<void> {
+    const reusable = threadStore.reuseActiveEmptyDraft();
+    if (reusable) {
+      selectConversation(reusable.sessionId);
+      return;
+    }
     const client = await getInitializedUIClient();
     const response = await client.serviceRequest<{
       sessionId: string;
       entry?: ThreadListItem;
-    }>('session.open', {});
+    }>('session.open', { surfaceId: documentSurfaceId });
     if (response.entry) threadStore.mergeThread(response.entry);
     else threadStore.createThread(response.sessionId);
     selectConversation(response.sessionId);

--- a/src/webfront/components/layout/ChatHistorySection.svelte
+++ b/src/webfront/components/layout/ChatHistorySection.svelte
@@ -16,12 +16,13 @@
   let listRequestId = 0;
   let undo: { sessionId: string; title: string } | null = $state(null);
   let currentTheme = $derived($uiTheme);
-  let attentionThreads = $derived($threadStore.threads.filter((thread) =>
+  let historyThreads = $derived($threadStore.threads.filter((thread) => thread.publishedAt !== null));
+  let attentionThreads = $derived(historyThreads.filter((thread) =>
     thread.runtime.awaitingInputCount > 0 || thread.attentionRequest,
   ));
 
   onMount(() => {
-    if ($threadStore.threads.length === 0) void loadPage(true);
+    if (historyThreads.length === 0) void loadPage(true);
     return () => {
       listRequestId += 1;
       if (searchTimer) clearTimeout(searchTimer);
@@ -206,9 +207,9 @@
 
   {#if error}
     <div class="px-2 py-1.5 text-xs text-chat-error dark:text-chat-error-dark" role="alert">{error}</div>
-  {:else if $threadStore.loading && $threadStore.threads.length === 0}
+  {:else if $threadStore.loading && historyThreads.length === 0}
     <div class="px-2 py-1.5 text-xs opacity-70">{$_t('Loading history...')}</div>
-  {:else if $threadStore.threads.length === 0}
+  {:else if historyThreads.length === 0}
     <div class="px-2 py-1.5 text-xs opacity-70">{$_t('No chat history yet')}</div>
   {:else}
     <div
@@ -216,7 +217,7 @@
       data-thread-history-list
       aria-label={$_t('Chat History')}
     >
-      {#each $threadStore.threads as item (item.sessionId)}
+      {#each historyThreads as item (item.sessionId)}
         {@const isActive = $threadStore.activeSessionId === item.sessionId}
         <div class="group flex items-center rounded-md transition-colors
           {currentTheme === 'modern'

--- a/src/webfront/components/layout/__tests__/ChatHistorySection.test.ts
+++ b/src/webfront/components/layout/__tests__/ChatHistorySection.test.ts
@@ -31,6 +31,7 @@ function item(index: number): ThreadListItem {
     titleUpdatedAt: index,
     createdAt: index,
     lastActiveAt: 100 - index,
+    publishedAt: index,
     pinned: false,
     deletedAt: null,
     purgeAfter: null,
@@ -81,6 +82,18 @@ describe('ChatHistorySection paging', () => {
       expect(search.classList.contains('placeholder:text-term-dim-green')).toBe(true);
       expect(loadMore.classList.contains('text-term-dim-green')).toBe(true);
     });
+  });
+
+  it('does not render an active empty draft as chat history', async () => {
+    const draft = { ...item(0), publishedAt: null };
+    threadStore.mergeThread(draft);
+    threadStore.setActiveThread(draft.sessionId);
+    mocks.serviceRequest.mockResolvedValue({ entries: [], nextCursor: null });
+
+    render(ChatHistorySection);
+
+    await screen.findByText('No chat history yet');
+    expect(screen.queryByText('Conversation 0')).toBeNull();
   });
 
   it('loads ten rows at a time inside a fixed-height scroll container', async () => {

--- a/src/webfront/components/layout/__tests__/ChatHistorySection.test.ts
+++ b/src/webfront/components/layout/__tests__/ChatHistorySection.test.ts
@@ -96,6 +96,23 @@ describe('ChatHistorySection paging', () => {
     expect(screen.queryByText('Conversation 0')).toBeNull();
   });
 
+  it('reuses the active empty draft when New Chat is clicked', async () => {
+    const draft = { ...item(0), publishedAt: null };
+    threadStore.mergeThread(draft);
+    threadStore.setActiveThread(draft.sessionId);
+    mocks.serviceRequest.mockResolvedValue({ entries: [], nextCursor: null });
+
+    render(ChatHistorySection);
+    await screen.findByText('No chat history yet');
+    mocks.serviceRequest.mockClear();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'New Chat' }));
+
+    expect(mocks.serviceRequest).not.toHaveBeenCalled();
+    expect(mocks.push).toHaveBeenCalledWith('/');
+    expect(threadStore.getActiveThread()?.sessionId).toBe(draft.sessionId);
+  });
+
   it('loads ten rows at a time inside a fixed-height scroll container', async () => {
     mocks.serviceRequest
       .mockResolvedValueOnce({ entries: Array.from({ length: 10 }, (_, index) => item(index)), nextCursor: 'page-2' })

--- a/src/webfront/components/layout/__tests__/SessionModeSwitch.test.ts
+++ b/src/webfront/components/layout/__tests__/SessionModeSwitch.test.ts
@@ -31,6 +31,7 @@ describe('SessionModeSwitch', () => {
       titleUpdatedAt: 1,
       createdAt: 1,
       lastActiveAt: 1,
+      publishedAt: 1,
       pinned: false,
       deletedAt: null,
       purgeAfter: null,

--- a/src/webfront/pages/chat/Main.svelte
+++ b/src/webfront/pages/chat/Main.svelte
@@ -1211,12 +1211,17 @@
   /** Create an index-only chat. No agent graph is assembled here. */
   async function createNewThread() {
     try {
+      const reusable = threadStore.reuseActiveEmptyDraft();
+      if (reusable) {
+        await switchToThread(reusable.sessionId);
+        return;
+      }
       const c = await getInitializedUIClient();
       const response = await c.serviceRequest<{
         sessionId: string;
         state: 'SUSPENDED' | 'IDLE';
         entry?: ThreadIndexEntry;
-      }>('session.open', {});
+      }>('session.open', { surfaceId });
       const { sessionId } = response;
       if (response.entry) threadStore.mergeThread(response.entry);
       else threadStore.createThread(sessionId);

--- a/src/webfront/stores/__tests__/threadStore.test.ts
+++ b/src/webfront/stores/__tests__/threadStore.test.ts
@@ -113,6 +113,23 @@ describe('canonical threadStore projection', () => {
     expect(get(threadStore).threads.map((row) => row.sessionId)).toEqual(['newer', 'older']);
   });
 
+  it('reuses an untouched active draft instead of creating another row', () => {
+    threadStore.mergeThread({ ...entry('draft', { publishedAt: null }), runtime });
+    threadStore.setActiveThread('draft');
+
+    expect(threadStore.reuseActiveEmptyDraft()).toMatchObject({
+      sessionId: 'draft',
+      publishedAt: null,
+      conversation: { inputText: '' },
+    });
+    expect(get(threadStore).threads).toHaveLength(1);
+
+    threadStore.patchConversation('draft', { inputText: 'keep this unsent text' });
+    expect(threadStore.reuseActiveEmptyDraft()).toBeNull();
+    threadStore.patchConversation('draft', { inputText: '', isProcessing: true });
+    expect(threadStore.reuseActiveEmptyDraft()).toBeNull();
+  });
+
   it('restores only a selection and waits for session.list to restore rows', async () => {
     storage.get.mockResolvedValue({
       activeSessionId: 'outside-first-page',

--- a/src/webfront/stores/__tests__/threadStore.test.ts
+++ b/src/webfront/stores/__tests__/threadStore.test.ts
@@ -29,6 +29,7 @@ function entry(sessionId: string, overrides: Partial<ThreadIndexEntry> = {}): Th
     titleUpdatedAt: 1,
     createdAt: 1,
     lastActiveAt: 1,
+    publishedAt: 1,
     pinned: false,
     deletedAt: null,
     purgeAfter: null,

--- a/src/webfront/stores/threadStore.ts
+++ b/src/webfront/stores/threadStore.ts
@@ -112,6 +112,7 @@ function placeholderEntry(sessionId: string, title = ''): ThreadIndexEntry {
     titleUpdatedAt: now,
     createdAt: now,
     lastActiveAt: now,
+    publishedAt: null,
     pinned: false,
     deletedAt: null,
     purgeAfter: null,

--- a/src/webfront/stores/threadStore.ts
+++ b/src/webfront/stores/threadStore.ts
@@ -239,6 +239,36 @@ function createThreadStore() {
       return state.threads.find((thread) => thread.sessionId === state.activeSessionId);
     },
 
+    /** Reuse the selected, untouched draft instead of storing another one. */
+    reuseActiveEmptyDraft(): SidePanelThread | null {
+      let reusable: SidePanelThread | null = null;
+      update((state) => {
+        const current = state.threads.find(
+          (thread) => thread.sessionId === state.activeSessionId,
+        );
+        if (
+          !current
+          || current.publishedAt !== null
+          || current.conversation.inputText.length > 0
+          || current.conversation.timeline.order.length > 0
+          || current.conversation.isProcessing
+          || current.pendingSubmissions.length > 0
+          || current.runtime.awaitingInputCount > 0
+        ) return state;
+        reusable = {
+          ...current,
+          conversation: { ...current.conversation, inputText: '' },
+        };
+        return {
+          ...state,
+          threads: state.threads.map((thread) => (
+            thread.sessionId === current.sessionId ? reusable! : thread
+          )),
+        };
+      });
+      return reusable;
+    },
+
     setActiveThread(sessionId: string): void {
       update((state) => ({ ...state, activeSessionId: sessionId }));
       void persistSelection();


### PR DESCRIPTION
## What changed

- Add an unpublished draft state to thread-index entries.
- Exclude empty drafts from normal chat-history pages and the history sidebar.
- Publish a conversation immediately after its first user message is durably recorded.
- Repair legacy rows as published and recover drafts whose durable message outlived a failed publication write.
- Keep drafts available to internal routing and deletion maintenance.

## Why

New sessions were written to the thread index and shown in Chat History before any conversation existed. This created empty, untitled history entries that were not meaningful to users.

The thread index is still needed for session routing, so this change separates internal draft storage from user-facing history visibility.

## User impact

Opening a new chat no longer adds an empty item to Chat History. The conversation appears after the first user message is safely persisted, even if the agent later fails or is interrupted.

## Validation

- `npm run type-check`
- Full `npx vitest run` suite
- Focused lifecycle/storage/UI suite: 196 tests passed
- ESLint on changed files: zero errors
- `git diff --check`
