### PR TITLE
WORKXOS-17 Move side panel toggle button to top-left window bar

### DIFF
--- a/src/webfront/pages/chat/Main.svelte
+++ b/src/webfront/pages/chat/Main.svelte
@@ -21,6 +21,9 @@
   import { welcomeAsciiLines } from '../../constants/welcomeAscii';
   // Platform store
   import { platform } from '../../stores/platformStore';
+  // Layout store — used to indent the status-line title clear of the
+  // narrow-mode menu button (rendered by AppShell) so they don't overlap.
+  import { isWideMode } from '../../stores/layoutStore';
   // Theme store
   import { uiTheme, themePreference, type UITheme } from '../../stores/themeStore';
   // Token usage visibility store
@@ -1577,7 +1580,10 @@
     <div class="flex flex-col flex-1 min-h-0 max-w-[1500px] mx-auto w-full">
         <!-- Status Line -->
         <div class="shrink-0 flex justify-between mb-2">
-          <div class="flex items-center space-x-2">
+          <!-- In narrow mode AppShell renders a floating menu button at the
+               top-left; pad the title so it sits to the right of that button
+               instead of underneath it. -->
+          <div class="flex items-center space-x-2 {!$isWideMode ? 'pl-10' : ''}">
             <TerminalMessage type="system" content={platform.platformName === 'extension' ? $_t("WorkX (Alpha)") : $_t("WorkX: Your personal AI (Alpha)")} />
             {#if zoomLevel !== 100}
               <button onclick={resetZoom} class="text-sm leading-relaxed font-[inherit] opacity-70 hover:opacity-100 cursor-pointer {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}" title="Reset zoom to 100%">


### PR DESCRIPTION
## Summary

In narrow-window mode, AppShell renders a floating hamburger button at the top-left that opens the left-panel drawer. On the chat page it overlapped the status-line title **"WorkX: Your personal AI (Alpha)"**.

The issue proposed two fixes. The preferred one — hosting the button in the OS window bar next to minimize/maximize/close — isn't feasible without a large cross-platform change: the app uses the **native** OS titlebar (no custom `decorations` in `tauri.conf.json`), so putting an HTML control among the native window buttons would require switching to custom window decorations + drag regions + macOS traffic-light insets. This PR implements the second proposed fix instead: **the button now sits to the left of the title, squeezing the title slightly right.**

## Change

- `src/webfront/pages/chat/Main.svelte`: pad the status-line title group (`pl-10`) only in narrow mode (`!$isWideMode`) so the title starts to the right of the always-present menu button rather than underneath it.

The AppShell menu button and drawer are untouched, so the menu stays globally available on every route (it's the only drawer opener on non-chat pages). Wide mode is unaffected — the padding is gated on `!$isWideMode`.

## Validation

- `npx eslint src/webfront/pages/chat/Main.svelte` — clean.
- Reasoned clearance: the button occupies x ≈ 8–44px; the padded title now starts at ≈ 56px (16px `p-4` + 40px `pl-10`), a ~12px gap.

Note: no running desktop/extension environment was available for a live screenshot; the change is a single Tailwind padding class gated on an existing layout store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
