### PR TITLE
Standardize desktop typography and spacing

### DIFF
--- a/src/desktop/ui/desktop.css
+++ b/src/desktop/ui/desktop.css
@@ -36,9 +36,10 @@ body.desktop-mode .desktop-titlebar {
 }
 
 body.desktop-mode .desktop-titlebar-title {
-  font-size: 0.875rem;
+  font-size: var(--text-sm);
+  line-height: var(--text-sm--line-height);
   color: #888;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 body.desktop-mode .desktop-titlebar-controls {
@@ -125,7 +126,8 @@ body.desktop-mode .desktop-statusbar {
   padding: 0 0.75rem;
   background: #1a1a1a;
   border-top: 1px solid #333;
-  font-size: 0.875rem;
+  font-size: var(--text-sm);
+  line-height: var(--text-sm--line-height);
   color: #666;
 }
 

--- a/src/extension/content/ui_effect/ControlButtons.svelte
+++ b/src/extension/content/ui_effect/ControlButtons.svelte
@@ -119,10 +119,14 @@
     padding: 12px 24px;
 
     /* Typography */
-    font-family: var(--font-chat);
-    font-size: var(--text-sm);
-    font-weight: var(--font-weight-semibold);
-    line-height: var(--leading-none);
+    font-family: var(
+      --font-chat,
+      ui-sans-serif, -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, 'Segoe UI', Roboto,
+      sans-serif
+    );
+    font-size: var(--text-sm, 0.875rem);
+    font-weight: var(--font-weight-semibold, 600);
+    line-height: var(--leading-none, 1);
     text-align: center;
 
     /* Visual appearance */

--- a/src/extension/content/ui_effect/ControlButtons.svelte
+++ b/src/extension/content/ui_effect/ControlButtons.svelte
@@ -119,10 +119,10 @@
     padding: 12px 24px;
 
     /* Typography */
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-    font-size: 14px;
-    font-weight: 600;
-    line-height: 1;
+    font-family: var(--font-chat);
+    font-size: var(--text-sm);
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--leading-none);
     text-align: center;
 
     /* Visual appearance */

--- a/src/extension/content/ui_effect/CursorAnimator.svelte
+++ b/src/extension/content/ui_effect/CursorAnimator.svelte
@@ -327,10 +327,14 @@
     border-radius: 12px; /* Capsule shape */
 
     /* Typography */
-    font-family: var(--font-chat);
-    font-size: var(--text-sm);
-    font-weight: var(--font-weight-semibold);
-    line-height: var(--leading-tight);
+    font-family: var(
+      --font-chat,
+      ui-sans-serif, -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, 'Segoe UI', Roboto,
+      sans-serif
+    );
+    font-size: var(--text-sm, 0.875rem);
+    font-weight: var(--font-weight-semibold, 600);
+    line-height: var(--leading-tight, 1.25);
     white-space: nowrap;
 
     /* Prevent drag/select */

--- a/src/extension/content/ui_effect/CursorAnimator.svelte
+++ b/src/extension/content/ui_effect/CursorAnimator.svelte
@@ -327,10 +327,10 @@
     border-radius: 12px; /* Capsule shape */
 
     /* Typography */
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-    font-size: 14px;
-    font-weight: 600;
-    line-height: 1.2;
+    font-family: var(--font-chat);
+    font-size: var(--text-sm);
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--leading-tight);
     white-space: nowrap;
 
     /* Prevent drag/select */

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -27,6 +27,10 @@
 
   --text-2xs: 0.625rem;
   --text-2xs--line-height: 1.4;
+  --text-ascii: 0.4rem;
+  --text-ascii--line-height: 1;
+  --text-code-inline: 0.875em;
+  --text-code-inline--line-height: inherit;
   --text-xs: 0.75rem;
   --text-xs--line-height: 1.4;
   --text-meta: 0.8125rem;

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -1,0 +1,91 @@
+/*
+ * Workx typography system
+ *
+ * The scale follows the compact desktop patterns used by ChatGPT and Claude:
+ * 13px metadata, 14px interface text, and 16px reading text. Keeping these as
+ * Tailwind theme tokens makes utility classes and legacy scoped CSS share one
+ * source of truth.
+ */
+@theme {
+  --font-sans:
+    ui-sans-serif, -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'SF Pro Display', system-ui,
+    'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  --font-chat:
+    ui-sans-serif, -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'SF Pro Display', system-ui,
+    'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  --font-mono:
+    ui-monospace, 'SFMono-Regular', 'SF Mono', Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
+  --font-terminal:
+    ui-monospace, 'SFMono-Regular', 'SF Mono', Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
+
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  --text-2xs: 0.625rem;
+  --text-2xs--line-height: 1.4;
+  --text-xs: 0.75rem;
+  --text-xs--line-height: 1.4;
+  --text-meta: 0.8125rem;
+  --text-meta--line-height: 1.4;
+  --text-sm: 0.875rem;
+  --text-sm--line-height: 1.4;
+  --text-base: 1rem;
+  --text-base--line-height: 1.5;
+  --text-lg: 1.125rem;
+  --text-lg--line-height: 1.4;
+  --text-xl: 1.25rem;
+  --text-xl--line-height: 1.3;
+  --text-2xl: 1.5rem;
+  --text-2xl--line-height: 1.25;
+  --text-3xl: 1.875rem;
+  --text-3xl--line-height: 1.2;
+  --text-4xl: 2.25rem;
+  --text-4xl--line-height: 1.15;
+
+  --leading-none: 1;
+  --leading-ui: 1.4;
+  --leading-tight: 1.25;
+  --leading-snug: 1.375;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.6;
+  --leading-loose: 1.75;
+
+  --tracking-normal: 0;
+  --tracking-wide: 0.025em;
+  --tracking-wider: 0.05em;
+  --tracking-widest: 0.1em;
+  --tracking-pin: 0.3em;
+}
+
+@layer base {
+  html {
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+    text-rendering: optimizeLegibility;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  body {
+    @apply font-chat text-sm;
+  }
+
+  button,
+  input,
+  select,
+  textarea {
+    font: inherit;
+    letter-spacing: inherit;
+  }
+
+  code,
+  kbd,
+  pre,
+  samp {
+    font-family: var(--font-mono);
+  }
+}

--- a/src/webfront/__tests__/typography.test.ts
+++ b/src/webfront/__tests__/typography.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+const srcRoot = resolve(__dirname, '../..');
+const typographyPath = join(srcRoot, 'styles/typography.css');
+
+function collectStyleFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return collectStyleFiles(path);
+    return path.endsWith('.css') || path.endsWith('.svelte') ? [path] : [];
+  });
+}
+
+describe('Workx typography system', () => {
+  it('defines the desktop typography scale as Tailwind theme tokens', () => {
+    const typography = readFileSync(typographyPath, 'utf8');
+
+    expect(typography).toContain('--font-chat:');
+    expect(typography).toContain("'SF Pro Text'");
+    expect(typography).toContain('--font-mono:');
+    expect(typography).toContain('--text-xs: 0.75rem;');
+    expect(typography).toContain('--text-meta: 0.8125rem;');
+    expect(typography).toContain('--text-meta--line-height: 1.4;');
+    expect(typography).toContain('--text-sm: 0.875rem;');
+    expect(typography).toContain('--text-base: 1rem;');
+    expect(typography).toContain('--text-sm--line-height: 1.4;');
+    expect(typography).toContain('--text-base--line-height: 1.5;');
+    expect(typography).toMatch(/body\s*{\s*@apply font-chat text-sm;/);
+  });
+
+  it('keeps component CSS on the shared theme instead of local typography values', () => {
+    const violations: string[] = [];
+    const rules = [
+      ['font size', /font-size\s*:\s*(?:\d|\.)/g],
+      ['line height', /(?<!-)line-height\s*:\s*(?:\d|\.)/g],
+      ['font weight', /font-weight\s*:\s*(?:[1-9]00|bold|normal)/g],
+      ['letter spacing', /letter-spacing\s*:\s*(?:-?\d|\.)/g],
+      [
+        'font family',
+        /font-family\s*:\s*(?:system-ui|-apple-system|ui-(?:mono|sans)space|['"]|monospace)/g,
+      ],
+    ] as const;
+
+    for (const file of collectStyleFiles(srcRoot)) {
+      if (file === typographyPath) continue;
+      const source = readFileSync(file, 'utf8');
+      for (const [label, pattern] of rules) {
+        if (pattern.test(source)) violations.push(`${relative(srcRoot, file)}: ${label}`);
+        pattern.lastIndex = 0;
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it('uses the reading scale in chat and the interface scale for metadata', () => {
+    const message = readFileSync(
+      join(srcRoot, 'webfront/components/event_display/MessageEvent.svelte'),
+      'utf8'
+    );
+    const input = readFileSync(join(srcRoot, 'webfront/components/MessageInput.svelte'), 'utf8');
+    const eventDisplay = readFileSync(
+      join(srcRoot, 'webfront/components/event_display/EventDisplay.svelte'),
+      'utf8'
+    );
+
+    expect(message).toMatch(/markdown-content[^"\n]*text-base/);
+    expect(input).toMatch(/terminal-textarea[^"\n]*text-base/);
+    expect(eventDisplay).toMatch(/flex items-center gap-2 mb-1 text-meta font-normal/);
+    expect(eventDisplay).not.toContain('text-xs italic');
+  });
+});

--- a/src/webfront/__tests__/typography.test.ts
+++ b/src/webfront/__tests__/typography.test.ts
@@ -5,6 +5,10 @@ import { join, relative, resolve } from 'node:path';
 const srcRoot = resolve(__dirname, '../..');
 const typographyPath = join(srcRoot, 'styles/typography.css');
 
+function readSource(relativePath: string): string {
+  return readFileSync(join(srcRoot, relativePath), 'utf8');
+}
+
 function collectStyleFiles(directory: string): string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const path = join(directory, entry.name);
@@ -73,19 +77,61 @@ describe('Workx typography system', () => {
   });
 
   it('uses the reading scale in chat and the interface scale for metadata', () => {
-    const message = readFileSync(
-      join(srcRoot, 'webfront/components/event_display/MessageEvent.svelte'),
-      'utf8'
-    );
-    const input = readFileSync(join(srcRoot, 'webfront/components/MessageInput.svelte'), 'utf8');
-    const eventDisplay = readFileSync(
-      join(srcRoot, 'webfront/components/event_display/EventDisplay.svelte'),
-      'utf8'
-    );
+    const message = readSource('webfront/components/event_display/MessageEvent.svelte');
+    const input = readSource('webfront/components/MessageInput.svelte');
+    const eventDisplay = readSource('webfront/components/event_display/EventDisplay.svelte');
 
     expect(message).toMatch(/markdown-content[^"\n]*text-base/);
     expect(input).toMatch(/terminal-textarea[^"\n]*text-base/);
     expect(eventDisplay).toMatch(/flex items-center gap-2 mb-1 text-meta font-normal/);
     expect(eventDisplay).not.toContain('text-xs italic');
+  });
+
+  it('does not shrink explicit action and form controls to microcopy sizes', () => {
+    const violations: string[] = [];
+    const interactiveTag = /<(button|input|select|textarea|label|a)\b[\s\S]*?>/g;
+    const microcopyUtility = /\btext-(?:2xs|xs)\b/;
+
+    for (const file of collectStyleFiles(join(srcRoot, 'webfront')).filter((path) =>
+      path.endsWith('.svelte')
+    )) {
+      const source = readFileSync(file, 'utf8');
+      for (const match of source.matchAll(interactiveTag)) {
+        if (microcopyUtility.test(match[0])) {
+          violations.push(`${relative(srcRoot, file)}: <${match[1]}> uses a microcopy size`);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps active timestamps and secondary facts on the 13px metadata role', () => {
+    const history = readSource('webfront/components/chat/ChatHistoryList.svelte');
+    const usage = readSource('webfront/components/usage/UsageList.svelte');
+    const jobItem = readSource('webfront/components/scheduler/SchedulerJobItem.svelte');
+    const jobDetail = readSource('webfront/components/scheduler/JobDetailModal.svelte');
+    const schedulerPopup = readSource('webfront/components/scheduler/SchedulerPopup.svelte');
+    const dataSources = readSource('webfront/settings/DataSourcesSettings.svelte');
+
+    expect(history.match(/shrink-0 text-meta font-normal opacity-70/g)).toHaveLength(5);
+    expect(usage).toMatch(/text-meta font-normal[\s\S]*?formatDate\(session\.lastTimestamp\)/);
+    expect(usage).toMatch(/text-meta font-normal[\s\S]*?session\.models\[0\]/);
+    expect(jobItem).toMatch(/mt-1 text-meta font-normal/);
+    expect(jobDetail.match(/items-center gap-2 text-meta font-normal/g)).toHaveLength(3);
+    expect(schedulerPopup.match(/gap-2 mb-2 text-meta font-normal/g)).toHaveLength(4);
+    expect(dataSources).toMatch(/\.timestamp,[\s\S]*?font-size: var\(--text-meta\);/);
+    expect(dataSources).toMatch(/\.revision-meta[\s\S]*?font-size: var\(--text-meta\);/);
+  });
+
+  it('keeps legacy scoped control CSS on the 14px interface role', () => {
+    const modelSettings = readSource('webfront/settings/ModelSettings.svelte');
+    const securitySettings = readSource('webfront/settings/SecuritySettings.svelte');
+    const backgroundTasks = readSource('webfront/components/BackgroundTasksBadge.svelte');
+
+    expect(modelSettings).toMatch(/\.btn-sm[\s\S]*?font-size: var\(--text-sm\);/);
+    expect(securitySettings).toMatch(/\.btn-action[\s\S]*?font-size: var\(--text-sm\);/);
+    expect(securitySettings).toMatch(/\.form-field label[\s\S]*?font-size: var\(--text-sm\);/);
+    expect(backgroundTasks).toMatch(/\.task-row[\s\S]*?font-size: var\(--text-sm\);/);
   });
 });

--- a/src/webfront/__tests__/typography.test.ts
+++ b/src/webfront/__tests__/typography.test.ts
@@ -23,6 +23,8 @@ describe('Workx typography system', () => {
     expect(typography).toContain('--text-xs: 0.75rem;');
     expect(typography).toContain('--text-meta: 0.8125rem;');
     expect(typography).toContain('--text-meta--line-height: 1.4;');
+    expect(typography).toContain('--text-code-inline: 0.875em;');
+    expect(typography).toContain('--text-code-inline--line-height: inherit;');
     expect(typography).toContain('--text-sm: 0.875rem;');
     expect(typography).toContain('--text-base: 1rem;');
     expect(typography).toContain('--text-sm--line-height: 1.4;');
@@ -34,6 +36,7 @@ describe('Workx typography system', () => {
     const violations: string[] = [];
     const rules = [
       ['font size', /font-size\s*:\s*(?:\d|\.)/g],
+      ['arbitrary font size utility', /text-\[(?:\d|\.)/g],
       ['line height', /(?<!-)line-height\s*:\s*(?:\d|\.)/g],
       ['font weight', /font-weight\s*:\s*(?:[1-9]00|bold|normal)/g],
       ['letter spacing', /letter-spacing\s*:\s*(?:-?\d|\.)/g],
@@ -53,6 +56,20 @@ describe('Workx typography system', () => {
     }
 
     expect(violations).toEqual([]);
+  });
+
+  it('provides local fallbacks for the isolated extension overlay', () => {
+    for (const relativePath of [
+      'extension/content/ui_effect/ControlButtons.svelte',
+      'extension/content/ui_effect/CursorAnimator.svelte',
+    ]) {
+      const source = readFileSync(join(srcRoot, relativePath), 'utf8');
+
+      expect(source).toContain('font-family: var(');
+      expect(source).toContain('--font-chat,');
+      expect(source).toContain('font-size: var(--text-sm, 0.875rem);');
+      expect(source).toContain('font-weight: var(--font-weight-semibold, 600);');
+    }
   });
 
   it('uses the reading scale in chat and the interface scale for metadata', () => {

--- a/src/webfront/components/BackgroundTaskPanel.svelte
+++ b/src/webfront/components/BackgroundTaskPanel.svelte
@@ -159,8 +159,8 @@
     padding: 8px 12px;
     background: var(--error-light, #fee2e2);
     color: var(--error-color, #b91c1c);
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
     border-bottom: 1px solid var(--border-color, #eee);
   }
   .failure-label {
@@ -183,8 +183,8 @@
     gap: 12px;
     padding: 6px 12px;
     color: var(--text-secondary, #888);
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
     border-bottom: 1px solid var(--border-color, #eee);
   }
   .chunks {

--- a/src/webfront/components/BackgroundTaskPanel.svelte
+++ b/src/webfront/components/BackgroundTaskPanel.svelte
@@ -132,7 +132,8 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    font-size: 13px;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     overflow: hidden;
   }
   .desc {
@@ -141,7 +142,8 @@
     white-space: nowrap;
   }
   .status {
-    font-size: 10px;
+    font-size: var(--text-2xs);
+    line-height: var(--text-2xs--line-height);
     text-transform: uppercase;
     padding: 1px 6px;
     border-radius: 4px;
@@ -157,11 +159,12 @@
     padding: 8px 12px;
     background: var(--error-light, #fee2e2);
     color: var(--error-color, #b91c1c);
-    font-size: 12px;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     border-bottom: 1px solid var(--border-color, #eee);
   }
   .failure-label {
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     flex-shrink: 0;
   }
   .failure-message {
@@ -170,8 +173,8 @@
   .close {
     background: transparent;
     border: none;
-    font-size: 20px;
-    line-height: 1;
+    font-size: var(--text-xl);
+    line-height: var(--leading-none);
     cursor: pointer;
     color: var(--text-secondary, #888);
   }
@@ -180,15 +183,17 @@
     gap: 12px;
     padding: 6px 12px;
     color: var(--text-secondary, #888);
-    font-size: 11px;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     border-bottom: 1px solid var(--border-color, #eee);
   }
   .chunks {
     flex: 1;
     overflow-y: auto;
     padding: 8px 12px;
-    font-family: monospace;
-    font-size: 12px;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
   }
   .chunk {
     margin-bottom: 8px;
@@ -201,7 +206,8 @@
   .chunk-stderr { color: var(--error-color, #b91c1c); }
   .chunk-kind {
     display: inline-block;
-    font-size: 9px;
+    font-size: var(--text-2xs);
+    line-height: var(--text-2xs--line-height);
     text-transform: uppercase;
     color: var(--text-secondary, #888);
     margin-right: 6px;

--- a/src/webfront/components/BackgroundTasksBadge.svelte
+++ b/src/webfront/components/BackgroundTasksBadge.svelte
@@ -117,7 +117,8 @@
     border: 1px solid var(--border-color, #ccc);
     background: var(--bg-secondary, #f5f5f5);
     color: var(--text-primary, #222);
-    font-size: 12px;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     cursor: pointer;
   }
   .badge-pill:hover,
@@ -157,7 +158,8 @@
     border: none;
     background: transparent;
     text-align: left;
-    font-size: 12px;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     cursor: pointer;
     color: inherit;
   }
@@ -165,7 +167,7 @@
     background: var(--bg-secondary, #f5f5f5);
   }
   .task-status {
-    font-family: monospace;
+    font-family: var(--font-mono);
   }
   .task-desc {
     overflow: hidden;
@@ -179,7 +181,8 @@
   .empty {
     padding: 12px;
     color: var(--text-secondary, #888);
-    font-size: 12px;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     text-align: center;
   }
 </style>

--- a/src/webfront/components/BackgroundTasksBadge.svelte
+++ b/src/webfront/components/BackgroundTasksBadge.svelte
@@ -117,8 +117,8 @@
     border: 1px solid var(--border-color, #ccc);
     background: var(--bg-secondary, #f5f5f5);
     color: var(--text-primary, #222);
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     cursor: pointer;
   }
   .badge-pill:hover,
@@ -158,8 +158,8 @@
     border: none;
     background: transparent;
     text-align: left;
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     cursor: pointer;
     color: inherit;
   }
@@ -176,13 +176,15 @@
   }
   .task-meta {
     color: var(--text-secondary, #888);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
     font-variant-numeric: tabular-nums;
   }
   .empty {
     padding: 12px;
     color: var(--text-secondary, #888);
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
     text-align: center;
   }
 </style>

--- a/src/webfront/components/MessageDisplay.svelte
+++ b/src/webfront/components/MessageDisplay.svelte
@@ -158,8 +158,8 @@
   class="px-4 py-3 my-2 rounded-lg transition-all duration-200 {roleBgClasses} {systemTextClasses} {textColorClasses}"
   class:streaming={isStreaming}
 >
-  <div class="flex justify-between mb-2 text-sm">
-    <span class="font-semibold {roleLabelClasses}">
+  <div class="flex justify-between mb-2 text-meta font-normal">
+    <span class="font-medium {roleLabelClasses}">
       {#if message.role === 'user'}
         {$_t("You")}
       {:else if message.role === 'assistant'}
@@ -267,29 +267,32 @@
   .content-text :global(h6) {
     margin-top: 1em;
     margin-bottom: 0.5em;
-    font-weight: 600;
-    line-height: 1.25;
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--leading-tight);
   }
 
   .content-text :global(h1) {
-    font-size: 1.5em;
+    font-size: var(--text-2xl);
+    line-height: var(--text-2xl--line-height);
     border-bottom: 1px solid #e0e0e0;
     padding-bottom: 0.3em;
   }
 
   .content-text :global(h2) {
-    font-size: 1.3em;
+    font-size: var(--text-xl);
+    line-height: var(--text-xl--line-height);
     border-bottom: 1px solid #e0e0e0;
     padding-bottom: 0.3em;
   }
 
   .content-text :global(h3) {
-    font-size: 1.15em;
+    font-size: var(--text-lg);
+    line-height: var(--text-lg--line-height);
   }
 
   .content-text :global(p) {
     margin: 0.5em 0;
-    line-height: 1.6;
+    line-height: var(--text-base--line-height);
   }
 
   .content-text :global(ul),
@@ -306,8 +309,9 @@
     background: rgba(0, 0, 0, 0.05);
     padding: 0.2em 0.4em;
     border-radius: 3px;
-    font-family: 'Monaco', 'Menlo', 'Courier New', monospace;
-    font-size: 0.9em;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     word-break: break-word;
   }
 
@@ -327,7 +331,8 @@
     background: transparent;
     padding: 0;
     color: inherit;
-    font-size: 0.9em;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     white-space: pre-wrap;
     word-break: break-all;
     overflow: visible;
@@ -341,7 +346,7 @@
   }
 
   .content-text :global(strong) {
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
   }
 
   .content-text :global(em) {
@@ -378,7 +383,7 @@
 
   .content-text :global(th) {
     background: #f5f5f5;
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
   }
 
   .content-text :global(img) {

--- a/src/webfront/components/MessageDisplay.svelte
+++ b/src/webfront/components/MessageDisplay.svelte
@@ -310,8 +310,8 @@
     padding: 0.2em 0.4em;
     border-radius: 3px;
     font-family: var(--font-mono);
-    font-size: var(--text-sm);
-    line-height: var(--text-sm--line-height);
+    font-size: var(--text-code-inline);
+    line-height: var(--text-code-inline--line-height);
     word-break: break-word;
   }
 

--- a/src/webfront/components/MessageInput.svelte
+++ b/src/webfront/components/MessageInput.svelte
@@ -623,7 +623,7 @@
         onfocus={() => isFocused = true}
         onblur={handleBlur}
         style="--textarea-py: {currentTheme === 'modern' ? '0.75rem' : '0.5rem'}"
-        class="terminal-textarea w-full bg-transparent border-none outline-none resize-none overflow-y-auto leading-relaxed text-sm
+        class="terminal-textarea w-full bg-transparent border-none outline-none resize-none overflow-y-auto text-base
           {currentTheme === 'modern'
             ? 'text-chat-text dark:text-chat-text-dark font-chat px-4 py-3 caret-chat-text dark:caret-white'
             : 'text-term-green font-terminal px-3 py-2'}"

--- a/src/webfront/components/MessageInput.svelte
+++ b/src/webfront/components/MessageInput.svelte
@@ -581,7 +581,7 @@
 
     <!-- Track 13: pasted-image attachment indicator -->
     {#if pendingAttachments.length > 0}
-      <div class="mb-1 flex items-center gap-2 text-xs {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
+      <div class="mb-1 flex items-center gap-2 text-meta font-normal {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
         <span>📎 {pendingAttachments.length} {pendingAttachments.length === 1 ? $_t('image attached') : $_t('images attached')}</span>
         <button
           type="button"
@@ -596,7 +596,7 @@
          Visible exactly when Tab will accept: palette closed AND input empty
          OR the typed text is a live prefix of the suggestion. -->
     {#if suggestion && !isCommandMode && (!value.trim() || suggestion.toLowerCase().startsWith(value.toLowerCase()))}
-      <div class="mb-1 flex items-center gap-2 text-xs {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
+      <div class="mb-1 flex items-center gap-2 text-meta font-normal {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
         <span class="opacity-70">Tab ↹</span>
         <span class="truncate">{suggestion}</span>
         <button

--- a/src/webfront/components/TerminalMessage.svelte
+++ b/src/webfront/components/TerminalMessage.svelte
@@ -27,6 +27,6 @@
     : (terminalColors[type] || terminalColors.default));
 </script>
 
-<div class="terminal-message {type} {$uiTheme} text-sm leading-relaxed font-[inherit] {colorClasses}" aria-live="polite" aria-atomic="true">
+<div class="terminal-message {type} {$uiTheme} text-sm leading-ui font-[inherit] {colorClasses}" aria-live="polite" aria-atomic="true">
   {content}
 </div>

--- a/src/webfront/components/chat/ChatHistoryList.svelte
+++ b/src/webfront/components/chat/ChatHistoryList.svelte
@@ -221,7 +221,7 @@
                 {currentTheme === 'modern'
                   ? 'text-chat-tooltip-text dark:text-chat-tooltip-text-dark font-chat'
                   : 'text-term-bright-green font-terminal'}">{getDisplayTitle(item)}</span>
-              <span class="shrink-0 text-sm opacity-70
+              <span class="shrink-0 text-meta font-normal opacity-70
                 {currentTheme === 'modern'
                   ? 'text-chat-text-secondary dark:text-chat-text-secondary-dark font-chat'
                   : 'text-term-dim-green font-terminal'}">{formatTimeAgo(item.lastActiveAt)}</span>
@@ -250,7 +250,7 @@
                 {currentTheme === 'modern'
                   ? 'text-chat-tooltip-text dark:text-chat-tooltip-text-dark font-chat'
                   : 'text-term-bright-green font-terminal'}">{getDisplayTitle(item)}</span>
-              <span class="shrink-0 text-sm opacity-70
+              <span class="shrink-0 text-meta font-normal opacity-70
                 {currentTheme === 'modern'
                   ? 'text-chat-text-secondary dark:text-chat-text-secondary-dark font-chat'
                   : 'text-term-dim-green font-terminal'}">{formatTimeAgo(item.lastActiveAt)}</span>
@@ -279,7 +279,7 @@
                 {currentTheme === 'modern'
                   ? 'text-chat-tooltip-text dark:text-chat-tooltip-text-dark font-chat'
                   : 'text-term-bright-green font-terminal'}">{getDisplayTitle(item)}</span>
-              <span class="shrink-0 text-sm opacity-70
+              <span class="shrink-0 text-meta font-normal opacity-70
                 {currentTheme === 'modern'
                   ? 'text-chat-text-secondary dark:text-chat-text-secondary-dark font-chat'
                   : 'text-term-dim-green font-terminal'}">{formatTimeAgo(item.lastActiveAt)}</span>
@@ -308,7 +308,7 @@
                 {currentTheme === 'modern'
                   ? 'text-chat-tooltip-text dark:text-chat-tooltip-text-dark font-chat'
                   : 'text-term-bright-green font-terminal'}">{getDisplayTitle(item)}</span>
-              <span class="shrink-0 text-sm opacity-70
+              <span class="shrink-0 text-meta font-normal opacity-70
                 {currentTheme === 'modern'
                   ? 'text-chat-text-secondary dark:text-chat-text-secondary-dark font-chat'
                   : 'text-term-dim-green font-terminal'}">{formatTimeAgo(item.lastActiveAt)}</span>
@@ -337,7 +337,7 @@
                 {currentTheme === 'modern'
                   ? 'text-chat-tooltip-text dark:text-chat-tooltip-text-dark font-chat'
                   : 'text-term-bright-green font-terminal'}">{getDisplayTitle(item)}</span>
-              <span class="shrink-0 text-sm opacity-70
+              <span class="shrink-0 text-meta font-normal opacity-70
                 {currentTheme === 'modern'
                   ? 'text-chat-text-secondary dark:text-chat-text-secondary-dark font-chat'
                   : 'text-term-dim-green font-terminal'}">{formatTimeAgo(item.lastActiveAt)}</span>

--- a/src/webfront/components/chat/ChatHistoryList.svelte
+++ b/src/webfront/components/chat/ChatHistoryList.svelte
@@ -164,7 +164,7 @@
 
 {#snippet runtimeBadge(item: ThreadListItem)}
   {#if item.runtime.awaitingInputCount > 0}
-    <span class="w-4 h-4 shrink-0 rounded-full inline-flex items-center justify-center bg-amber-400 text-black text-[10px] font-bold"
+    <span class="w-4 h-4 shrink-0 rounded-full inline-flex items-center justify-center bg-amber-400 text-black text-2xs font-bold"
       title={$_t('Waiting for your input')} aria-label={$_t('Waiting for your input')}>!</span>
   {:else}
     <span class="w-2 h-2 shrink-0 rounded-full

--- a/src/webfront/components/chat/MessageSelector.svelte
+++ b/src/webfront/components/chat/MessageSelector.svelte
@@ -171,7 +171,7 @@
               onclick={() => doRewind('conversation')}
             >
               <div class="font-medium">{$_t('Rewind conversation')}</div>
-              <div class="opacity-60 text-xs">{$_t('Fork a new branch from this turn. Everything after is dropped.')}</div>
+              <div class="opacity-60 text-meta font-normal">{$_t('Fork a new branch from this turn. Everything after is dropped.')}</div>
             </button>
             <button
               class="px-3 py-2 rounded text-left cursor-pointer border
@@ -179,7 +179,7 @@
               onclick={() => doRewind('summarize_up_to')}
             >
               <div class="font-medium">{$_t('Summarize earlier turns')}</div>
-              <div class="opacity-60 text-xs">{$_t('Replace everything up to this turn with a single summary.')}</div>
+              <div class="opacity-60 text-meta font-normal">{$_t('Replace everything up to this turn with a single summary.')}</div>
             </button>
             <button
               class="px-3 py-2 rounded text-left cursor-pointer opacity-70 hover:opacity-100"

--- a/src/webfront/components/common/ManagedBadge.svelte
+++ b/src/webfront/components/common/ManagedBadge.svelte
@@ -12,7 +12,7 @@
 
 {#if locked}
   <span
-    class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-800 align-middle"
+    class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 align-middle"
     title={tooltip}
     data-testid="managed-badge"
   >

--- a/src/webfront/components/common/TabContext.svelte
+++ b/src/webfront/components/common/TabContext.svelte
@@ -195,7 +195,7 @@
             <span class="inline-block max-w-full overflow-hidden text-ellipsis whitespace-nowrap">{displayTitle}</span>
           {/if}
           {#if clickable}
-            <span class="text-[10px] transition-transform duration-200 shrink-0 {isDropdownOpen ? 'rotate-180' : ''}
+            <span class="text-2xs transition-transform duration-200 shrink-0 {isDropdownOpen ? 'rotate-180' : ''}
               {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : ''}">▼</span>
           {/if}
         </div>

--- a/src/webfront/components/common/Tooltip.svelte
+++ b/src/webfront/components/common/Tooltip.svelte
@@ -155,8 +155,9 @@
     border: 1px solid #00cc00;
     border-radius: 4px;
     color: #00ff00;
-    font-family: 'Monaco', 'Courier New', monospace;
-    font-size: 14px;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
   }
 
@@ -190,8 +191,9 @@
     border: none;
     border-radius: 0.375rem;
     color: #ffffff;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    font-size: 14px;
+    font-family: var(--font-chat);
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   }
 

--- a/src/webfront/components/event_display/ApprovalEvent.svelte
+++ b/src/webfront/components/event_display/ApprovalEvent.svelte
@@ -280,11 +280,11 @@
             bind:value={planDraft}
             rows="12"
             spellcheck="false"
-            class="w-full px-2 py-1.5 bg-gray-800 border border-gray-600 rounded text-xs font-mono text-gray-200 focus:outline-none focus:border-indigo-500"
+            class="w-full px-2 py-1.5 bg-gray-800 border border-gray-600 rounded text-sm font-mono text-gray-200 focus:outline-none focus:border-indigo-500"
             disabled={processing}
           ></textarea>
           {#if planEditError}
-            <div class="text-red-400 text-xs">{planEditError}</div>
+            <div class="text-red-400 text-meta font-normal">{planEditError}</div>
           {/if}
           <div>
             <button

--- a/src/webfront/components/event_display/EventDisplay.svelte
+++ b/src/webfront/components/event_display/EventDisplay.svelte
@@ -155,25 +155,23 @@
   <!-- Simple left/right aligned messages with sender labels -->
   <div class={getContainerClasses()}>
     <!-- Header outside bubble for user messages in modern theme -->
-    <div class="flex items-center gap-2 mb-1 text-sm
+    <div class="flex items-center gap-2 mb-1 text-meta font-normal
       {event.title === 'user' ? 'justify-end gap-2' : ''}">
-      <span class="{currentTheme === 'modern'
+      <span class="font-medium {currentTheme === 'modern'
         ? (event.title === 'user'
-          ? 'font-medium text-chat-primary dark:text-chat-primary-dark'
-          : 'font-medium text-chat-text dark:text-chat-text-dark')
+          ? 'text-chat-primary dark:text-chat-primary-dark'
+          : 'text-chat-text dark:text-chat-text-dark')
         : (event.title === 'user'
-          ? 'font-semibold text-cyan-400'
-          : 'font-semibold text-violet-400')}">{event.title === 'user' ? t('You') : agentDisplayName}:</span>
+          ? 'text-cyan-400'
+          : 'text-violet-400')}">{event.title === 'user' ? t('You') : agentDisplayName}:</span>
       {#if event.title !== 'user' && event.modelKey}
-        <span class="text-sm italic
-          {currentTheme === 'modern'
-            ? 'text-chat-text-muted dark:text-chat-text-muted-dark'
-            : 'text-gray-500'}">{event.modelKey.includes(':') ? event.modelKey.split(':').slice(1).join(':') : event.modelKey}</span>
-      {/if}
-      <span class="text-sm
-        {currentTheme === 'modern'
+        <span class="{currentTheme === 'modern'
           ? 'text-chat-text-muted dark:text-chat-text-muted-dark'
-          : 'text-gray-400'}">{formatTime(event.timestamp, 'relative')}</span>
+          : 'text-gray-500'}">{event.modelKey.includes(':') ? event.modelKey.split(':').slice(1).join(':') : event.modelKey}</span>
+      {/if}
+      <span class="{currentTheme === 'modern'
+        ? 'text-chat-text-muted dark:text-chat-text-muted-dark'
+        : 'text-gray-400'}">{formatTime(event.timestamp, 'relative')}</span>
     </div>
     <div class="{event.title === 'user' ? 'w-fit max-w-[80%]' : 'w-full'}
       {currentTheme === 'modern' && event.title === 'user'
@@ -184,7 +182,7 @@
         : ''}">
         <MessageEvent {event} />
         {#if event.streaming}
-          <span class="text-cyan-400 text-sm animate-pulse ml-2" role="status" aria-live="polite">
+          <span class="text-cyan-400 text-meta animate-pulse ml-2" role="status" aria-live="polite">
             {$_t("streaming...")}
           </span>
         {/if}
@@ -246,7 +244,7 @@
 
         <!-- Timestamp -->
         <Tooltip content={formatTime(event.timestamp, 'absolute')}>
-          <span class="text-sm
+          <span class="text-meta font-normal
             {currentTheme === 'modern'
               ? 'text-chat-text-muted dark:text-chat-text-muted-dark'
               : 'text-gray-500'}">
@@ -357,7 +355,7 @@
   /* Modern Chat user bubble paragraph spacing */
   :global(.user-bubble-content p) {
     margin: 0;
-    line-height: 1.4;
+    line-height: var(--text-base--line-height);
   }
 
   :global(.user-bubble-content p:not(:last-child)) {

--- a/src/webfront/components/event_display/MessageEvent.svelte
+++ b/src/webfront/components/event_display/MessageEvent.svelte
@@ -36,7 +36,7 @@
 </script>
 
 <div class="message-event {$uiTheme}" class:user-message={isUserMessage}>
-  <div class="markdown-content text-sm min-w-0 overflow-hidden {contentClasses}">
+  <div class="markdown-content text-base min-w-0 overflow-hidden {contentClasses}">
     {@html contentHtml}
   </div>
 
@@ -58,29 +58,32 @@
   .markdown-content :global(h6) {
     margin-top: 1em;
     margin-bottom: 0.5em;
-    font-weight: 600;
-    line-height: 1.25;
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--leading-tight);
   }
 
   .markdown-content :global(h1) {
-    font-size: 1.5em;
+    font-size: var(--text-2xl);
+    line-height: var(--text-2xl--line-height);
     border-bottom: 1px solid #e0e0e0;
     padding-bottom: 0.3em;
   }
 
   .markdown-content :global(h2) {
-    font-size: 1.3em;
+    font-size: var(--text-xl);
+    line-height: var(--text-xl--line-height);
     border-bottom: 1px solid #e0e0e0;
     padding-bottom: 0.3em;
   }
 
   .markdown-content :global(h3) {
-    font-size: 1.15em;
+    font-size: var(--text-lg);
+    line-height: var(--text-lg--line-height);
   }
 
   .markdown-content :global(p) {
     margin: 0.5em 0;
-    line-height: 1.6;
+    line-height: var(--text-base--line-height);
   }
 
   .markdown-content :global(ul),
@@ -97,8 +100,9 @@
     background: rgba(0, 0, 0, 0.05);
     padding: 0.2em 0.4em;
     border-radius: 3px;
-    font-family: 'Monaco', 'Menlo', 'Courier New', monospace;
-    font-size: 0.9em;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     word-break: break-word;
   }
 
@@ -118,7 +122,8 @@
     background: transparent;
     padding: 0;
     color: inherit;
-    font-size: 0.9em;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     white-space: pre-wrap;
     word-break: break-all;
     overflow: visible;
@@ -141,7 +146,7 @@
   }
 
   .markdown-content :global(strong) {
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
   }
 
   .markdown-content :global(em) {
@@ -169,7 +174,7 @@
 
   .markdown-content :global(th) {
     background: #f5f5f5;
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
   }
 
   .markdown-content :global(img) {

--- a/src/webfront/components/event_display/MessageEvent.svelte
+++ b/src/webfront/components/event_display/MessageEvent.svelte
@@ -101,8 +101,8 @@
     padding: 0.2em 0.4em;
     border-radius: 3px;
     font-family: var(--font-mono);
-    font-size: var(--text-sm);
-    line-height: var(--text-sm--line-height);
+    font-size: var(--text-code-inline);
+    line-height: var(--text-code-inline--line-height);
     word-break: break-word;
   }
 

--- a/src/webfront/components/event_display/PlanEvent.svelte
+++ b/src/webfront/components/event_display/PlanEvent.svelte
@@ -110,7 +110,7 @@
                 {task.subject}
               </span>
               {#if getBlockedByText(task)}
-                <span class="text-xs text-yellow-500/60 ml-1">({getBlockedByText(task)})</span>
+                <span class="text-meta font-normal text-yellow-500/60 ml-1">({getBlockedByText(task)})</span>
               {/if}
             </div>
           </li>

--- a/src/webfront/components/event_display/SystemEvent.svelte
+++ b/src/webfront/components/event_display/SystemEvent.svelte
@@ -85,8 +85,8 @@
 
   .action-message {
     margin: 0.5rem 0 0;
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
   }
 
   .action-message.error {

--- a/src/webfront/components/event_display/SystemEvent.svelte
+++ b/src/webfront/components/event_display/SystemEvent.svelte
@@ -85,7 +85,8 @@
 
   .action-message {
     margin: 0.5rem 0 0;
-    font-size: 0.8rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
   }
 
   .action-message.error {

--- a/src/webfront/components/event_display/TaskEvent.svelte
+++ b/src/webfront/components/event_display/TaskEvent.svelte
@@ -30,7 +30,7 @@
     </div>
 
     {#if event.metadata}
-      <div class="text-sm mt-1
+      <div class="text-meta font-normal mt-1
         {currentTheme === 'modern'
           ? 'text-chat-text-muted dark:text-chat-text-muted-dark'
           : 'text-gray-500'}">

--- a/src/webfront/components/event_display/ToolCallEvent.svelte
+++ b/src/webfront/components/event_display/ToolCallEvent.svelte
@@ -12,7 +12,7 @@
 <div class="tool-call-event">
   <div class={`text-sm ${event.style.textColor}`}>
     {#if event.metadata?.duration}
-      <span class="text-gray-500">
+      <span class="text-meta font-normal text-gray-500">
         ({formatDuration(event.metadata.duration)})
       </span>
     {/if}
@@ -23,7 +23,7 @@
   </div>
 
   {#if event.metadata}
-    <div class="text-sm text-gray-500 mt-1">
+    <div class="text-meta font-normal text-gray-500 mt-1">
       {#if event.metadata.command}
         <div>{$_t("Command:")} {event.metadata.command}</div>
       {/if}

--- a/src/webfront/components/layout/ChatHistorySection.svelte
+++ b/src/webfront/components/layout/ChatHistorySection.svelte
@@ -234,7 +234,7 @@
             title={item.title || $_t('Untitled conversation')}
           >
             {#if item.runtime.awaitingInputCount > 0}
-              <span class="w-4 h-4 rounded-full shrink-0 inline-flex items-center justify-center bg-amber-400 text-black text-[10px] font-bold"
+              <span class="w-4 h-4 rounded-full shrink-0 inline-flex items-center justify-center bg-amber-400 text-black text-2xs font-bold"
                 title={$_t('Waiting for your input')} aria-label={$_t('Waiting for your input')}>!</span>
             {:else}
               <span class="w-2 h-2 rounded-full shrink-0
@@ -244,7 +244,7 @@
             {/if}
             <span class="flex-1 truncate">{item.title || $_t('Untitled conversation')}</span>
             {#if item.runtime.durability === 'degraded'}<span title={$_t('Durability degraded')}>⚠</span>{/if}
-            <span class="shrink-0 text-xs opacity-60">{formatTimeAgo(item.lastActiveAt)}</span>
+            <span class="shrink-0 text-meta font-normal opacity-60">{formatTimeAgo(item.lastActiveAt)}</span>
           </button>
           {#if item.attentionRequest}
             <button class="px-1 border-none bg-transparent text-inherit cursor-pointer" title={$_t('Continue browser action')}

--- a/src/webfront/components/layout/ChatHistorySection.svelte
+++ b/src/webfront/components/layout/ChatHistorySection.svelte
@@ -172,7 +172,7 @@
 <LeftPanelSection title="Chat History">
   <div class="px-2 pb-2 flex gap-1">
     <input
-      class="min-w-0 flex-1 rounded px-2 py-1 text-xs bg-transparent border
+      class="min-w-0 flex-1 rounded px-2 py-1 text-sm bg-transparent border
         {currentTheme === 'modern'
           ? 'border-chat-border dark:border-chat-border-dark text-chat-text dark:text-chat-text-dark placeholder:text-chat-text-muted dark:placeholder:text-chat-text-muted-dark'
           : 'border-term-dim-green text-term-green placeholder:text-term-dim-green'}"
@@ -192,7 +192,7 @@
 
   {#if attentionThreads.length > 0}
     <button
-      class="mx-2 mb-2 w-[calc(100%-1rem)] rounded px-2 py-1.5 text-left text-xs border-none cursor-pointer bg-amber-500/15 text-amber-700 dark:text-amber-300"
+      class="mx-2 mb-2 w-[calc(100%-1rem)] rounded px-2 py-1.5 text-left text-sm border-none cursor-pointer bg-amber-500/15 text-amber-700 dark:text-amber-300"
       onclick={() => openAttention(attentionThreads[0])}
       aria-label={$_t('Open a conversation waiting for your attention')}
     >
@@ -205,11 +205,11 @@
   {/if}
 
   {#if error}
-    <div class="px-2 py-1.5 text-xs text-chat-error dark:text-chat-error-dark" role="alert">{error}</div>
+    <div class="px-2 py-1.5 text-meta font-normal text-chat-error dark:text-chat-error-dark" role="alert">{error}</div>
   {:else if $threadStore.loading && $threadStore.threads.length === 0}
-    <div class="px-2 py-1.5 text-xs opacity-70">{$_t('Loading history...')}</div>
+    <div class="px-2 py-1.5 text-meta font-normal opacity-70">{$_t('Loading history...')}</div>
   {:else if $threadStore.threads.length === 0}
-    <div class="px-2 py-1.5 text-xs opacity-70">{$_t('No chat history yet')}</div>
+    <div class="px-2 py-1.5 text-meta font-normal opacity-70">{$_t('No chat history yet')}</div>
   {:else}
     <div
       class="max-h-80 overflow-y-auto overscroll-contain pr-0.5"
@@ -263,7 +263,7 @@
   {/if}
 
   {#if $threadStore.nextCursor}
-    <button class="w-full px-2 py-1.5 text-center text-xs border-none bg-transparent cursor-pointer opacity-70 hover:opacity-100
+    <button class="w-full px-2 py-1.5 text-center text-sm border-none bg-transparent cursor-pointer opacity-70 hover:opacity-100
       {currentTheme === 'modern'
         ? 'text-chat-text-secondary dark:text-chat-text-secondary-dark hover:text-chat-text dark:hover:text-chat-text-dark'
         : 'text-term-dim-green hover:text-term-green'}"
@@ -273,7 +273,7 @@
   {/if}
 
   {#if undo}
-    <div class="mx-2 mt-2 rounded px-2 py-1.5 text-xs flex justify-between bg-black/10" role="status">
+    <div class="mx-2 mt-2 rounded px-2 py-1.5 text-meta font-normal flex justify-between bg-black/10" role="status">
       <span>{$_t('Conversation deleted')}</span>
       <button class="border-none bg-transparent underline cursor-pointer" onclick={() => void undoDelete()}>{$_t('Undo')}</button>
     </div>

--- a/src/webfront/components/layout/SessionModeSwitch.svelte
+++ b/src/webfront/components/layout/SessionModeSwitch.svelte
@@ -59,7 +59,7 @@
           onclick={() => void setSessionMode(modeSpec.id)}
           title={isPending ? $_t('Switching after current task…') : $_t('Switch agent mode')}
           aria-pressed={isActive}
-          class="rounded-md border-none px-2 py-1.5 text-xs font-[inherit] cursor-pointer transition-colors
+          class="rounded-md border-none px-2 py-1.5 text-sm font-[inherit] cursor-pointer transition-colors
             {isActive
               ? (currentTheme === 'modern'
                   ? 'bg-chat-surface dark:bg-chat-surface-dark text-chat-text dark:text-chat-text-dark shadow-sm font-semibold'

--- a/src/webfront/components/layout/footbar/Credits.svelte
+++ b/src/webfront/components/layout/footbar/Credits.svelte
@@ -183,7 +183,7 @@
         {/if}
 
         {#if hoursUntilRefresh > 0}
-          <div class="flex items-center gap-1.5 text-sm mt-1.5
+          <div class="flex items-center gap-1.5 text-meta font-normal mt-1.5
             {$uiTheme === 'modern' ? 'text-white/50' : 'text-term-dim-green'}">
             <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <circle cx="12" cy="12" r="10"></circle>

--- a/src/webfront/components/scheduler/ArchivedJobsView.svelte
+++ b/src/webfront/components/scheduler/ArchivedJobsView.svelte
@@ -134,7 +134,7 @@
                 showActions={false}
               />
               {#if job.completedAt}
-                <div class="absolute top-2 right-2 text-sm opacity-70
+                <div class="absolute top-2 right-2 text-meta font-normal opacity-70
                   {currentTheme === 'modern'
                     ? 'text-chat-text-muted dark:text-chat-text-muted-dark'
                     : 'text-term-dim-green'}">

--- a/src/webfront/components/scheduler/CalendarWrapper.svelte
+++ b/src/webfront/components/scheduler/CalendarWrapper.svelte
@@ -107,7 +107,7 @@
     --ec-now-indicator-color: #00ff00;
     --ec-event-text-color: #000;
     --ec-list-day-bg-color: rgba(0, 255, 0, 0.05);
-    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+    font-family: var(--font-terminal);
   }
 
   .calendar-terminal :global(.ec-toolbar) {
@@ -117,7 +117,7 @@
   .calendar-terminal :global(.ec-newEvent) {
     border-color: #00ff00;
     color: #00ff00;
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     margin-left: 0.5rem;
   }
 
@@ -141,7 +141,7 @@
     background-color: var(--color-chat-primary, #3b82f6);
     border-color: var(--color-chat-primary, #3b82f6);
     color: #fff;
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     margin-left: 0.5rem;
   }
 

--- a/src/webfront/components/scheduler/EventPopover.svelte
+++ b/src/webfront/components/scheduler/EventPopover.svelte
@@ -110,7 +110,7 @@
 
     <!-- Content -->
     <div class="px-3 py-2">
-      <p class="m-0 mb-2 text-sm leading-relaxed break-words
+      <p class="m-0 mb-2 text-sm leading-ui break-words
         {currentTheme === 'modern'
           ? 'text-chat-text dark:text-chat-text-dark font-chat'
           : 'text-term-green font-terminal'}">
@@ -122,19 +122,19 @@
       </p>
 
       {#if instance}
-        <div class="text-xs mb-1
+        <div class="text-meta font-normal mb-1
           {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
           {$_t('Scheduled')}: {formatTime(instance.instanceTime)}
         </div>
       {:else if job?.scheduledTime}
-        <div class="text-xs mb-1
+        <div class="text-meta font-normal mb-1
           {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
           {$_t('Scheduled')}: {formatTime(job.scheduledTime)}
         </div>
       {/if}
 
       {#if job}
-        <div class="text-xs
+        <div class="text-meta font-normal
           {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
           {$_t('Created')}: {formatTime(job.createdAt)}
         </div>

--- a/src/webfront/components/scheduler/EventPopover.svelte
+++ b/src/webfront/components/scheduler/EventPopover.svelte
@@ -151,14 +151,14 @@
         {#if instance.status === 'upcoming'}
           <div class="flex gap-2">
             <button
-              class="flex-1 py-1.5 text-xs rounded cursor-pointer transition-all duration-200
+              class="flex-1 py-1.5 text-sm rounded cursor-pointer transition-all duration-200
                 {currentTheme === 'modern'
                   ? 'bg-emerald-500/10 border border-emerald-500/30 text-emerald-500 hover:bg-emerald-500/20'
                   : 'bg-[rgba(0,255,0,0.1)] border border-term-dim-green text-term-green hover:bg-[rgba(0,255,0,0.2)]'}"
               onclick={() => oneditinstance?.({ scheduleEventId: instance.scheduleEventId, instanceTime: instance.instanceTime })}
             >{$_t('Edit Instance')}</button>
             <button
-              class="flex-1 py-1.5 text-xs rounded cursor-pointer transition-all duration-200
+              class="flex-1 py-1.5 text-sm rounded cursor-pointer transition-all duration-200
                 {currentTheme === 'modern'
                   ? 'bg-blue-500/10 border border-blue-500/30 text-blue-500 hover:bg-blue-500/20'
                   : 'bg-[rgba(0,255,255,0.1)] border border-[rgba(0,255,255,0.3)] text-[#00ffff] hover:bg-[rgba(0,255,255,0.2)]'}"
@@ -166,13 +166,13 @@
             >{$_t('Edit Series')}</button>
           </div>
           <button
-            class="w-full py-1.5 text-xs rounded cursor-pointer transition-all duration-200
+            class="w-full py-1.5 text-sm rounded cursor-pointer transition-all duration-200
               bg-[rgba(239,68,68,0.1)] border border-[rgba(239,68,68,0.3)] text-red-400 hover:bg-[rgba(239,68,68,0.2)]"
             onclick={() => ondeleteinstance?.({ scheduleEventId: instance.scheduleEventId, instanceTime: instance.instanceTime })}
           >{$_t('Delete Instance')}</button>
         {/if}
         {#if instance.rruleDescription}
-          <div class="text-xs mt-1
+          <div class="text-meta font-normal mt-1
             {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
             {instance.rruleDescription}
           </div>
@@ -182,20 +182,20 @@
         <div class="flex gap-2">
           {#if job.status === 'scheduled' || job.status === 'missed' || job.status === 'draft'}
             <button
-              class="flex-1 py-1.5 text-xs rounded cursor-pointer transition-all duration-200
+              class="flex-1 py-1.5 text-sm rounded cursor-pointer transition-all duration-200
                 {currentTheme === 'modern'
                   ? 'bg-emerald-500/10 border border-emerald-500/30 text-emerald-500 hover:bg-emerald-500/20'
                   : 'bg-[rgba(0,255,0,0.1)] border border-term-dim-green text-term-green hover:bg-[rgba(0,255,0,0.2)]'}"
               onclick={() => ontrigger?.({ jobId: job.id })}
             >{$_t('Trigger')}</button>
             <button
-              class="flex-1 py-1.5 text-xs rounded cursor-pointer transition-all duration-200
+              class="flex-1 py-1.5 text-sm rounded cursor-pointer transition-all duration-200
                 bg-[rgba(239,68,68,0.1)] border border-[rgba(239,68,68,0.3)] text-red-400 hover:bg-[rgba(239,68,68,0.2)]"
               onclick={() => oncancel?.({ jobId: job.id })}
             >{$_t('Cancel')}</button>
           {:else if (job.status === 'completed' || job.status === 'failed') && job.sessionId}
             <a
-              class="flex-1 py-1.5 text-xs rounded text-center no-underline transition-all duration-200
+              class="flex-1 py-1.5 text-sm rounded text-center no-underline transition-all duration-200
                 {currentTheme === 'modern'
                   ? 'bg-chat-surface dark:bg-chat-surface-dark border border-chat-border dark:border-chat-border-dark text-chat-text dark:text-chat-text-dark hover:bg-chat-button-hover dark:hover:bg-chat-button-hover-dark'
                   : 'bg-[rgba(0,255,0,0.1)] border border-term-dim-green text-term-green hover:bg-[rgba(0,255,0,0.2)]'}"

--- a/src/webfront/components/scheduler/JobDetailModal.svelte
+++ b/src/webfront/components/scheduler/JobDetailModal.svelte
@@ -189,7 +189,7 @@
             {currentTheme === 'modern'
               ? 'text-chat-text-muted dark:text-chat-text-muted-dark'
               : 'text-term-dim-green'}">{$_t('Task')}</span>
-          <p class="m-0 text-sm leading-relaxed break-words whitespace-pre-wrap
+          <p class="m-0 text-sm leading-ui break-words whitespace-pre-wrap
             {currentTheme === 'modern'
               ? 'text-chat-text dark:text-chat-text-dark font-chat'
               : 'text-term-bright-green font-terminal'}">{job.input}</p>
@@ -250,7 +250,7 @@
         {#if job.error}
           <div class="mb-4 p-3 rounded bg-[rgba(239,68,68,0.1)] border border-[rgba(239,68,68,0.3)]">
             <span class="block text-xs uppercase tracking-wider mb-1 text-red-400">{$_t('Error')}</span>
-            <p class="m-0 text-sm leading-relaxed break-words text-red-400">{job.error}</p>
+            <p class="m-0 text-sm leading-ui break-words text-red-400">{job.error}</p>
           </div>
         {/if}
       </div>

--- a/src/webfront/components/scheduler/JobDetailModal.svelte
+++ b/src/webfront/components/scheduler/JobDetailModal.svelte
@@ -198,34 +198,34 @@
         <!-- Time details -->
         <div class="flex flex-col gap-2 mb-4">
           {#if job.scheduledTime}
-            <div class="flex items-center gap-2">
+            <div class="flex items-center gap-2 text-meta font-normal">
               <svg class="w-4 h-4 shrink-0 {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <circle cx="12" cy="12" r="10"></circle>
                 <polyline points="12 6 12 12 16 14"></polyline>
               </svg>
-              <span class="text-sm {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{$_t('Scheduled')}:</span>
-              <span class="text-sm {currentTheme === 'modern' ? 'text-chat-text dark:text-chat-text-dark' : 'text-term-bright-green'}">{formatTime(job.scheduledTime)}</span>
+              <span class="{currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{$_t('Scheduled')}:</span>
+              <span class="{currentTheme === 'modern' ? 'text-chat-text dark:text-chat-text-dark' : 'text-term-bright-green'}">{formatTime(job.scheduledTime)}</span>
             </div>
           {/if}
 
-          <div class="flex items-center gap-2">
+          <div class="flex items-center gap-2 text-meta font-normal">
             <svg class="w-4 h-4 shrink-0 {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
               <line x1="16" y1="2" x2="16" y2="6"></line>
               <line x1="8" y1="2" x2="8" y2="6"></line>
               <line x1="3" y1="10" x2="21" y2="10"></line>
             </svg>
-            <span class="text-sm {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{$_t('Created')}:</span>
-            <span class="text-sm {currentTheme === 'modern' ? 'text-chat-text dark:text-chat-text-dark' : 'text-term-bright-green'}">{formatTime(job.createdAt)}</span>
+            <span class="{currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{$_t('Created')}:</span>
+            <span class="{currentTheme === 'modern' ? 'text-chat-text dark:text-chat-text-dark' : 'text-term-bright-green'}">{formatTime(job.createdAt)}</span>
           </div>
 
           {#if job.completedAt}
-            <div class="flex items-center gap-2">
+            <div class="flex items-center gap-2 text-meta font-normal">
               <svg class="w-4 h-4 shrink-0 {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <polyline points="20 6 9 17 4 12"></polyline>
               </svg>
-              <span class="text-sm {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{$_t('Completed')}:</span>
-              <span class="text-sm {currentTheme === 'modern' ? 'text-chat-text dark:text-chat-text-dark' : 'text-term-bright-green'}">{formatTime(job.completedAt)}</span>
+              <span class="{currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{$_t('Completed')}:</span>
+              <span class="{currentTheme === 'modern' ? 'text-chat-text dark:text-chat-text-dark' : 'text-term-bright-green'}">{formatTime(job.completedAt)}</span>
             </div>
           {/if}
         </div>

--- a/src/webfront/components/scheduler/JobHistoryModule.svelte
+++ b/src/webfront/components/scheduler/JobHistoryModule.svelte
@@ -284,7 +284,7 @@
           <div class="relative">
             <SchedulerJobItem {...job} showActions={false} onDetails={handleDetails} />
             {#if job.completedAt}
-              <div class="absolute top-2 right-2 text-xs opacity-70
+              <div class="absolute top-2 right-2 text-meta font-normal opacity-70
                 {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
                 {formatCompletedTime(job.completedAt)}
               </div>

--- a/src/webfront/components/scheduler/JobHistoryModule.svelte
+++ b/src/webfront/components/scheduler/JobHistoryModule.svelte
@@ -244,7 +244,7 @@
       <!-- Sort + Filter row -->
       <div class="flex items-center gap-2 flex-wrap">
         <button
-          class="px-2 py-0.5 text-xs rounded cursor-pointer transition-all duration-200
+          class="px-2 py-0.5 text-sm rounded cursor-pointer transition-all duration-200
             {currentTheme === 'modern'
               ? 'bg-chat-surface dark:bg-chat-surface-dark border border-chat-border dark:border-chat-border-dark text-chat-text dark:text-chat-text-dark font-chat hover:bg-chat-button-hover dark:hover:bg-chat-button-hover-dark'
               : 'bg-transparent border border-term-dim-green text-term-green font-terminal hover:bg-[rgba(0,255,0,0.1)]'}"

--- a/src/webfront/components/scheduler/NewJobModule.svelte
+++ b/src/webfront/components/scheduler/NewJobModule.svelte
@@ -181,12 +181,12 @@
 
       <!-- Quick Schedule Buttons -->
       <div>
-        <span class="block text-xs mb-1.5
+        <span class="block text-sm mb-1.5
           {currentTheme === 'modern' ? 'text-chat-text-secondary dark:text-chat-text-secondary-dark' : 'text-term-dim-green'}">{$_t('Quick Schedule')}:</span>
         <div class="flex gap-1.5 flex-wrap">
           {#each [{ label: '2m', min: 2 }, { label: '5m', min: 5 }, { label: '15m', min: 15 }, { label: '30m', min: 30 }, { label: '1h', min: 60 }, { label: '3h', min: 180 }, { label: '24h', min: 1440 }] as item}
             <button
-              class="px-2.5 py-1 text-xs rounded cursor-pointer transition-all duration-200
+              class="px-2.5 py-1 text-sm rounded cursor-pointer transition-all duration-200
                 {currentTheme === 'modern'
                   ? 'bg-chat-surface dark:bg-chat-surface-dark border border-chat-border dark:border-chat-border-dark text-chat-text dark:text-chat-text-dark font-chat hover:bg-chat-button-hover dark:hover:bg-chat-button-hover-dark'
                   : 'bg-transparent border border-term-dim-green text-term-green font-terminal hover:bg-[rgba(0,255,0,0.1)]'}"
@@ -199,7 +199,7 @@
       <!-- Date/Time Picker -->
       <div class="flex gap-2">
         <div class="flex-1">
-          <label for="new-job-date" class="block text-xs mb-1
+          <label for="new-job-date" class="block text-sm mb-1
             {currentTheme === 'modern' ? 'text-chat-text-secondary dark:text-chat-text-secondary-dark' : 'text-term-dim-green'}">{$_t('Date')}</label>
           <input
             id="new-job-date"
@@ -213,7 +213,7 @@
           />
         </div>
         <div class="flex-1">
-          <label for="new-job-time" class="block text-xs mb-1
+          <label for="new-job-time" class="block text-sm mb-1
             {currentTheme === 'modern' ? 'text-chat-text-secondary dark:text-chat-text-secondary-dark' : 'text-term-dim-green'}">{$_t('Time')}</label>
           <input
             id="new-job-time"

--- a/src/webfront/components/scheduler/NewJobModule.svelte
+++ b/src/webfront/components/scheduler/NewJobModule.svelte
@@ -169,7 +169,7 @@
       <!-- Task Input -->
       <div>
         <textarea
-          class="w-full p-2 rounded text-sm leading-relaxed resize-y outline-none min-h-[60px]
+          class="w-full p-2 rounded text-sm leading-ui resize-y outline-none min-h-[60px]
             {currentTheme === 'modern'
               ? 'bg-chat-input dark:bg-chat-input-dark border border-chat-border dark:border-chat-border-dark text-chat-text dark:text-chat-text-dark font-chat placeholder:text-chat-text-secondary/60 dark:placeholder:text-chat-text-secondary-dark/60 focus:border-chat-input-focus dark:focus:border-chat-input-focus-dark'
               : 'bg-black/50 border border-term-dim-green text-term-green font-terminal placeholder:text-term-dim-green/60 focus:border-term-green'}"

--- a/src/webfront/components/scheduler/RecurrenceSelector.svelte
+++ b/src/webfront/components/scheduler/RecurrenceSelector.svelte
@@ -86,7 +86,7 @@
 <div class="flex flex-col gap-2 {currentTheme === 'modern' ? 'recurrence-modern' : 'recurrence-terminal'}">
   <!-- Repeat Mode -->
   <div>
-    <span class="block text-xs mb-1 {labelClass(currentTheme)}">{$_t('Repeat')}</span>
+    <span class="block text-sm mb-1 {labelClass(currentTheme)}">{$_t('Repeat')}</span>
     <select
       class="w-full px-2 py-1.5 text-sm rounded {inputClass(currentTheme)}"
       bind:value={mode}
@@ -105,7 +105,7 @@
     {#if mode === 'custom'}
       <div class="flex gap-2 items-end">
         <div class="flex-1">
-          <span class="block text-xs mb-1 {labelClass(currentTheme)}">{$_t('Every')}</span>
+          <span class="block text-sm mb-1 {labelClass(currentTheme)}">{$_t('Every')}</span>
           <input
             type="number"
             min="1"
@@ -132,7 +132,7 @@
 
     <!-- End Condition -->
     <div>
-      <span class="block text-xs mb-1 {labelClass(currentTheme)}">{$_t('Ends')}</span>
+      <span class="block text-sm mb-1 {labelClass(currentTheme)}">{$_t('Ends')}</span>
       <select
         class="w-full px-2 py-1.5 text-sm rounded {inputClass(currentTheme)}"
         bind:value={endCondition}
@@ -146,7 +146,7 @@
 
     {#if endCondition === 'after'}
       <div>
-        <span class="block text-xs mb-1 {labelClass(currentTheme)}">{$_t('After')}</span>
+        <span class="block text-sm mb-1 {labelClass(currentTheme)}">{$_t('After')}</span>
         <div class="flex items-center gap-2">
           <input
             type="number"
@@ -163,7 +163,7 @@
 
     {#if endCondition === 'until'}
       <div>
-        <span class="block text-xs mb-1 {labelClass(currentTheme)}">{$_t('Until')}</span>
+        <span class="block text-sm mb-1 {labelClass(currentTheme)}">{$_t('Until')}</span>
         <input
           type="date"
           class="w-full px-2 py-1.5 text-sm rounded picker-input {inputClass(currentTheme)}"

--- a/src/webfront/components/scheduler/ScheduleJobModal.svelte
+++ b/src/webfront/components/scheduler/ScheduleJobModal.svelte
@@ -226,7 +226,7 @@
           >{$_t('Job')}:</span>
           {#if isEditable}
             <textarea
-              class="w-full mt-2 p-2 rounded text-sm leading-relaxed resize-y outline-none
+              class="w-full mt-2 p-2 rounded text-sm leading-ui resize-y outline-none
                 {currentTheme === 'modern'
                   ? 'bg-chat-input dark:bg-chat-input-dark border border-chat-border dark:border-chat-border-dark text-chat-text dark:text-chat-text-dark font-chat focus:border-chat-primary dark:focus:border-chat-primary-dark placeholder:text-chat-text-muted dark:placeholder:text-chat-text-muted-dark'
                   : 'bg-[rgba(0,0,0,0.5)] border border-term-dim-green text-term-bright-green font-terminal focus:border-term-bright-green placeholder:text-term-dim-green/60'}"
@@ -235,7 +235,7 @@
               rows="3"
             ></textarea>
           {:else}
-            <p class="mt-1 mb-0 text-sm leading-relaxed break-words
+            <p class="mt-1 mb-0 text-sm leading-ui break-words
               {currentTheme === 'modern'
                 ? 'text-chat-text dark:text-chat-text-dark font-chat'
                 : 'text-term-bright-green font-terminal'}"

--- a/src/webfront/components/scheduler/ScheduleJobModal.svelte
+++ b/src/webfront/components/scheduler/ScheduleJobModal.svelte
@@ -320,8 +320,8 @@
                 <polyline points="12 6 12 12 16 14"></polyline>
               </svg>
             </span>
-            <span class="text-sm {currentTheme === 'modern' ? 'text-chat-text dark:text-chat-text-dark font-chat' : 'text-term-bright-green font-terminal'}">{getScheduledDateDisplay()}</span>
-            <span class="text-sm {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">({getRelativeTime()})</span>
+            <span class="text-meta font-normal {currentTheme === 'modern' ? 'text-chat-text dark:text-chat-text-dark font-chat' : 'text-term-bright-green font-terminal'}">{getScheduledDateDisplay()}</span>
+            <span class="text-meta font-normal {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">({getRelativeTime()})</span>
           </div>
         {/if}
 

--- a/src/webfront/components/scheduler/SchedulerJobItem.svelte
+++ b/src/webfront/components/scheduler/SchedulerJobItem.svelte
@@ -145,12 +145,12 @@
 >
   <div class="flex-1 min-w-0">
     <!-- Status Badge -->
-    <span class="inline-block px-1.5 py-0.5 text-sm font-semibold uppercase rounded mb-1 {getStatusBadgeClasses(status)}">
+    <span class="inline-block px-1.5 py-0.5 text-xs font-semibold uppercase rounded mb-1 {getStatusBadgeClasses(status)}">
       {getStatusLabel(status)}
     </span>
     {#if recurrence}
       <span
-        class="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-sm rounded mb-1 ml-1
+        class="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs rounded mb-1 ml-1
           {currentTheme === 'modern'
             ? 'bg-[rgba(96,165,250,0.15)] text-blue-400'
             : 'bg-[rgba(0,255,0,0.15)] text-term-dim-green'}"
@@ -173,7 +173,7 @@
     >{input}</p>
 
     <!-- Time Info -->
-    <div class="mt-1 text-sm">
+    <div class="mt-1 text-meta font-normal">
       {#if scheduledTime}
         <span class="{currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{formatTime(scheduledTime)}</span>
         <span class="ml-1 {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark opacity-70' : 'text-[rgba(0,255,0,0.5)]'}">({getRelativeTime(scheduledTime)})</span>

--- a/src/webfront/components/scheduler/SchedulerJobItem.svelte
+++ b/src/webfront/components/scheduler/SchedulerJobItem.svelte
@@ -166,7 +166,7 @@
     {/if}
 
     <!-- Job Input Preview -->
-    <p class="m-0 text-sm leading-relaxed overflow-hidden text-ellipsis whitespace-nowrap
+    <p class="m-0 text-sm leading-ui overflow-hidden text-ellipsis whitespace-nowrap
       {currentTheme === 'modern'
         ? 'text-chat-text dark:text-chat-text-dark font-chat'
         : 'text-term-bright-green font-terminal'}"

--- a/src/webfront/components/scheduler/SchedulerPopup.svelte
+++ b/src/webfront/components/scheduler/SchedulerPopup.svelte
@@ -374,7 +374,7 @@
             ? 'text-chat-text-muted dark:text-chat-text-muted-dark'
             : 'text-term-dim-green'}">
           <p>{$_t('No scheduled jobs')}</p>
-          <p class="text-sm opacity-70 mt-2">{$_t('Long-press the send button to schedule a job')}</p>
+          <p class="text-meta font-normal opacity-70 mt-2">{$_t('Long-press the send button to schedule a job')}</p>
         </div>
       {:else}
         {#if showSessionDetails}
@@ -386,7 +386,7 @@
               {currentTheme === 'modern'
                 ? 'bg-chat-bg dark:bg-chat-bg-dark border-b border-chat-border dark:border-chat-border-dark'
                 : 'bg-[rgba(0,255,0,0.05)] border-b border-term-dim-green'}">
-              <span class="text-sm font-semibold uppercase tracking-wider
+              <span class="text-xs font-semibold uppercase tracking-wider
                 {currentTheme === 'modern'
                   ? 'text-chat-text dark:text-chat-text-dark'
                   : 'text-term-bright-green'}"
@@ -428,7 +428,7 @@
                           ? 'text-chat-text dark:text-chat-text-dark'
                           : 'text-term-bright-green'}"
                       >{session.type === 'primary' ? $_t('User Session') : $_t('Scheduled Job')}</span>
-                      <span class="text-sm capitalize
+                      <span class="text-meta font-normal capitalize
                         {currentTheme === 'modern'
                           ? (session.state === 'active' ? 'text-chat-button dark:text-chat-button-dark' : session.state === 'initializing' ? 'text-amber-500' : 'text-chat-text-muted dark:text-chat-text-muted-dark')
                           : (session.state === 'active' ? 'text-term-bright-green' : session.state === 'initializing' ? 'text-term-yellow' : 'text-term-dim-green')}"
@@ -439,7 +439,7 @@
               </div>
             {/if}
             {#if sessionCount >= maxSessions}
-              <div class="flex items-center gap-1.5 py-2 px-2.5 text-sm
+              <div class="flex items-center gap-1.5 py-2 px-2.5 text-meta font-normal
                 {currentTheme === 'modern'
                   ? 'bg-[rgba(245,158,11,0.1)] border-t border-amber-500 text-amber-500'
                   : 'bg-[rgba(255,255,0,0.1)] border-t border-term-yellow text-term-yellow'}">
@@ -544,22 +544,22 @@
               </button>
             </div>
             <div class="p-3">
-              <div class="flex gap-2 mb-2 text-sm">
+              <div class="flex gap-2 mb-2 text-meta font-normal">
                 <span class="shrink-0 {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{$_t('Status')}:</span>
                 <span class="break-words {currentTheme === 'modern' ? 'text-chat-text dark:text-chat-text-dark' : (expandedJobDetails.status === 'running' ? 'text-term-bright-green' : expandedJobDetails.status === 'completed' ? 'text-[#00ffff]' : expandedJobDetails.status === 'failed' ? 'text-term-red' : expandedJobDetails.status === 'missed' ? 'text-term-yellow' : 'text-term-bright-green')}">{expandedJobDetails.status}</span>
               </div>
-              <div class="flex gap-2 mb-2 text-sm">
+              <div class="flex gap-2 mb-2 text-meta font-normal">
                 <span class="shrink-0 {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{$_t('Created')}:</span>
                 <span class="break-words {currentTheme === 'modern' ? 'text-chat-text dark:text-chat-text-dark' : 'text-term-bright-green'}">{new Date(expandedJobDetails.createdAt).toLocaleString()}</span>
               </div>
               {#if expandedJobDetails.scheduledTime}
-                <div class="flex gap-2 mb-2 text-sm">
+                <div class="flex gap-2 mb-2 text-meta font-normal">
                   <span class="shrink-0 {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{$_t('Scheduled')}:</span>
                   <span class="break-words {currentTheme === 'modern' ? 'text-chat-text dark:text-chat-text-dark' : 'text-term-bright-green'}">{new Date(expandedJobDetails.scheduledTime).toLocaleString()}</span>
                 </div>
               {/if}
               {#if expandedJobDetails.completedAt}
-                <div class="flex gap-2 mb-2 text-sm">
+                <div class="flex gap-2 mb-2 text-meta font-normal">
                   <span class="shrink-0 {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{$_t('Completed')}:</span>
                   <span class="break-words {currentTheme === 'modern' ? 'text-chat-text dark:text-chat-text-dark' : 'text-term-bright-green'}">{new Date(expandedJobDetails.completedAt).toLocaleString()}</span>
                 </div>
@@ -578,7 +578,7 @@
                 <div class="mt-3 pt-3 border-t border-dashed {currentTheme === 'modern' ? 'border-chat-border dark:border-chat-border-dark' : 'border-[rgba(0,255,0,0.2)]'}">
                   <span class="shrink-0 text-sm {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{$_t('Result Summary')}:</span>
                   <pre class="mt-2 mb-0 p-2 rounded text-sm font-terminal whitespace-pre-wrap break-words max-h-[150px] overflow-y-auto {currentTheme === 'modern' ? 'bg-chat-bg dark:bg-chat-bg-dark text-chat-text dark:text-chat-text-dark' : 'bg-[rgba(0,0,0,0.4)] text-term-bright-green'}">{expandedJobDetails.result.summary}</pre>
-                  <div class="flex gap-4 mt-2 text-sm {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
+                  <div class="flex gap-4 mt-2 text-meta font-normal {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
                     <span>{$_t('Tokens')}: {expandedJobDetails.result.tokenUsage.totalTokens}</span>
                     <span>{$_t('Duration')}: {(expandedJobDetails.result.duration / 1000).toFixed(1)}s</span>
                   </div>
@@ -605,7 +605,7 @@
         {:else}
           {#if runningJob}
             <div class="mb-4">
-              <h4 class="m-0 mb-2 text-sm uppercase tracking-wider {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{$_t('Running')}</h4>
+              <h4 class="m-0 mb-2 text-xs uppercase tracking-wider {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{$_t('Running')}</h4>
               <SchedulerJobItem
                 {...runningJob}
                 showActions={true}
@@ -617,7 +617,7 @@
 
           {#if missedJobs.length > 0}
             <div class="mb-4">
-              <h4 class="m-0 mb-2 text-sm uppercase tracking-wider {currentTheme === 'modern' ? 'text-amber-500' : 'text-term-yellow'}">{$_t('Missed')} ({missedJobs.length})</h4>
+              <h4 class="m-0 mb-2 text-xs uppercase tracking-wider {currentTheme === 'modern' ? 'text-amber-500' : 'text-term-yellow'}">{$_t('Missed')} ({missedJobs.length})</h4>
               {#each missedJobs as job (job.id)}
                 <SchedulerJobItem
                   {...job}
@@ -631,7 +631,7 @@
 
           {#if queuedJobs.length > 0}
             <div class="mb-4">
-              <h4 class="m-0 mb-2 text-sm uppercase tracking-wider {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{$_t('Queued')} ({queuedJobs.length})</h4>
+              <h4 class="m-0 mb-2 text-xs uppercase tracking-wider {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{$_t('Queued')} ({queuedJobs.length})</h4>
               {#each queuedJobs as job (job.id)}
                 <SchedulerJobItem
                   {...job}
@@ -645,7 +645,7 @@
 
           {#if scheduledJobs.length > 0}
             <div class="mb-4 last:mb-0">
-              <h4 class="m-0 mb-2 text-sm uppercase tracking-wider {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{$_t('Upcoming')} ({scheduledJobs.length})</h4>
+              <h4 class="m-0 mb-2 text-xs uppercase tracking-wider {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">{$_t('Upcoming')} ({scheduledJobs.length})</h4>
               {#each scheduledJobs as job (job.id)}
                 <SchedulerJobItem
                   {...job}

--- a/src/webfront/components/scheduler/StatusFilter.svelte
+++ b/src/webfront/components/scheduler/StatusFilter.svelte
@@ -45,7 +45,7 @@
 <div class="flex gap-1.5 flex-wrap">
   {#each statuses as status}
     <button
-      class="px-2 py-0.5 text-xs rounded-full cursor-pointer transition-all duration-200 border
+      class="px-2 py-0.5 text-sm rounded-full cursor-pointer transition-all duration-200 border
         {selected.has(status)
           ? getStatusColor(status)
           : currentTheme === 'modern'

--- a/src/webfront/components/usage/UsageList.svelte
+++ b/src/webfront/components/usage/UsageList.svelte
@@ -45,7 +45,7 @@
             {theme === 'modern'
               ? 'text-chat-text dark:text-chat-text-dark font-chat'
               : 'text-term-green font-terminal'}">{model}</span>
-          <span class="text-xs
+          <span class="text-meta font-normal
             {theme === 'modern'
               ? 'text-chat-muted dark:text-chat-muted-dark font-chat'
               : 'text-term-dim-green font-terminal'}">{fmt(stats.total_tokens)} tokens &middot; {stats.taskCount} {$_t('tasks')}{#if stats.costUSD > 0} &middot; {formatCost(stats.costUSD)}{stats.costEstimated ? ' ≈' : ''}{/if}</span>
@@ -70,13 +70,13 @@
           : 'border border-term-dim-green bg-[rgba(0,255,0,0.03)]'}">
         <!-- Row 1: date/time, model, task count -->
         <div class="flex items-center justify-between mb-1">
-          <span class="text-sm
+          <span class="text-meta font-normal
             {theme === 'modern'
               ? 'text-chat-text dark:text-chat-text-dark font-chat'
               : 'text-term-green font-terminal'}">
             {formatDate(session.lastTimestamp)} {formatTime(session.lastTimestamp)}
           </span>
-          <span class="text-xs
+          <span class="text-meta font-normal
             {theme === 'modern'
               ? 'text-chat-muted dark:text-chat-muted-dark font-chat'
               : 'text-term-dim-green font-terminal'}">
@@ -84,7 +84,7 @@
           </span>
         </div>
         <!-- Row 2: token totals -->
-        <div class="text-xs
+        <div class="text-meta font-normal
           {theme === 'modern'
             ? 'text-chat-muted dark:text-chat-muted-dark font-chat'
             : 'text-term-dim-green font-terminal'}">

--- a/src/webfront/components/vault/PinSetupDialog.svelte
+++ b/src/webfront/components/vault/PinSetupDialog.svelte
@@ -140,15 +140,16 @@
 
   .pin-dialog-title {
     margin: 0 0 0.5rem;
-    font-size: 1.1rem;
+    font-size: var(--text-lg);
+    line-height: var(--text-lg--line-height);
     color: var(--workx-text, #00ff00);
   }
 
   .pin-dialog-description {
     margin: 0 0 1rem;
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     color: var(--workx-text-secondary, #00cc00);
-    line-height: 1.4;
+    line-height: var(--leading-ui);
   }
 
   .pin-field {
@@ -157,7 +158,8 @@
 
   .pin-field label {
     display: block;
-    font-size: 0.8rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     margin-bottom: 0.25rem;
     color: var(--workx-text-secondary, #00cc00);
   }
@@ -165,8 +167,9 @@
   .pin-field input {
     width: 100%;
     padding: 0.5rem;
-    font-size: 1.2rem;
-    letter-spacing: 0.3em;
+    font-size: var(--text-xl);
+    line-height: var(--text-xl--line-height);
+    letter-spacing: var(--tracking-pin);
     text-align: center;
     background: var(--workx-surface, #0a0a0a);
     border: 1px solid var(--workx-border, #00cc00);
@@ -182,7 +185,8 @@
 
   .pin-error {
     color: var(--workx-error, #ff0000);
-    font-size: 0.8rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     margin-bottom: 0.75rem;
   }
 
@@ -196,7 +200,8 @@
   .btn-cancel, .btn-submit {
     padding: 0.5rem 1rem;
     border-radius: 0.375rem;
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     cursor: pointer;
     border: 1px solid var(--workx-border, #00cc00);
   }
@@ -209,7 +214,7 @@
   .btn-submit {
     background: var(--workx-primary, #00ff00);
     color: var(--workx-background, #000);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
   }
 
   .btn-submit:disabled {

--- a/src/webfront/components/vault/PinSetupDialog.svelte
+++ b/src/webfront/components/vault/PinSetupDialog.svelte
@@ -158,8 +158,8 @@
 
   .pin-field label {
     display: block;
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     margin-bottom: 0.25rem;
     color: var(--workx-text-secondary, #00cc00);
   }
@@ -185,8 +185,8 @@
 
   .pin-error {
     color: var(--workx-error, #ff0000);
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
     margin-bottom: 0.75rem;
   }
 

--- a/src/webfront/components/vault/PinUnlockOverlay.svelte
+++ b/src/webfront/components/vault/PinUnlockOverlay.svelte
@@ -249,8 +249,8 @@
 
   .unlock-error {
     color: var(--workx-error, #ff0000);
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
     margin-bottom: 0.75rem;
     text-align: center;
   }
@@ -293,8 +293,8 @@
     background: none;
     border: none;
     color: var(--workx-text-secondary, #00cc00);
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     cursor: pointer;
     margin-top: 1rem;
     padding: 0.25rem 0.5rem;

--- a/src/webfront/components/vault/PinUnlockOverlay.svelte
+++ b/src/webfront/components/vault/PinUnlockOverlay.svelte
@@ -202,17 +202,18 @@
 
   .unlock-title {
     margin: 0 0 0.5rem;
-    font-size: 1.25rem;
+    font-size: var(--text-xl);
+    line-height: var(--text-xl--line-height);
     color: var(--workx-text, #00ff00);
     text-align: center;
   }
 
   .unlock-description {
     margin: 0 0 1.5rem;
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     color: var(--workx-text-secondary, #00cc00);
     text-align: center;
-    line-height: 1.4;
+    line-height: var(--leading-ui);
   }
 
   form {
@@ -230,8 +231,9 @@
   .pin-field input {
     width: 100%;
     padding: 0.75rem;
-    font-size: 1.5rem;
-    letter-spacing: 0.4em;
+    font-size: var(--text-2xl);
+    line-height: var(--text-2xl--line-height);
+    letter-spacing: var(--tracking-pin);
     text-align: center;
     background: var(--workx-surface, #0a0a0a);
     border: 1px solid var(--workx-border, #00cc00);
@@ -247,22 +249,24 @@
 
   .unlock-error {
     color: var(--workx-error, #ff0000);
-    font-size: 0.8rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     margin-bottom: 0.75rem;
     text-align: center;
   }
 
   .lockout-message {
     color: var(--workx-warning, #ffff00);
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
     text-align: center;
     margin-bottom: 1rem;
-    line-height: 1.4;
+    line-height: var(--leading-ui);
   }
 
   .countdown {
-    font-weight: 700;
-    font-size: 1.1rem;
+    font-weight: var(--font-weight-bold);
+    font-size: var(--text-lg);
+    line-height: var(--text-lg--line-height);
     display: inline-block;
     margin-left: 0.25rem;
   }
@@ -271,8 +275,9 @@
     width: 100%;
     padding: 0.625rem;
     border-radius: 0.5rem;
-    font-size: 0.95rem;
-    font-weight: 600;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-semibold);
     cursor: pointer;
     background: var(--workx-primary, #00ff00);
     color: var(--workx-background, #000);
@@ -288,7 +293,8 @@
     background: none;
     border: none;
     color: var(--workx-text-secondary, #00cc00);
-    font-size: 0.8rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     cursor: pointer;
     margin-top: 1rem;
     padding: 0.25rem 0.5rem;
@@ -306,9 +312,9 @@
 
   .forgot-warning {
     margin: 0 0 1rem;
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     color: var(--workx-error, #ff0000);
-    line-height: 1.4;
+    line-height: var(--leading-ui);
   }
 
   .forgot-actions {
@@ -320,7 +326,8 @@
   .btn-cancel, .btn-danger {
     padding: 0.5rem 1rem;
     border-radius: 0.375rem;
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     cursor: pointer;
     border: 1px solid var(--workx-border, #00cc00);
   }

--- a/src/webfront/pages/apps/Apps.svelte
+++ b/src/webfront/pages/apps/Apps.svelte
@@ -490,13 +490,13 @@
                 </button>
               {/if}
               {#if app.auth?.accountHint && app.auth?.status === 'connected'}
-                <span class="text-[10px] truncate max-w-[120px]
+                <span class="text-2xs truncate max-w-[120px]
                   {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
                   {app.auth.accountHint}
                 </span>
               {/if}
               {#if app.version}
-                <span class="ml-auto text-[10px]
+                <span class="ml-auto text-2xs
                   {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
                   v{app.version}
                 </span>
@@ -549,7 +549,7 @@
                   </button>
                   {#if app.auth?.setupUrl}
                     <a href={app.auth.setupUrl} target="_blank" rel="noopener noreferrer"
-                      class="ml-auto text-[10px] underline
+                      class="ml-auto text-2xs underline
                         {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
                       {$_t('Where do I get this?')}
                     </a>

--- a/src/webfront/pages/apps/Apps.svelte
+++ b/src/webfront/pages/apps/Apps.svelte
@@ -422,7 +422,7 @@
                   {app.name}
                 </h2>
                 {#if app.categories.length}
-                  <p class="m-0 text-xs truncate
+                  <p class="m-0 text-meta font-normal truncate
                     {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
                     {app.categories.join(' · ')}
                   </p>
@@ -431,7 +431,7 @@
             </div>
 
             {#if app.description}
-              <p class="m-0 text-xs line-clamp-3
+              <p class="m-0 text-meta font-normal line-clamp-3
                 {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
                 {app.description}
               </p>
@@ -442,7 +442,7 @@
                 <button
                   disabled={pendingId === app.appId}
                   onclick={() => handleInstall(app)}
-                  class="text-xs px-2.5 py-1 rounded cursor-pointer disabled:opacity-50
+                  class="text-sm px-2.5 py-1 rounded cursor-pointer disabled:opacity-50
                     {modern
                       ? 'bg-chat-primary dark:bg-chat-primary-dark text-white font-chat hover:opacity-90'
                       : 'border border-term-dim-green text-term-green font-terminal hover:bg-[rgba(0,255,0,0.1)]'}"
@@ -451,12 +451,12 @@
                 </button>
               {:else if appNeedsConnect(app)}
                 {#if isOauthPending(app.appId)}
-                  <span class="text-xs {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
+                  <span class="text-meta font-normal {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
                     {$_t('Connecting… finish in your browser')}
                   </span>
                   <button
                     onclick={() => cancelOAuth(app.appId)}
-                    class="text-xs px-2 py-1 rounded cursor-pointer
+                    class="text-sm px-2 py-1 rounded cursor-pointer
                       {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark hover:underline' : 'text-term-dim-green hover:underline'}"
                   >
                     {$_t('Cancel')}
@@ -464,7 +464,7 @@
                 {:else}
                   <button
                     onclick={() => handleConnect(app)}
-                    class="text-xs px-2.5 py-1 rounded cursor-pointer
+                    class="text-sm px-2.5 py-1 rounded cursor-pointer
                       {modern
                         ? 'bg-chat-primary dark:bg-chat-primary-dark text-white font-chat hover:opacity-90'
                         : 'border border-term-dim-green text-term-green font-terminal hover:bg-[rgba(0,255,0,0.1)]'}"
@@ -481,7 +481,7 @@
                 <button
                   disabled={pendingId === app.appId}
                   onclick={() => handleActivate(app)}
-                  class="text-xs px-2.5 py-1 rounded cursor-pointer disabled:opacity-50
+                  class="text-sm px-2.5 py-1 rounded cursor-pointer disabled:opacity-50
                     {modern
                       ? 'bg-chat-button-hover dark:bg-chat-button-hover-dark text-chat-text dark:text-chat-text-dark font-chat'
                       : 'border border-term-dim-green text-term-green font-terminal hover:bg-[rgba(0,255,0,0.1)]'}"
@@ -490,13 +490,13 @@
                 </button>
               {/if}
               {#if app.auth?.accountHint && app.auth?.status === 'connected'}
-                <span class="text-2xs truncate max-w-[120px]
+                <span class="text-meta font-normal truncate max-w-[120px]
                   {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
                   {app.auth.accountHint}
                 </span>
               {/if}
               {#if app.version}
-                <span class="ml-auto text-2xs
+                <span class="ml-auto text-meta font-normal
                   {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
                   v{app.version}
                 </span>
@@ -504,14 +504,14 @@
             </div>
 
             {#if connectErrors[app.appId]}
-              <p class="m-0 text-xs text-red-500">{connectErrors[app.appId]}</p>
+              <p class="m-0 text-meta font-normal text-red-500">{connectErrors[app.appId]}</p>
             {/if}
 
             {#if apiKeyFormId === app.appId}
               <div class="flex flex-col gap-2 mt-1 p-2 rounded
                 {modern ? 'bg-chat-bg dark:bg-chat-bg-dark' : 'border border-term-dim-green'}">
                 {#each apiKeyFields as field (field.key)}
-                  <label class="flex flex-col gap-1 text-xs
+                  <label class="flex flex-col gap-1 text-sm
                     {modern ? 'text-chat-text dark:text-chat-text-dark' : 'text-term-green'}">
                     <span>{field.label}{field.optional ? '' : ' *'}</span>
                     <input
@@ -519,7 +519,7 @@
                       bind:value={apiKeyValues[field.key]}
                       placeholder={field.placeholder ?? ''}
                       autocomplete="off"
-                      class="px-2 py-1 rounded text-xs
+                      class="px-2 py-1 rounded text-sm
                         {modern
                           ? 'bg-chat-surface dark:bg-chat-surface-dark border border-chat-border dark:border-chat-border-dark text-chat-text dark:text-chat-text-dark'
                           : 'bg-transparent border border-term-dim-green text-term-green'}"
@@ -527,13 +527,13 @@
                   </label>
                 {/each}
                 {#if apiKeyError}
-                  <p class="m-0 text-xs text-red-500">{apiKeyError}</p>
+                  <p class="m-0 text-meta font-normal text-red-500">{apiKeyError}</p>
                 {/if}
                 <div class="flex items-center gap-2">
                   <button
                     disabled={apiKeySubmitting}
                     onclick={() => submitApiKeyForm(app)}
-                    class="text-xs px-2.5 py-1 rounded cursor-pointer disabled:opacity-50
+                    class="text-sm px-2.5 py-1 rounded cursor-pointer disabled:opacity-50
                       {modern
                         ? 'bg-chat-primary dark:bg-chat-primary-dark text-white font-chat hover:opacity-90'
                         : 'border border-term-dim-green text-term-green font-terminal hover:bg-[rgba(0,255,0,0.1)]'}"
@@ -542,14 +542,14 @@
                   </button>
                   <button
                     onclick={closeApiKeyForm}
-                    class="text-xs px-2 py-1 rounded cursor-pointer
+                    class="text-sm px-2 py-1 rounded cursor-pointer
                       {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark hover:underline' : 'text-term-dim-green hover:underline'}"
                   >
                     {$_t('Cancel')}
                   </button>
                   {#if app.auth?.setupUrl}
                     <a href={app.auth.setupUrl} target="_blank" rel="noopener noreferrer"
-                      class="ml-auto text-2xs underline
+                      class="ml-auto text-meta font-normal underline
                         {modern ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}">
                       {$_t('Where do I get this?')}
                     </a>

--- a/src/webfront/pages/chat/Main.svelte
+++ b/src/webfront/pages/chat/Main.svelte
@@ -1758,7 +1758,7 @@
                 <p class="m-0 mb-2 font-semibold text-lg
                   {currentTheme === 'modern' ? 'text-chat-text dark:text-chat-text-dark text-xl' : 'text-term-bright-green'}">{$_t("Hello $NAME$", { substitutions: [$userStore.userName || $userStore.userEmail] })}</p>
               {/if}
-              <pre class="welcome-ascii m-0 font-terminal text-[0.4rem] leading-none whitespace-pre">{#each welcomeAsciiLines as line, index (index)}<span class={line.color}>{line.text}</span>{/each}</pre>
+              <pre class="welcome-ascii m-0 font-terminal text-ascii leading-none whitespace-pre">{#each welcomeAsciiLines as line, index (index)}<span class={line.color}>{line.text}</span>{/each}</pre>
               <p class="m-0 text-base text-term-blue">
                 {platform.platformName === 'extension' ? $_t("General in-browser AI agent for work tasks") : $_t("Your personal AI assistant")}
               </p>

--- a/src/webfront/pages/chat/Main.svelte
+++ b/src/webfront/pages/chat/Main.svelte
@@ -1580,7 +1580,7 @@
           <div class="flex items-center space-x-2">
             <TerminalMessage type="system" content={platform.platformName === 'extension' ? $_t("WorkX (Alpha)") : $_t("WorkX: Your personal AI (Alpha)")} />
             {#if zoomLevel !== 100}
-              <button onclick={resetZoom} class="text-sm leading-relaxed font-[inherit] opacity-70 hover:opacity-100 cursor-pointer {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}" title="Reset zoom to 100%">
+              <button onclick={resetZoom} class="text-sm leading-ui font-[inherit] opacity-70 hover:opacity-100 cursor-pointer {currentTheme === 'modern' ? 'text-chat-text-muted dark:text-chat-text-muted-dark' : 'text-term-dim-green'}" title="Reset zoom to 100%">
                 [{zoomLevel}%] ✕
               </button>
             {/if}
@@ -1759,10 +1759,10 @@
                   {currentTheme === 'modern' ? 'text-chat-text dark:text-chat-text-dark text-xl' : 'text-term-bright-green'}">{$_t("Hello $NAME$", { substitutions: [$userStore.userName || $userStore.userEmail] })}</p>
               {/if}
               <pre class="welcome-ascii m-0 font-terminal text-[0.4rem] leading-none whitespace-pre">{#each welcomeAsciiLines as line, index (index)}<span class={line.color}>{line.text}</span>{/each}</pre>
-              <p class="m-0 text-[0.95rem] text-term-blue">
+              <p class="m-0 text-base text-term-blue">
                 {platform.platformName === 'extension' ? $_t("General in-browser AI agent for work tasks") : $_t("Your personal AI assistant")}
               </p>
-              <p class="m-0 text-[0.95rem] text-term-dim-green">
+              <p class="m-0 text-base text-term-dim-green">
                 {$_t("Developed and supported by AI Republic")}
               </p>
               <a

--- a/src/webfront/pages/chat/Main.svelte
+++ b/src/webfront/pages/chat/Main.svelte
@@ -1739,7 +1739,7 @@
             <div class="flex justify-center py-2">
               <button
                 type="button"
-                class="text-xs opacity-70 hover:opacity-100 underline"
+                class="text-sm opacity-70 hover:opacity-100 underline"
                 disabled={loadingOlderHistory}
                 onclick={loadOlderHistory}
               >

--- a/src/webfront/pages/diagnostics/Doctor.svelte
+++ b/src/webfront/pages/diagnostics/Doctor.svelte
@@ -102,7 +102,7 @@
     overflow-y: auto;
     background: var(--color-bg, #000);
     color: var(--color-fg, #e0e0e0);
-    font-family: var(--font-mono, monospace);
+    font-family: var(--font-mono);
   }
   .doctor-container {
     width: 100%;
@@ -118,7 +118,8 @@
     margin-bottom: 12px;
   }
   .doctor-title {
-    font-size: 16px;
+    font-size: var(--text-base);
+    line-height: var(--text-base--line-height);
     margin: 0;
   }
   .close-button {
@@ -144,13 +145,14 @@
     border: 1px solid var(--color-border, #333);
     border-radius: 4px;
     margin-bottom: 12px;
-    font-weight: bold;
+    font-weight: var(--font-weight-bold);
   }
   .overall .meta {
     margin-left: auto;
-    font-weight: normal;
+    font-weight: var(--font-weight-normal);
     opacity: 0.7;
-    font-size: 12px;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
   }
   .check-list {
     list-style: none;
@@ -167,18 +169,19 @@
     flex: 1;
   }
   .check-title {
-    font-weight: bold;
+    font-weight: var(--font-weight-bold);
   }
   .check-detail {
     opacity: 0.8;
-    font-size: 12px;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     white-space: pre-wrap;
     word-break: break-word;
   }
   .badge {
     width: 1.2em;
     text-align: center;
-    font-weight: bold;
+    font-weight: var(--font-weight-bold);
     flex-shrink: 0;
   }
   .check-pass .badge,
@@ -207,6 +210,6 @@
     background: var(--color-border, #333);
   }
   .doctor-page.modern {
-    font-family: var(--font-sans, system-ui, sans-serif);
+    font-family: var(--font-chat);
   }
 </style>

--- a/src/webfront/pages/diagnostics/Doctor.svelte
+++ b/src/webfront/pages/diagnostics/Doctor.svelte
@@ -151,8 +151,8 @@
     margin-left: auto;
     font-weight: var(--font-weight-normal);
     opacity: 0.7;
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
   }
   .check-list {
     list-style: none;
@@ -173,8 +173,8 @@
   }
   .check-detail {
     opacity: 0.8;
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
     white-space: pre-wrap;
     word-break: break-word;
   }

--- a/src/webfront/pages/scheduler/Scheduler.svelte
+++ b/src/webfront/pages/scheduler/Scheduler.svelte
@@ -176,7 +176,7 @@
         : 'text-term-green font-terminal'}">{$_t('Scheduler')}</h1>
     <div class="ml-auto">
       <button
-        class="flex items-center gap-1.5 px-2.5 py-1 text-xs rounded cursor-pointer transition-all duration-200
+        class="flex items-center gap-1.5 px-2.5 py-1 text-sm rounded cursor-pointer transition-all duration-200
           {currentTheme === 'modern'
             ? 'bg-chat-surface dark:bg-chat-surface-dark border border-chat-border dark:border-chat-border-dark text-chat-text dark:text-chat-text-dark font-chat hover:bg-chat-button-hover dark:hover:bg-chat-button-hover-dark'
             : 'bg-transparent border border-term-dim-green text-term-green font-terminal hover:bg-[rgba(0,255,0,0.1)]'}"

--- a/src/webfront/pages/settings/Settings.svelte
+++ b/src/webfront/pages/settings/Settings.svelte
@@ -376,8 +376,9 @@
 
   .settings-title {
     margin: 0;
-    font-size: 1.25rem;
-    font-weight: 600;
+    font-size: var(--text-xl);
+    line-height: var(--text-xl--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 

--- a/src/webfront/pages/usage/Usage.svelte
+++ b/src/webfront/pages/usage/Usage.svelte
@@ -44,7 +44,7 @@
         : 'text-term-green font-terminal'}">{$_t('Token Usage')}</h1>
     <div class="ml-auto flex items-center gap-2">
       <button
-        class="flex items-center gap-1.5 px-2.5 py-1 text-xs rounded cursor-pointer transition-all duration-200
+        class="flex items-center gap-1.5 px-2.5 py-1 text-sm rounded cursor-pointer transition-all duration-200
           {currentTheme === 'modern'
             ? 'bg-chat-surface dark:bg-chat-surface-dark border border-chat-border dark:border-chat-border-dark text-chat-text dark:text-chat-text-dark font-chat hover:bg-chat-button-hover dark:hover:bg-chat-button-hover-dark'
             : 'bg-transparent border border-term-dim-green text-term-green font-terminal hover:bg-[rgba(0,255,0,0.1)]'}
@@ -54,7 +54,7 @@
         {$_t('By Model')}
       </button>
       <button
-        class="flex items-center gap-1.5 px-2.5 py-1 text-xs rounded cursor-pointer transition-all duration-200
+        class="flex items-center gap-1.5 px-2.5 py-1 text-sm rounded cursor-pointer transition-all duration-200
           {currentTheme === 'modern'
             ? 'bg-chat-surface dark:bg-chat-surface-dark border border-chat-border dark:border-chat-border-dark text-chat-text dark:text-chat-text-dark font-chat hover:bg-chat-button-hover dark:hover:bg-chat-button-hover-dark'
             : 'bg-transparent border border-term-dim-green text-term-green font-terminal hover:bg-[rgba(0,255,0,0.1)]'}"
@@ -96,7 +96,7 @@
           <rect x="17" y="3" width="4" height="18" rx="1"></rect>
         </svg>
         <p class="text-sm font-medium mb-1">{$_t('No usage data yet')}</p>
-        <p class="text-xs opacity-70">{$_t('Token usage will appear here after running tasks')}</p>
+        <p class="text-meta font-normal opacity-70">{$_t('Token usage will appear here after running tasks')}</p>
       </div>
     {:else}
       <!-- Track 18: total cost summary (hidden when there is no cost yet,
@@ -113,7 +113,7 @@
           <span class="text-lg font-semibold
             {currentTheme === 'modern'
               ? 'text-chat-text dark:text-chat-text-dark font-chat'
-              : 'text-term-green font-terminal'}">{formatCost(totalCostUSD)}{#if anyCostEstimated}<span class="text-xs font-normal opacity-70"> &middot; {$_t('≈ estimated')}</span>{/if}</span>
+              : 'text-term-green font-terminal'}">{formatCost(totalCostUSD)}{#if anyCostEstimated}<span class="text-meta font-normal opacity-70"> &middot; {$_t('≈ estimated')}</span>{/if}</span>
         </div>
       {/if}
 

--- a/src/webfront/settings/A2ASettings.svelte
+++ b/src/webfront/settings/A2ASettings.svelte
@@ -801,8 +801,9 @@
     border: none;
     color: var(--workx-primary);
     cursor: pointer;
-    font-size: 0.9375rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     padding: 0.5rem 0;
     margin-bottom: 1rem;
     display: flex;
@@ -817,16 +818,17 @@
 
   .settings-title {
     margin: 0 0 0.5rem 0;
-    font-size: 1.5rem;
-    font-weight: 600;
+    font-size: var(--text-2xl);
+    line-height: var(--text-2xl--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
   .settings-description {
     margin: 0 0 1.5rem 0;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     color: var(--workx-text-secondary);
-    line-height: 1.5;
+    line-height: var(--leading-normal);
   }
 
   .settings-form {
@@ -889,8 +891,9 @@
 
   .section-title {
     margin: 0;
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: var(--text-base);
+    line-height: var(--text-base--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
@@ -953,34 +956,37 @@
   }
 
   .agent-name {
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
   .agent-url {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text-secondary);
     word-break: break-all;
   }
 
   .trusted-badge {
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     padding: 0.125rem 0.5rem;
     border-radius: 1rem;
     text-transform: uppercase;
-    letter-spacing: 0.025em;
+    letter-spacing: var(--tracking-wide);
     background: color-mix(in srgb, var(--workx-primary) 15%, transparent);
     color: var(--workx-primary);
   }
 
   .status-badge {
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     padding: 0.125rem 0.5rem;
     border-radius: 1rem;
     text-transform: uppercase;
-    letter-spacing: 0.025em;
+    letter-spacing: var(--tracking-wide);
   }
 
   .badge-success {
@@ -1011,7 +1017,8 @@
     padding: 0.5rem;
     background: color-mix(in srgb, var(--workx-error) 10%, transparent);
     border-radius: 0.375rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-error);
   }
 
@@ -1029,7 +1036,8 @@
   }
 
   .card-field {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text-secondary);
     margin-bottom: 0.25rem;
   }
@@ -1039,7 +1047,7 @@
   }
 
   .card-label {
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
@@ -1063,7 +1071,8 @@
   .limit-message {
     text-align: center;
     color: var(--workx-text-secondary);
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     margin-top: 0.5rem;
   }
 
@@ -1093,12 +1102,13 @@
   }
 
   .skill-name {
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
   .skill-agent {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     padding: 0.125rem 0.375rem;
     background: color-mix(in srgb, var(--workx-primary) 10%, transparent);
     color: var(--workx-primary);
@@ -1107,9 +1117,9 @@
 
   .skill-description {
     margin: 0;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     color: var(--workx-text-secondary);
-    line-height: 1.4;
+    line-height: var(--leading-ui);
   }
 
   .skill-tags {
@@ -1120,20 +1130,21 @@
   }
 
   .skill-tag {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     padding: 0.125rem 0.375rem;
     background: color-mix(in srgb, var(--workx-text-secondary) 10%, transparent);
     color: var(--workx-text-secondary);
     border-radius: 0.25rem;
-    line-height: 1.3;
+    line-height: var(--leading-ui);
   }
 
   /* Buttons */
   .btn {
     padding: 0.5rem 1rem;
     border-radius: 0.5rem;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     cursor: pointer;
     transition: all 0.2s;
     border: 1px solid transparent;
@@ -1166,7 +1177,8 @@
 
   .btn-small {
     padding: 0.375rem 0.75rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
   }
 
   .btn-icon {
@@ -1198,8 +1210,9 @@
   .form-label {
     display: block;
     margin-bottom: 0.5rem;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     color: var(--workx-text);
   }
 
@@ -1210,7 +1223,8 @@
     border-radius: 0.375rem;
     background: var(--workx-surface);
     color: var(--workx-text);
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     transition: all 0.2s;
   }
 
@@ -1230,7 +1244,8 @@
     align-items: center;
     gap: 0.5rem;
     cursor: pointer;
-    font-size: 0.9375rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text);
   }
 
@@ -1243,9 +1258,9 @@
 
   .help-text {
     margin-top: 0.375rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     color: var(--workx-text-secondary);
-    line-height: 1.4;
+    line-height: var(--leading-ui);
   }
 
   .form-error {
@@ -1255,7 +1270,8 @@
     padding: 0.75rem;
     background: color-mix(in srgb, var(--workx-error) 10%, transparent);
     border-radius: 0.5rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-error);
     margin-top: 1rem;
   }
@@ -1295,8 +1311,9 @@
 
   .modal-header h3 {
     margin: 0;
-    font-size: 1.125rem;
-    font-weight: 600;
+    font-size: var(--text-lg);
+    line-height: var(--text-lg--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
@@ -1337,7 +1354,8 @@
     gap: 0.5rem;
     padding: 0.75rem;
     border-radius: 0.5rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     margin-top: 1rem;
     max-width: 600px;
   }

--- a/src/webfront/settings/AdvancedModelConfig.svelte
+++ b/src/webfront/settings/AdvancedModelConfig.svelte
@@ -327,8 +327,9 @@
     border: none;
     color: var(--workx-primary);
     cursor: pointer;
-    font-size: 0.9375rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     padding: 0.5rem 0;
     margin-bottom: 1rem;
     display: flex;
@@ -343,14 +344,16 @@
 
   .config-title {
     margin: 0 0 0.25rem 0;
-    font-size: 1.5rem;
-    font-weight: 600;
+    font-size: var(--text-2xl);
+    line-height: var(--text-2xl--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
   .config-subtitle {
     margin: 0 0 1.5rem 0;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text-secondary);
   }
 
@@ -377,15 +380,17 @@
 
   .section-title {
     margin: 0 0 1rem 0;
-    font-size: 1.125rem;
-    font-weight: 600;
+    font-size: var(--text-lg);
+    line-height: var(--text-lg--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
   .subsection-title {
     margin: 1.5rem 0 1rem 0;
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: var(--text-base);
+    line-height: var(--text-base--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
     padding-top: 1rem;
     border-top: 1px solid var(--workx-border);
@@ -415,25 +420,28 @@
   }
 
   .info-label {
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     color: var(--workx-text-secondary);
     text-transform: uppercase;
-    letter-spacing: 0.025em;
+    letter-spacing: var(--tracking-wide);
   }
 
   .info-value {
-    font-size: 0.9375rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text);
     word-break: break-word;
   }
 
   .info-value.code {
-    font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+    font-family: var(--font-mono);
     background: var(--workx-background);
     padding: 0.25rem 0.5rem;
     border-radius: 0.25rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
   }
 
   .info-value.warning {
@@ -443,7 +451,8 @@
   .info-link {
     color: var(--workx-primary);
     text-decoration: none;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     word-break: break-all;
   }
 
@@ -467,8 +476,9 @@
     gap: 0.25rem;
     padding: 0.375rem 0.75rem;
     border-radius: 9999px;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
   }
 
   .tag.enabled {

--- a/src/webfront/settings/ApprovalSettings.svelte
+++ b/src/webfront/settings/ApprovalSettings.svelte
@@ -284,7 +284,8 @@
     border: none;
     color: var(--workx-primary);
     cursor: pointer;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     padding: 0.25rem 0.5rem;
     border-radius: 0.375rem;
     transition: background 0.2s;
@@ -296,8 +297,9 @@
 
   .section-title {
     margin: 0;
-    font-size: 1.25rem;
-    font-weight: 600;
+    font-size: var(--text-xl);
+    line-height: var(--text-xl--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
@@ -316,14 +318,16 @@
 
   .subsection-title {
     margin: 0 0 0.25rem 0;
-    font-size: 0.9375rem;
-    font-weight: 600;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
   .subsection-description {
     margin: 0 0 0.75rem 0;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text-secondary);
   }
 
@@ -370,13 +374,15 @@
   }
 
   .mode-label {
-    font-weight: 600;
-    font-size: 0.875rem;
+    font-weight: var(--font-weight-semibold);
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text);
   }
 
   .mode-desc {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text-secondary);
   }
 
@@ -389,7 +395,8 @@
   .domain-input {
     flex: 1;
     padding: 0.5rem 0.75rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     background: var(--workx-background);
     border: 1px solid var(--workx-border);
     border-radius: 0.375rem;
@@ -402,7 +409,8 @@
 
   .add-button {
     padding: 0.5rem 1rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     background: var(--workx-primary);
     color: white;
     border: none;
@@ -426,7 +434,8 @@
     align-items: center;
     gap: 0.375rem;
     padding: 0.25rem 0.5rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     border-radius: 0.25rem;
   }
 
@@ -445,7 +454,8 @@
     border: none;
     color: inherit;
     cursor: pointer;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     padding: 0;
     opacity: 0.6;
     transition: opacity 0.2s;
@@ -463,8 +473,9 @@
 
   .save-button {
     padding: 0.625rem 1.5rem;
-    font-size: 0.875rem;
-    font-weight: 600;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-semibold);
     background: var(--workx-primary);
     color: white;
     border: none;
@@ -479,7 +490,8 @@
   }
 
   .save-message {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
   }
 
   .save-message.success {

--- a/src/webfront/settings/ComponentsSettings.svelte
+++ b/src/webfront/settings/ComponentsSettings.svelte
@@ -266,7 +266,8 @@
     background: transparent;
     color: var(--workx-text);
     padding: 0.2rem 0.4rem;
-    font-size: 1.25rem;
+    font-size: var(--text-xl);
+    line-height: var(--text-xl--line-height);
   }
 
   .privacy-note,
@@ -316,7 +317,8 @@
     border-radius: 999px;
     padding: 0.2rem 0.55rem;
     white-space: nowrap;
-    font-size: 0.8rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
   }
 
   .state-badge.installed {

--- a/src/webfront/settings/DataSourcesSettings.svelte
+++ b/src/webfront/settings/DataSourcesSettings.svelte
@@ -988,7 +988,8 @@
     margin-bottom: 0.25rem;
   }
   .back {
-    font-size: 1.25rem;
+    font-size: var(--text-xl);
+    line-height: var(--text-xl--line-height);
   }
   button,
   input,
@@ -1011,7 +1012,7 @@
   button.primary {
     background: var(--workx-primary);
     color: var(--workx-background);
-    font-weight: 700;
+    font-weight: var(--font-weight-bold);
   }
   button.danger {
     color: var(--workx-error);
@@ -1023,7 +1024,7 @@
     padding: 1rem;
     margin: 1rem 0;
     background: color-mix(in srgb, var(--workx-primary) 7%, var(--workx-surface));
-    line-height: 1.45;
+    line-height: var(--leading-normal);
   }
   .message {
     border-radius: 0.4rem;
@@ -1072,7 +1073,8 @@
   }
   dt {
     color: var(--workx-text-secondary);
-    font-size: 0.8rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
   }
   dd {
     margin: 0.2rem 0 0;
@@ -1083,7 +1085,8 @@
     border: 1px solid var(--workx-border);
     border-radius: 99px;
     padding: 0.2rem 0.5rem;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
   }
   .badge.good {
     color: var(--workx-success);
@@ -1102,7 +1105,8 @@
   small,
   .help {
     color: var(--workx-text-secondary);
-    font-size: 0.82rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
   }
   .editor-nav {
     justify-content: space-between;
@@ -1120,8 +1124,9 @@
     padding: 0;
   }
   legend {
-    font-size: 1.25rem;
-    font-weight: 700;
+    font-size: var(--text-xl);
+    line-height: var(--text-xl--line-height);
+    font-weight: var(--font-weight-bold);
     margin-bottom: 1rem;
   }
   .grid {

--- a/src/webfront/settings/DataSourcesSettings.svelte
+++ b/src/webfront/settings/DataSourcesSettings.svelte
@@ -938,7 +938,7 @@
               <div class="revisions">
                 {#each contextRevisions as revision (revision.revision)}
                   <div>
-                    <span
+                    <span class="revision-meta"
                       >Revision {revision.revision} · {revision.activeFactCount} facts · {new Date(
                         revision.createdAt
                       ).toLocaleString()}</span
@@ -1073,8 +1073,8 @@
   }
   dt {
     color: var(--workx-text-secondary);
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
   }
   dd {
     margin: 0.2rem 0 0;
@@ -1105,8 +1105,8 @@
   small,
   .help {
     color: var(--workx-text-secondary);
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
   }
   .editor-nav {
     justify-content: space-between;
@@ -1197,6 +1197,11 @@
   }
   .revisions > div {
     justify-content: space-between;
+  }
+  .revision-meta {
+    color: var(--workx-text-secondary);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
   }
   @media (max-width: 700px) {
     .grid.two,

--- a/src/webfront/settings/ExtensionSettings.svelte
+++ b/src/webfront/settings/ExtensionSettings.svelte
@@ -414,8 +414,9 @@
     border: none;
     color: var(--workx-primary);
     cursor: pointer;
-    font-size: 0.9375rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     padding: 0.5rem 0;
     margin-bottom: 1rem;
     display: flex;
@@ -430,8 +431,9 @@
 
   .settings-title {
     margin: 0 0 1.5rem 0;
-    font-size: 1.5rem;
-    font-weight: 600;
+    font-size: var(--text-2xl);
+    line-height: var(--text-2xl--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
@@ -457,8 +459,9 @@
 
   .section-title {
     margin: 0 0 1rem 0;
-    font-size: 1.125rem;
-    font-weight: 600;
+    font-size: var(--text-lg);
+    line-height: var(--text-lg--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
@@ -469,8 +472,9 @@
   .form-label {
     display: block;
     margin-bottom: 0.5rem;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     color: var(--workx-text);
   }
 
@@ -481,7 +485,8 @@
     border-radius: 0.375rem;
     background: var(--workx-surface);
     color: var(--workx-text);
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     transition: all 0.2s;
   }
 
@@ -498,8 +503,9 @@
     border-radius: 0.375rem;
     background: var(--workx-surface);
     color: var(--workx-text);
-    font-size: 0.875rem;
-    font-family: 'Courier New', Courier, monospace;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-family: var(--font-mono);
     resize: vertical;
     transition: all 0.2s;
   }
@@ -517,7 +523,8 @@
     border-radius: 0.375rem;
     background: var(--workx-surface);
     color: var(--workx-text);
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     transition: all 0.2s;
   }
 
@@ -532,7 +539,8 @@
     align-items: center;
     gap: 0.5rem;
     cursor: pointer;
-    font-size: 0.9375rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text);
   }
 
@@ -545,9 +553,9 @@
 
   .help-text {
     margin-top: 0.375rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     color: var(--workx-text-secondary);
-    line-height: 1.4;
+    line-height: var(--leading-ui);
   }
 
   .button-group {
@@ -557,8 +565,9 @@
   .btn {
     padding: 0.75rem 1.5rem;
     border-radius: 0.5rem;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     cursor: pointer;
     transition: all 0.2s;
     border: 1px solid var(--workx-primary);
@@ -592,7 +601,8 @@
     gap: 0.5rem;
     padding: 0.75rem;
     border-radius: 0.5rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     margin-top: 1rem;
   }
 

--- a/src/webfront/settings/GeneralSettings.svelte
+++ b/src/webfront/settings/GeneralSettings.svelte
@@ -294,7 +294,7 @@
                       ? 'font-chat text-chat-text dark:text-chat-text-dark'
                       : 'font-terminal text-term-green'}"
                   >{option.label}</span>
-                  <span class="text-xs leading-ui
+                  <span class="text-meta font-normal
                     {currentTheme === 'modern'
                       ? 'font-chat text-chat-text-secondary dark:text-chat-text-secondary-dark'
                       : 'font-terminal text-term-dim-green'}"

--- a/src/webfront/settings/GeneralSettings.svelte
+++ b/src/webfront/settings/GeneralSettings.svelte
@@ -200,7 +200,7 @@
 
 <div class="p-6">
   <button
-    class="bg-transparent border-none cursor-pointer text-[15px] font-medium py-2 px-0 mb-4 flex items-center gap-1 transition-opacity duration-200 hover:opacity-80
+    class="bg-transparent border-none cursor-pointer text-sm font-medium py-2 px-0 mb-4 flex items-center gap-1 transition-opacity duration-200 hover:opacity-80
       {currentTheme === 'modern'
         ? 'font-chat text-chat-primary dark:text-chat-primary-dark'
         : 'font-terminal text-term-green'}"
@@ -289,12 +289,12 @@
                       ? 'bg-chat-surface dark:bg-chat-surface-dark'
                       : 'bg-term-bg'}"
                 >
-                  <span class="font-semibold text-[13px]
+                  <span class="font-semibold text-sm
                     {currentTheme === 'modern'
                       ? 'font-chat text-chat-text dark:text-chat-text-dark'
                       : 'font-terminal text-term-green'}"
                   >{option.label}</span>
-                  <span class="text-xs leading-relaxed
+                  <span class="text-xs leading-ui
                     {currentTheme === 'modern'
                       ? 'font-chat text-chat-text-secondary dark:text-chat-text-secondary-dark'
                       : 'font-terminal text-term-dim-green'}"
@@ -304,7 +304,7 @@
             </label>
           {/each}
         </div>
-        <div class="mt-1.5 text-sm leading-relaxed
+        <div class="mt-1.5 text-sm leading-ui
           {currentTheme === 'modern'
             ? 'font-chat text-chat-text-secondary dark:text-chat-text-secondary-dark'
             : 'font-terminal text-term-dim-green'}"
@@ -323,12 +323,12 @@
       <div>
         <div class="flex items-center justify-between gap-4">
           <div class="flex flex-col gap-1">
-            <span class="text-[15px] font-medium
+            <span class="text-sm font-medium
               {currentTheme === 'modern'
                 ? 'font-chat text-chat-text dark:text-chat-text-dark'
                 : 'font-terminal text-term-green'}"
             >{$_t("Show token usage in tasks")}</span>
-            <span class="text-sm leading-relaxed
+            <span class="text-sm leading-ui
               {currentTheme === 'modern'
                 ? 'font-chat text-chat-text-secondary dark:text-chat-text-secondary-dark'
                 : 'font-terminal text-term-dim-green'}"
@@ -353,12 +353,12 @@
       <div>
         <div class="flex items-center justify-between gap-4">
           <div class="flex flex-col gap-1">
-            <span class="text-[15px] font-medium
+            <span class="text-sm font-medium
               {currentTheme === 'modern'
                 ? 'font-chat text-chat-text dark:text-chat-text-dark'
                 : 'font-terminal text-term-green'}"
             >{$_t("Start on login")}</span>
-            <span class="text-sm leading-relaxed
+            <span class="text-sm leading-ui
               {currentTheme === 'modern'
                 ? 'font-chat text-chat-text-secondary dark:text-chat-text-secondary-dark'
                 : 'font-terminal text-term-dim-green'}"
@@ -401,7 +401,7 @@
             <option value={lang.code}>{lang.title}</option>
           {/each}
         </select>
-        <div class="mt-1.5 text-sm leading-relaxed
+        <div class="mt-1.5 text-sm leading-ui
           {currentTheme === 'modern'
             ? 'font-chat text-chat-text-secondary dark:text-chat-text-secondary-dark'
             : 'font-terminal text-term-dim-green'}"
@@ -437,7 +437,7 @@
             <option value={num}>{num} {num === 1 ? $_t("session") : $_t("sessions")}</option>
           {/each}
         </select>
-        <div class="mt-1.5 text-sm leading-relaxed
+        <div class="mt-1.5 text-sm leading-ui
           {currentTheme === 'modern'
             ? 'font-chat text-chat-text-secondary dark:text-chat-text-secondary-dark'
             : 'font-terminal text-term-dim-green'}"
@@ -472,7 +472,7 @@
               ? 'font-chat bg-chat-surface dark:bg-chat-surface-dark text-chat-text dark:text-chat-text-dark border border-chat-border dark:border-chat-border-dark focus:outline-none focus:border-chat-primary dark:focus:border-chat-primary-dark focus:ring-3 focus:ring-chat-primary/10 dark:focus:ring-chat-primary-dark/10'
               : 'font-terminal bg-term-bg text-term-green border border-term-dim-green focus:outline-none focus:border-term-bright-green focus:ring-3 focus:ring-term-green/10'}"
         />
-        <div class="mt-1.5 text-sm leading-relaxed
+        <div class="mt-1.5 text-sm leading-ui
           {currentTheme === 'modern'
             ? 'font-chat text-chat-text-secondary dark:text-chat-text-secondary-dark'
             : 'font-terminal text-term-dim-green'}"

--- a/src/webfront/settings/KeyboardShortcutsSettings.svelte
+++ b/src/webfront/settings/KeyboardShortcutsSettings.svelte
@@ -266,13 +266,14 @@
   }
 
   .shortcut-label {
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
   }
 
   .shortcut-description,
   .shortcut-current,
   .warning {
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     opacity: 0.75;
     margin-top: 0.25rem;
   }

--- a/src/webfront/settings/MCPSettings.svelte
+++ b/src/webfront/settings/MCPSettings.svelte
@@ -773,8 +773,9 @@
     border: none;
     color: var(--workx-primary);
     cursor: pointer;
-    font-size: 0.9375rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     padding: 0.5rem 0;
     margin-bottom: 1rem;
     display: flex;
@@ -789,16 +790,17 @@
 
   .settings-title {
     margin: 0 0 0.5rem 0;
-    font-size: 1.5rem;
-    font-weight: 600;
+    font-size: var(--text-2xl);
+    line-height: var(--text-2xl--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
   .settings-description {
     margin: 0 0 1.5rem 0;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     color: var(--workx-text-secondary);
-    line-height: 1.5;
+    line-height: var(--leading-normal);
   }
 
   .settings-form {
@@ -861,8 +863,9 @@
 
   .section-title {
     margin: 0;
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: var(--text-base);
+    line-height: var(--text-base--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
@@ -925,23 +928,25 @@
   }
 
   .server-name {
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
   .server-url {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text-secondary);
     word-break: break-all;
   }
 
   .status-badge {
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     padding: 0.125rem 0.5rem;
     border-radius: 1rem;
     text-transform: uppercase;
-    letter-spacing: 0.025em;
+    letter-spacing: var(--tracking-wide);
   }
 
   .badge-success {
@@ -972,7 +977,8 @@
     padding: 0.5rem;
     background: color-mix(in srgb, var(--workx-error) 10%, transparent);
     border-radius: 0.375rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-error);
   }
 
@@ -1001,7 +1007,8 @@
   .limit-message {
     text-align: center;
     color: var(--workx-text-secondary);
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     margin-top: 0.5rem;
   }
 
@@ -1026,12 +1033,13 @@
   }
 
   .tool-name {
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
   .tool-server {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     padding: 0.125rem 0.375rem;
     background: color-mix(in srgb, var(--workx-primary) 10%, transparent);
     color: var(--workx-primary);
@@ -1040,17 +1048,18 @@
 
   .tool-description {
     margin: 0;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     color: var(--workx-text-secondary);
-    line-height: 1.4;
+    line-height: var(--leading-ui);
   }
 
   /* Buttons */
   .btn {
     padding: 0.5rem 1rem;
     border-radius: 0.5rem;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     cursor: pointer;
     transition: all 0.2s;
     border: 1px solid transparent;
@@ -1083,7 +1092,8 @@
 
   .btn-small {
     padding: 0.375rem 0.75rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
   }
 
   .btn-icon {
@@ -1115,8 +1125,9 @@
   .form-label {
     display: block;
     margin-bottom: 0.5rem;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     color: var(--workx-text);
   }
 
@@ -1127,7 +1138,8 @@
     border-radius: 0.375rem;
     background: var(--workx-surface);
     color: var(--workx-text);
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     transition: all 0.2s;
   }
 
@@ -1142,7 +1154,8 @@
     align-items: center;
     gap: 0.5rem;
     cursor: pointer;
-    font-size: 0.9375rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text);
   }
 
@@ -1155,9 +1168,9 @@
 
   .help-text {
     margin-top: 0.375rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     color: var(--workx-text-secondary);
-    line-height: 1.4;
+    line-height: var(--leading-ui);
   }
 
   .form-error {
@@ -1167,7 +1180,8 @@
     padding: 0.75rem;
     background: color-mix(in srgb, var(--workx-error) 10%, transparent);
     border-radius: 0.5rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-error);
     margin-top: 1rem;
   }
@@ -1207,8 +1221,9 @@
 
   .modal-header h3 {
     margin: 0;
-    font-size: 1.125rem;
-    font-weight: 600;
+    font-size: var(--text-lg);
+    line-height: var(--text-lg--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
@@ -1249,7 +1264,8 @@
     gap: 0.5rem;
     padding: 0.75rem;
     border-radius: 0.5rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     margin-top: 1rem;
     max-width: 600px;
   }

--- a/src/webfront/settings/MemorySettings.svelte
+++ b/src/webfront/settings/MemorySettings.svelte
@@ -210,7 +210,7 @@
 
 <div class="p-6">
   <button
-    class="bg-transparent border-none cursor-pointer text-[15px] font-medium py-2 px-0 mb-4 flex items-center gap-1 transition-opacity duration-200 hover:opacity-80
+    class="bg-transparent border-none cursor-pointer text-sm font-medium py-2 px-0 mb-4 flex items-center gap-1 transition-opacity duration-200 hover:opacity-80
       {currentTheme === 'modern'
         ? 'font-chat text-chat-primary dark:text-chat-primary-dark'
         : 'font-terminal text-term-green'}"
@@ -235,12 +235,12 @@
       <div>
         <div class="flex items-center justify-between gap-4">
           <div class="flex flex-col gap-1">
-            <span class="text-[15px] font-medium
+            <span class="text-sm font-medium
               {currentTheme === 'modern'
                 ? 'font-chat text-chat-text dark:text-chat-text-dark'
                 : 'font-terminal text-term-green'}"
             >{$_t("Agent Memory")}</span>
-            <span class="text-sm leading-relaxed
+            <span class="text-sm leading-ui
               {currentTheme === 'modern'
                 ? 'font-chat text-chat-text-secondary dark:text-chat-text-secondary-dark'
                 : 'font-terminal text-term-dim-green'}"
@@ -266,7 +266,7 @@
                     ? 'font-chat text-chat-text dark:text-chat-text-dark'
                     : 'font-terminal text-term-green'}"
                 >{$_t("Use own OpenAI API key")}</span>
-                <span class="text-xs leading-relaxed
+                <span class="text-xs leading-ui
                   {currentTheme === 'modern'
                     ? 'font-chat text-chat-text-secondary dark:text-chat-text-secondary-dark'
                     : 'font-terminal text-term-dim-green'}"
@@ -327,7 +327,7 @@
         data-setting-id="memory-current"
       >
         <div class="flex items-center justify-between gap-4 mb-3">
-          <span class="text-[15px] font-medium
+          <span class="text-sm font-medium
             {currentTheme === 'modern'
               ? 'font-chat text-chat-text dark:text-chat-text-dark'
               : 'font-terminal text-term-green'}"
@@ -412,12 +412,12 @@
           : 'bg-term-bg border-term-dim-green'}"
     >
       <div class="flex flex-col gap-2">
-        <span class="text-[15px] font-medium
+        <span class="text-sm font-medium
           {currentTheme === 'modern'
             ? 'font-chat text-chat-text dark:text-chat-text-dark'
             : 'font-terminal text-term-green'}"
         >{$_t("How it works")}</span>
-        <div class="text-sm leading-relaxed flex flex-col gap-1.5
+        <div class="text-sm leading-ui flex flex-col gap-1.5
           {currentTheme === 'modern'
             ? 'font-chat text-chat-text-secondary dark:text-chat-text-secondary-dark'
             : 'font-terminal text-term-dim-green'}"

--- a/src/webfront/settings/MemorySettings.svelte
+++ b/src/webfront/settings/MemorySettings.svelte
@@ -266,7 +266,7 @@
                     ? 'font-chat text-chat-text dark:text-chat-text-dark'
                     : 'font-terminal text-term-green'}"
                 >{$_t("Use own OpenAI API key")}</span>
-                <span class="text-xs leading-ui
+                <span class="text-meta font-normal
                   {currentTheme === 'modern'
                     ? 'font-chat text-chat-text-secondary dark:text-chat-text-secondary-dark'
                     : 'font-terminal text-term-dim-green'}"
@@ -366,7 +366,7 @@
                   : 'bg-term-black text-term-green'}"
               >{memorySnapshot.coreMemory?.trim() || $_t("No core memory stored.")}</pre>
               {#if memorySnapshot.coreMemoryTruncated}
-                <div class="mt-1 text-xs">{$_t("Core memory preview is truncated.")}</div>
+                <div class="mt-1 text-meta font-normal">{$_t("Core memory preview is truncated.")}</div>
               {/if}
             </div>
 
@@ -382,7 +382,7 @@
                 <div class="flex flex-col gap-2">
                   {#each memorySnapshot.dailyFiles ?? [] as day}
                     <div>
-                      <div class="text-xs font-medium mb-1">{day.date}</div>
+                      <div class="text-meta font-medium mb-1">{day.date}</div>
                       <ul class="m-0 pl-4 flex flex-col gap-1">
                         {#each day.entries as entry}
                           <li>
@@ -392,7 +392,7 @@
                         {/each}
                       </ul>
                       {#if day.truncated}
-                        <div class="mt-1 text-xs">{$_t("More entries hidden.")}</div>
+                        <div class="mt-1 text-meta font-normal">{$_t("More entries hidden.")}</div>
                       {/if}
                     </div>
                   {/each}

--- a/src/webfront/settings/ModelSettings.svelte
+++ b/src/webfront/settings/ModelSettings.svelte
@@ -1503,8 +1503,9 @@
     border: none;
     color: var(--workx-primary);
     cursor: pointer;
-    font-size: 0.9375rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     padding: 0.5rem 0;
     display: flex;
     align-items: center;
@@ -1536,8 +1537,9 @@
 
   .section-title {
     margin: 0 0 1rem 0;
-    font-size: 1.125rem;
-    font-weight: 600;
+    font-size: var(--text-lg);
+    line-height: var(--text-lg--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
@@ -1549,10 +1551,11 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     padding: 0.25rem 0.75rem;
     border-radius: 9999px;
-    font-weight: 500;
+    font-weight: var(--font-weight-medium);
   }
 
   .auth-status.authenticated {
@@ -1572,8 +1575,9 @@
   .form-label {
     display: block;
     margin-bottom: 0.5rem;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     color: var(--workx-text);
   }
 
@@ -1589,8 +1593,9 @@
     border-radius: 0.5rem;
     background: var(--workx-surface);
     color: var(--workx-text);
-    font-size: 0.875rem;
-    font-family: 'SF Mono', 'Monaco', monospace;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-family: var(--font-mono);
     transition: all 0.2s;
   }
 
@@ -1633,7 +1638,8 @@
     border-radius: 0.5rem;
     background: var(--workx-surface);
     color: var(--workx-text);
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     cursor: pointer;
     transition: all 0.2s;
   }
@@ -1651,7 +1657,8 @@
 
   .help-text {
     margin-top: 0.5rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text-secondary);
   }
 
@@ -1667,8 +1674,9 @@
     gap: 0.5rem;
     padding: 0.75rem 1.5rem;
     border-radius: 0.5rem;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     cursor: pointer;
     transition: all 0.2s;
     border: 1px solid var(--workx-primary);
@@ -1735,7 +1743,8 @@
     gap: 0.5rem;
     padding: 0.75rem;
     border-radius: 0.5rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     margin-top: 1rem;
   }
 
@@ -1777,15 +1786,15 @@
   }
 
   .security-title {
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     margin-bottom: 0.25rem;
     color: var(--workx-text);
   }
 
   .security-text {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     color: var(--workx-text-secondary);
-    line-height: 1.5;
+    line-height: var(--leading-normal);
   }
 
   /* Provider Information */
@@ -1817,15 +1826,17 @@
   }
 
   .provider-info-label {
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     color: var(--workx-text-secondary);
     flex-shrink: 0;
   }
 
   .provider-info-value {
-    font-size: 0.875rem;
-    font-weight: 600;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
     max-width: 150px;
     overflow: hidden;
@@ -1838,8 +1849,9 @@
     border: none;
     color: var(--workx-primary);
     cursor: pointer;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     padding: 0.25rem 0.5rem;
     border-radius: 0.25rem;
     transition: all 0.2s;
@@ -1867,13 +1879,15 @@
   }
 
   .toggle-label {
-    font-size: 0.9375rem;
-    font-weight: 600;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
   .toggle-description {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text-secondary);
   }
 
@@ -1966,7 +1980,8 @@
 
   .chatgpt-oauth-status .btn-sm {
     padding: 0.25rem 0.5rem;
-    font-size: 0.8rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     margin-left: auto;
   }
 
@@ -1986,18 +2001,19 @@
   }
 
   .divider-text {
-    font-size: 0.8rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: var(--tracking-wider);
   }
 
   /* Custom endpoints (BYOK) */
   .custom-help {
     margin: 0 0 1rem 0;
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
     color: var(--workx-text-secondary, var(--workx-text));
     opacity: 0.8;
-    line-height: 1.4;
+    line-height: var(--leading-ui);
   }
 
   .custom-list {
@@ -2023,13 +2039,15 @@
   }
 
   .custom-item-name {
-    font-size: 0.9rem;
-    font-weight: 600;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
   .custom-item-meta {
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     color: var(--workx-text-secondary, var(--workx-text));
     opacity: 0.75;
     overflow: hidden;
@@ -2049,7 +2067,8 @@
 
   .btn-sm {
     padding: 0.35rem 0.7rem;
-    font-size: 0.8rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     flex-shrink: 0;
   }
 </style>

--- a/src/webfront/settings/ModelSettings.svelte
+++ b/src/webfront/settings/ModelSettings.svelte
@@ -1980,8 +1980,8 @@
 
   .chatgpt-oauth-status .btn-sm {
     padding: 0.25rem 0.5rem;
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     margin-left: auto;
   }
 
@@ -2046,8 +2046,8 @@
   }
 
   .custom-item-meta {
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
     color: var(--workx-text-secondary, var(--workx-text));
     opacity: 0.75;
     overflow: hidden;
@@ -2067,8 +2067,8 @@
 
   .btn-sm {
     padding: 0.35rem 0.7rem;
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     flex-shrink: 0;
   }
 </style>

--- a/src/webfront/settings/SecuritySettings.svelte
+++ b/src/webfront/settings/SecuritySettings.svelte
@@ -254,17 +254,17 @@
 
   .section-description {
     margin: 0 0 1rem;
-    font-size: var(--text-xs);
+    font-size: var(--text-meta);
     color: var(--workx-text-secondary);
-    line-height: var(--leading-ui);
+    line-height: var(--text-meta--line-height);
   }
 
   .status-message {
     padding: 0.5rem;
     margin-bottom: 0.75rem;
     border-radius: 0.375rem;
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
     color: var(--workx-success, #00ff00);
     background: rgba(0, 255, 0, 0.1);
     border: 1px solid var(--workx-success, #00ff00);
@@ -291,8 +291,8 @@
   }
 
   .setting-value {
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
     color: var(--workx-text-secondary);
   }
 
@@ -304,8 +304,8 @@
   .btn-action {
     padding: 0.375rem 0.75rem;
     border-radius: 0.375rem;
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     cursor: pointer;
     background: var(--workx-primary, #00ff00);
     color: var(--workx-background, #000);
@@ -344,8 +344,8 @@
 
   .form-field label {
     display: block;
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     margin-bottom: 0.125rem;
     color: var(--workx-text-secondary);
   }
@@ -371,15 +371,15 @@
 
   .form-error {
     color: var(--workx-error, #ff0000);
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
     margin-bottom: 0.5rem;
   }
 
   .form-warning {
-    font-size: var(--text-xs);
+    font-size: var(--text-meta);
     color: var(--workx-warning, #ffff00);
     margin: 0 0 0.5rem;
-    line-height: var(--leading-ui);
+    line-height: var(--text-meta--line-height);
   }
 </style>

--- a/src/webfront/settings/SecuritySettings.svelte
+++ b/src/webfront/settings/SecuritySettings.svelte
@@ -235,8 +235,9 @@
 
   .settings-view-title {
     margin: 0;
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: var(--text-base);
+    line-height: var(--text-base--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
@@ -246,22 +247,24 @@
 
   .section-title {
     margin: 0 0 0.25rem;
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text);
   }
 
   .section-description {
     margin: 0 0 1rem;
-    font-size: 0.8rem;
+    font-size: var(--text-xs);
     color: var(--workx-text-secondary);
-    line-height: 1.4;
+    line-height: var(--leading-ui);
   }
 
   .status-message {
     padding: 0.5rem;
     margin-bottom: 0.75rem;
     border-radius: 0.375rem;
-    font-size: 0.8rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     color: var(--workx-success, #00ff00);
     background: rgba(0, 255, 0, 0.1);
     border: 1px solid var(--workx-success, #00ff00);
@@ -282,12 +285,14 @@
   }
 
   .setting-label {
-    font-size: 0.85rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text);
   }
 
   .setting-value {
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     color: var(--workx-text-secondary);
   }
 
@@ -299,12 +304,13 @@
   .btn-action {
     padding: 0.375rem 0.75rem;
     border-radius: 0.375rem;
-    font-size: 0.8rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     cursor: pointer;
     background: var(--workx-primary, #00ff00);
     color: var(--workx-background, #000);
     border: none;
-    font-weight: 500;
+    font-weight: var(--font-weight-medium);
   }
 
   .btn-action:disabled {
@@ -338,7 +344,8 @@
 
   .form-field label {
     display: block;
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     margin-bottom: 0.125rem;
     color: var(--workx-text-secondary);
   }
@@ -346,8 +353,9 @@
   .form-field input {
     width: 100%;
     padding: 0.375rem;
-    font-size: 1rem;
-    letter-spacing: 0.2em;
+    font-size: var(--text-base);
+    line-height: var(--text-base--line-height);
+    letter-spacing: var(--tracking-pin);
     text-align: center;
     background: var(--workx-background);
     border: 1px solid var(--workx-border);
@@ -363,14 +371,15 @@
 
   .form-error {
     color: var(--workx-error, #ff0000);
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     margin-bottom: 0.5rem;
   }
 
   .form-warning {
-    font-size: 0.8rem;
+    font-size: var(--text-xs);
     color: var(--workx-warning, #ffff00);
     margin: 0 0 0.5rem;
-    line-height: 1.3;
+    line-height: var(--leading-ui);
   }
 </style>

--- a/src/webfront/settings/StorageSettings.svelte
+++ b/src/webfront/settings/StorageSettings.svelte
@@ -306,8 +306,9 @@
     border: none;
     color: var(--workx-primary);
     cursor: pointer;
-    font-size: 0.9375rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     padding: 0.5rem 0;
     margin-bottom: 1rem;
     display: flex;
@@ -322,8 +323,9 @@
 
   .settings-title {
     margin: 0 0 1.5rem 0;
-    font-size: 1.5rem;
-    font-weight: 600;
+    font-size: var(--text-2xl);
+    line-height: var(--text-2xl--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
@@ -349,8 +351,9 @@
 
   .section-title {
     margin: 0 0 1rem 0;
-    font-size: 1.125rem;
-    font-weight: 600;
+    font-size: var(--text-lg);
+    line-height: var(--text-lg--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
@@ -361,8 +364,9 @@
   .form-label {
     display: block;
     margin-bottom: 0.5rem;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     color: var(--workx-text);
   }
 
@@ -373,7 +377,8 @@
     border-radius: 0.375rem;
     background: var(--workx-surface);
     color: var(--workx-text);
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     transition: all 0.2s;
   }
 
@@ -396,7 +401,8 @@
     border-radius: 0.375rem;
     background: var(--workx-surface);
     color: var(--workx-text);
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     transition: all 0.2s;
   }
 
@@ -411,7 +417,8 @@
     align-items: center;
     gap: 0.5rem;
     cursor: pointer;
-    font-size: 0.9375rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text);
   }
 
@@ -433,9 +440,9 @@
 
   .help-text {
     margin-top: 0.375rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     color: var(--workx-text-secondary);
-    line-height: 1.4;
+    line-height: var(--leading-ui);
   }
 
   .button-group {
@@ -445,8 +452,9 @@
   .btn {
     padding: 0.75rem 1.5rem;
     border-radius: 0.5rem;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     cursor: pointer;
     transition: all 0.2s;
     border: 1px solid var(--workx-primary);
@@ -480,7 +488,8 @@
     gap: 0.5rem;
     padding: 0.75rem;
     border-radius: 0.5rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     margin-top: 1rem;
   }
 

--- a/src/webfront/settings/ToolsSettings.svelte
+++ b/src/webfront/settings/ToolsSettings.svelte
@@ -315,7 +315,7 @@
 
 <div class="p-6">
   <button
-    class="bg-transparent border-none cursor-pointer text-[15px] font-medium py-2 px-0 mb-4 flex items-center gap-1 transition-opacity duration-200 hover:opacity-80
+    class="bg-transparent border-none cursor-pointer text-sm font-medium py-2 px-0 mb-4 flex items-center gap-1 transition-opacity duration-200 hover:opacity-80
       {primaryClasses}"
     onclick={handleBack}
   >← {$_t("Back")}</button>
@@ -338,7 +338,7 @@
           />
           <span>{$_t("Enable All Tools")}</span>
         </label>
-        <div class="mt-1.5 text-sm leading-relaxed {textSecondaryClasses}">{$_t("Master toggle to enable or disable all browser and agent tools")}</div>
+        <div class="mt-1.5 text-sm leading-ui {textSecondaryClasses}">{$_t("Master toggle to enable or disable all browser and agent tools")}</div>
       </div>
     </div>
 
@@ -382,7 +382,7 @@
             { id: 'page-vision-tool', bind: 'page_vision_tool', label: $_t("Page Vision Tool"), help: $_t("Visual analysis of page content and layout") }
           ] as tool}
             <div class="{tool !== undefined ? 'mb-6 last:mb-0' : ''}" data-setting-id={tool.id}>
-              <label class="flex items-center gap-2 cursor-pointer text-[15px] {textClasses}">
+              <label class="flex items-center gap-2 cursor-pointer text-sm {textClasses}">
                 <input
                   type="checkbox"
                   bind:checked={currentTools[tool.bind]}
@@ -391,7 +391,7 @@
                 />
                 <span>{tool.label}</span>
               </label>
-              <div class="mt-1.5 text-sm leading-relaxed {textSecondaryClasses}">{tool.help}</div>
+              <div class="mt-1.5 text-sm leading-ui {textSecondaryClasses}">{tool.help}</div>
             </div>
           {/each}
         </div>
@@ -426,7 +426,7 @@
       {#if agentToolsExpanded}
         <div class="p-4 border-t {isModern ? 'border-chat-border dark:border-chat-border-dark' : 'border-term-dim-green'}">
           <div class="mb-6" data-setting-id="exec-command">
-            <label class="flex items-center gap-2 cursor-pointer text-[15px] {textClasses}">
+            <label class="flex items-center gap-2 cursor-pointer text-sm {textClasses}">
               <input
                 type="checkbox"
                 bind:checked={currentTools.execCommand}
@@ -435,11 +435,11 @@
               />
               <span>{$_t("Execute Commands")}</span>
             </label>
-            <div class="mt-1.5 text-sm leading-relaxed {textSecondaryClasses}">{$_t("Allow agent to execute system commands (use with caution)")}</div>
+            <div class="mt-1.5 text-sm leading-ui {textSecondaryClasses}">{$_t("Allow agent to execute system commands (use with caution)")}</div>
           </div>
 
           <div class="mb-6" data-setting-id="web-search">
-            <label class="flex items-center gap-2 cursor-pointer text-[15px] {textClasses}">
+            <label class="flex items-center gap-2 cursor-pointer text-sm {textClasses}">
               <input
                 type="checkbox"
                 bind:checked={currentTools.webSearch}
@@ -448,11 +448,11 @@
               />
               <span>{$_t("Web Search")}</span>
             </label>
-            <div class="mt-1.5 text-sm leading-relaxed {textSecondaryClasses}">{$_t("Enable web search capabilities for the agent")}</div>
+            <div class="mt-1.5 text-sm leading-ui {textSecondaryClasses}">{$_t("Enable web search capabilities for the agent")}</div>
           </div>
 
           <div class="mb-6" data-setting-id="file-operations">
-            <label class="flex items-center gap-2 cursor-pointer text-[15px] opacity-50 cursor-not-allowed {textClasses}">
+            <label class="flex items-center gap-2 cursor-pointer text-sm opacity-50 cursor-not-allowed {textClasses}">
               <input
                 type="checkbox"
                 bind:checked={currentTools.fileOperations}
@@ -462,11 +462,11 @@
               />
               <span class="italic {textSecondaryClasses}">{$_t("File Operations (Not Available)")}</span>
             </label>
-            <div class="mt-1.5 text-sm leading-relaxed {textSecondaryClasses}">{$_t("Allow agent to read, write, and manage files (Coming in future update)")}</div>
+            <div class="mt-1.5 text-sm leading-ui {textSecondaryClasses}">{$_t("Allow agent to read, write, and manage files (Coming in future update)")}</div>
           </div>
 
           <div data-setting-id="mcp-tools">
-            <label class="flex items-center gap-2 cursor-pointer text-[15px] {textClasses}">
+            <label class="flex items-center gap-2 cursor-pointer text-sm {textClasses}">
               <input
                 type="checkbox"
                 bind:checked={currentTools.mcpTools}
@@ -475,7 +475,7 @@
               />
               <span>{$_t("MCP Tools")}</span>
             </label>
-            <div class="mt-1.5 text-sm leading-relaxed {textSecondaryClasses}">{$_t("Enable Model Context Protocol tools from connected MCP servers")}</div>
+            <div class="mt-1.5 text-sm leading-ui {textSecondaryClasses}">{$_t("Enable Model Context Protocol tools from connected MCP servers")}</div>
           </div>
         </div>
       {/if}
@@ -520,7 +520,7 @@
               class="w-full py-2.5 px-2.5 rounded-md text-sm transition-all duration-200 {inputClasses}"
               placeholder="30000"
             />
-            <div class="mt-1.5 text-sm leading-relaxed {textSecondaryClasses}">{$_t("Maximum time (in milliseconds) a tool can run before timeout (default: 30000)")}</div>
+            <div class="mt-1.5 text-sm leading-ui {textSecondaryClasses}">{$_t("Maximum time (in milliseconds) a tool can run before timeout (default: 30000)")}</div>
           </div>
 
           <!-- Legacy Sandbox Policy (non-desktop) -->
@@ -537,7 +537,7 @@
                 <option value="workspace-write">{$_t("Workspace Write")}</option>
                 <option value="danger-full-access">{$_t("Full Access (Dangerous)")}</option>
               </select>
-              <div class="mt-1.5 text-sm leading-relaxed {textSecondaryClasses}">{$_t("Security level for tool execution environment")}</div>
+              <div class="mt-1.5 text-sm leading-ui {textSecondaryClasses}">{$_t("Security level for tool execution environment")}</div>
             </div>
           {/if}
         </div>
@@ -592,7 +592,7 @@
                 <option value="safe">{$_t("Safe")}</option>
                 <option value="power">{$_t("Power")}</option>
               </select>
-              <div class="mt-1.5 text-sm leading-relaxed {textSecondaryClasses}">
+              <div class="mt-1.5 text-sm leading-ui {textSecondaryClasses}">
                 {#if executionMode === 'safe'}
                   {$_t("All commands run inside an OS-native sandbox. Writes restricted to workspace directory.")}
                 {:else if executionMode === 'power'}
@@ -616,7 +616,7 @@
                 <option value="ro">{$_t("Read-Only")}</option>
                 <option value="none">{$_t("No Access")}</option>
               </select>
-              <div class="mt-1.5 text-sm leading-relaxed {textSecondaryClasses}">{$_t("How the workspace directory is mounted in the sandbox")}</div>
+              <div class="mt-1.5 text-sm leading-ui {textSecondaryClasses}">{$_t("How the workspace directory is mounted in the sandbox")}</div>
             </div>
 
             <!-- Network Mode -->
@@ -631,13 +631,13 @@
                 <option value="host">{$_t("Allowed")}</option>
                 <option value="sandbox">{$_t("Restricted")}</option>
               </select>
-              <div class="mt-1.5 text-sm leading-relaxed {textSecondaryClasses}">{$_t("Whether sandboxed commands can access the network")}</div>
+              <div class="mt-1.5 text-sm leading-ui {textSecondaryClasses}">{$_t("Whether sandboxed commands can access the network")}</div>
             </div>
 
             <!-- Bind Mounts -->
             <div data-setting-id="bind-mounts">
               <label class="block mb-2 text-sm font-medium {textClasses}">{$_t("Additional Bind Mounts")}</label>
-              <div class="mb-2 text-sm leading-relaxed {textSecondaryClasses}">{$_t("Extra directories accessible inside the sandbox")}</div>
+              <div class="mb-2 text-sm leading-ui {textSecondaryClasses}">{$_t("Extra directories accessible inside the sandbox")}</div>
 
               {#if bindMounts.length > 0}
                 <div class="flex flex-col gap-1.5 mb-2">
@@ -701,7 +701,7 @@
           </span>
         </div>
         <div class="p-4 border-t {isModern ? 'border-chat-border dark:border-chat-border-dark' : 'border-term-dim-green'}">
-          <div class="mb-4 text-sm leading-relaxed {textSecondaryClasses}">
+          <div class="mb-4 text-sm leading-ui {textSecondaryClasses}">
             {$_t("Control your real Chrome browser through the WorkX extension instead of a separate automation browser. Native connection is automatic on macOS/Linux. For Windows or fallback pairing, copy the token below into Extension side panel → Settings → Extension → Desktop Bridge.")}
           </div>
 

--- a/src/webfront/settings/components/ModelSelector.svelte
+++ b/src/webfront/settings/components/ModelSelector.svelte
@@ -643,7 +643,7 @@
     display: inline-flex;
     align-items: center;
     gap: 0.25rem;
-    font-weight: 500;
+    font-weight: var(--font-weight-medium);
     cursor: pointer;
   }
 
@@ -741,9 +741,9 @@
 
   /* Tooltip line styling */
   .tooltip-line {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     color: rgb(209, 213, 219);
-    line-height: 1.3;
+    line-height: var(--leading-ui);
     word-wrap: break-word;
   }
 

--- a/src/webfront/settings/components/ModelSelector.svelte
+++ b/src/webfront/settings/components/ModelSelector.svelte
@@ -498,7 +498,7 @@
                     {/each}
                     {#if isSelectedModelName && !isLockedForFreeUser}
                       <span
-                        class="selected-tag px-2 py-0.5 text-sm bg-cyan-500/20 text-cyan-400 rounded border border-cyan-500/30"
+                        class="selected-tag px-2 py-0.5 text-xs bg-cyan-500/20 text-cyan-400 rounded border border-cyan-500/30"
                       >
                         {$_t('Selected')}
                       </span>
@@ -525,7 +525,7 @@
                   {/if}
                   {#if isSelectedModelName && !isLockedForFreeUser}
                     <span
-                      class="selected-tag px-2 py-0.5 text-sm bg-cyan-500/20 text-cyan-400 rounded border border-cyan-500/30"
+                      class="selected-tag px-2 py-0.5 text-xs bg-cyan-500/20 text-cyan-400 rounded border border-cyan-500/30"
                     >
                       {$_t('Selected')}
                     </span>
@@ -575,13 +575,13 @@
                       </a>
                     </div>
                   {:else}
-                    <div class="mt-1 text-sm text-gray-400">
+                    <div class="mt-1 text-meta font-normal text-gray-400">
                       {displayProvider.contextWindow.toLocaleString()} {$_t('tokens')}
                     </div>
                   {/if}
                 {:else if firstProvider.pricing}
                   <div class="mt-2 flex items-center justify-between gap-2">
-                    <div class="text-sm text-gray-400">
+                    <div class="text-meta font-normal text-gray-400">
                       <div>{$_t('Input:')} {firstProvider.pricing.inputToken}</div>
                       <div>{$_t('Output:')} {firstProvider.pricing.outputToken}</div>
                     </div>
@@ -604,7 +604,7 @@
                     </a>
                   </div>
                 {:else}
-                  <div class="mt-1 text-sm text-gray-400">
+                  <div class="mt-1 text-meta font-normal text-gray-400">
                     {firstProvider.contextWindow.toLocaleString()} {$_t('tokens')}
                   </div>
                 {/if}
@@ -741,9 +741,9 @@
 
   /* Tooltip line styling */
   .tooltip-line {
-    font-size: var(--text-sm);
+    font-size: var(--text-meta);
     color: rgb(209, 213, 219);
-    line-height: var(--leading-ui);
+    line-height: var(--text-meta--line-height);
     word-wrap: break-word;
   }
 

--- a/src/webfront/settings/components/SettingsMenu.svelte
+++ b/src/webfront/settings/components/SettingsMenu.svelte
@@ -203,8 +203,9 @@
 
   .menu-title {
     margin: 0 0 1.5rem 0;
-    font-size: 1.5rem;
-    font-weight: 600;
+    font-size: var(--text-2xl);
+    line-height: var(--text-2xl--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
@@ -265,15 +266,16 @@
 
   .category-label {
     margin: 0;
-    font-size: 1.125rem;
-    font-weight: 600;
+    font-size: var(--text-lg);
+    line-height: var(--text-lg--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
   .category-description {
     margin: 0;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     color: var(--workx-text-secondary);
-    line-height: 1.5;
+    line-height: var(--leading-normal);
   }
 </style>

--- a/src/webfront/settings/components/SettingsSearch.svelte
+++ b/src/webfront/settings/components/SettingsSearch.svelte
@@ -356,7 +356,8 @@
     border: 1px solid var(--workx-border);
     border-radius: 0.5rem;
     color: var(--workx-text);
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     outline: none;
     transition: border-color 0.2s;
   }
@@ -445,14 +446,16 @@
   }
 
   .result-label {
-    font-size: 0.875rem;
-    font-weight: 600;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
   .result-section-badge {
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     padding: 0.0625rem 0.375rem;
     background: color-mix(in srgb, var(--workx-primary) 12%, transparent);
     color: var(--workx-primary);
@@ -461,22 +464,24 @@
   }
 
   .result-description {
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     color: var(--workx-text-secondary);
-    line-height: 1.4;
+    line-height: var(--leading-ui);
   }
 
   .no-results {
     padding: 1.25rem 0.75rem;
     text-align: center;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text-secondary);
   }
 
   .more-results {
     padding: 0.5rem 0.75rem;
     text-align: center;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
     color: var(--workx-text-secondary);
     border-top: 1px solid var(--workx-border);
   }

--- a/src/webfront/settings/components/UnsavedChangesDialog.svelte
+++ b/src/webfront/settings/components/UnsavedChangesDialog.svelte
@@ -124,16 +124,17 @@
 
   #dialog-title {
     margin: 0 0 0.75rem 0;
-    font-size: 1.25rem;
-    font-weight: 600;
+    font-size: var(--text-xl);
+    line-height: var(--text-xl--line-height);
+    font-weight: var(--font-weight-semibold);
     color: var(--workx-text);
   }
 
   .dialog-message {
     margin: 0 0 1.5rem 0;
-    font-size: 0.9375rem;
+    font-size: var(--text-sm);
     color: var(--workx-text-secondary);
-    line-height: 1.5;
+    line-height: var(--leading-normal);
   }
 
   .dialog-actions {
@@ -145,8 +146,9 @@
   .btn {
     padding: 0.625rem 1.25rem;
     border-radius: 0.375rem;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var(--text-sm);
+    line-height: var(--text-sm--line-height);
+    font-weight: var(--font-weight-medium);
     cursor: pointer;
     transition: all 0.2s;
     border: none;

--- a/src/webfront/shortcuts/ShortcutHelp.svelte
+++ b/src/webfront/shortcuts/ShortcutHelp.svelte
@@ -46,12 +46,13 @@
   }
 
   .shortcut-label {
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
   }
 
   .shortcut-description {
     margin-top: 2px;
-    font-size: 12px;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
     opacity: 0.72;
   }
 
@@ -62,6 +63,7 @@
     border-radius: 4px;
     background: color-mix(in srgb, var(--workx-surface, #111) 90%, white);
     font: inherit;
-    font-size: 12px;
+    font-size: var(--text-xs);
+    line-height: var(--text-xs--line-height);
   }
 </style>

--- a/src/webfront/shortcuts/ShortcutHelp.svelte
+++ b/src/webfront/shortcuts/ShortcutHelp.svelte
@@ -51,8 +51,8 @@
 
   .shortcut-description {
     margin-top: 2px;
-    font-size: var(--text-xs);
-    line-height: var(--text-xs--line-height);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
     opacity: 0.72;
   }
 

--- a/src/webfront/styles.css
+++ b/src/webfront/styles.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "../styles/typography.css";
 
 @custom-variant dark (&:where(.dark, .dark *));
 
@@ -14,12 +15,6 @@
   --color-term-bright-green: #33ff00;
   --color-term-dim-green: #00cc00;
   --color-term-blue: #60a5fa;
-
-  /* Terminal Font */
-  --font-terminal: 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', monospace;
-
-  /* Chat Font */
-  --font-chat: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 
   /* WorkX Semantic Colors — Light */
   --color-bx-primary: #4f46e5;
@@ -122,7 +117,6 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: system-ui, -apple-system, sans-serif;
   background: #000000;
   color: #00ff00;
   width: 100%;
@@ -131,7 +125,7 @@ body {
 }
 
 body.terminal-mode {
-  font-family: 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', monospace;
+  @apply font-terminal text-sm;
   background: #000000;
   color: #00ff00;
 }
@@ -164,9 +158,9 @@ body.terminal-mode {
 
 /* Terminal component styles */
 .terminal-container {
+  @apply font-terminal text-sm;
   background-color: var(--color-term-bg);
   color: var(--color-term-green);
-  font-family: var(--font-terminal);
   padding: 0 1rem 1rem;
   min-height: 100vh;
   overflow: auto;

--- a/src/welcome/welcome.css
+++ b/src/welcome/welcome.css
@@ -1,8 +1,8 @@
 /* Welcome page styles */
 @import "tailwindcss";
+@import "../styles/typography.css";
 
 body {
   margin: 0;
   padding: 0;
-  font-family: system-ui, -apple-system, sans-serif;
 }


### PR DESCRIPTION
## What changed

- add a shared Tailwind typography theme using the macOS system/SF Pro font stack
- standardize the desktop scale around 13px metadata, 14px interface text, and 16px reading text
- normalize line heights, weights, letter spacing, and monospace usage across chat, settings, scheduler, vault, welcome, desktop, and extension UI surfaces
- replace scattered arbitrary typography values with shared Tailwind utilities and theme tokens
- keep inline code proportional inside headings while preserving fixed sizing for fenced code
- provide local typography fallbacks for the extension's isolated shadow-root overlay
- add regression coverage that prevents component-local typography values from drifting from the shared scale

## Why

Typography values were distributed across component classes and scoped CSS, which produced inconsistent text hierarchy and spacing. Centralizing the scale makes WorkX feel closer to native macOS chat apps while keeping Tailwind as the primary styling system.

## Impact

Users get more consistent type sizing and reading rhythm throughout the desktop app. Developers get one source of truth for typography tokens and tests that catch future drift.

## Validation

- `npm run type-check`
- `npx vitest run src/webfront/__tests__/typography.test.ts` (4 tests passed)
- targeted ESLint on the review-touched files (0 errors; existing warnings only)
- `npx vite build --config vite.config.content.mjs`
- `npm run build:desktop`
- Tauri desktop app smoke-tested locally