### PR TITLE
WORKXOS-14 Optimize the chat history in left pannel

### DIFF
--- a/src/webfront/components/layout/ChatHistorySection.svelte
+++ b/src/webfront/components/layout/ChatHistorySection.svelte
@@ -93,17 +93,6 @@
     }
   }
 
-  async function newConversation(): Promise<void> {
-    const client = await getInitializedUIClient();
-    const response = await client.serviceRequest<{
-      sessionId: string;
-      entry?: ThreadListItem;
-    }>('session.open', {});
-    if (response.entry) threadStore.mergeThread(response.entry);
-    else threadStore.createThread(response.sessionId);
-    selectConversation(response.sessionId);
-  }
-
   async function togglePin(sessionId: string, pinned: boolean): Promise<void> {
     const client = await getInitializedUIClient();
     const entry = await client.serviceRequest<ThreadListItem>('session.pin', { sessionId, pinned });
@@ -170,9 +159,9 @@
 </script>
 
 <LeftPanelSection title="Chat History">
-  <div class="px-2 pb-2 flex gap-1">
+  <div class="px-2 pb-2">
     <input
-      class="min-w-0 flex-1 rounded px-2 py-1 text-xs bg-transparent border
+      class="w-full min-w-0 rounded px-2 py-1 text-xs bg-transparent border
         {currentTheme === 'modern'
           ? 'border-chat-border dark:border-chat-border-dark text-chat-text dark:text-chat-text-dark placeholder:text-chat-text-muted dark:placeholder:text-chat-text-muted-dark'
           : 'border-term-dim-green text-term-green placeholder:text-term-dim-green'}"
@@ -181,13 +170,6 @@
       placeholder={$_t('Search chats')}
       aria-label={$_t('Search chats')}
     />
-    <button
-      class="rounded px-2 text-sm cursor-pointer border-none
-        {currentTheme === 'modern' ? 'bg-chat-primary text-white' : 'bg-term-green/20 text-term-bright-green'}"
-      onclick={() => void newConversation()}
-      aria-label={$_t('New Chat')}
-      title={$_t('New Chat')}
-    >+</button>
   </div>
 
   {#if attentionThreads.length > 0}
@@ -212,13 +194,13 @@
     <div class="px-2 py-1.5 text-xs opacity-70">{$_t('No chat history yet')}</div>
   {:else}
     <div
-      class="max-h-80 overflow-y-auto overscroll-contain pr-0.5"
+      class="flex flex-col gap-0.5"
       data-thread-history-list
       aria-label={$_t('Chat History')}
     >
       {#each $threadStore.threads as item (item.sessionId)}
         {@const isActive = $threadStore.activeSessionId === item.sessionId}
-        <div class="group flex items-center rounded-md transition-colors
+        <div class="group relative flex items-center rounded-md transition-colors
           {currentTheme === 'modern'
             ? (isActive
                 ? 'bg-chat-button-hover dark:bg-chat-button-hover-dark text-chat-text dark:text-chat-text-dark'
@@ -243,20 +225,39 @@
                 title={item.runtime.state === 'running' ? $_t('Running') : undefined}></span>
             {/if}
             <span class="flex-1 truncate">{item.title || $_t('Untitled conversation')}</span>
-            {#if item.runtime.durability === 'degraded'}<span title={$_t('Durability degraded')}>⚠</span>{/if}
-            <span class="shrink-0 text-xs opacity-60">{formatTimeAgo(item.lastActiveAt)}</span>
+            {#if item.runtime.durability === 'degraded'}<span class="shrink-0" title={$_t('Durability degraded')}>⚠</span>{/if}
+            {#if item.pinned}
+              <!-- Persistent pin marker so pinned rows read as pinned at rest;
+                   the hover overlay's pin toggle fades in over it on hover. -->
+              <span class="shrink-0 text-xs opacity-70 group-hover:opacity-0 transition-opacity"
+                title={$_t('Pinned')} aria-hidden="true">★</span>
+            {/if}
           </button>
-          {#if item.attentionRequest}
-            <button class="px-1 border-none bg-transparent text-inherit cursor-pointer" title={$_t('Continue browser action')}
-              onclick={() => void resolveAttention(item.sessionId, item.attentionRequest!.requestId)}>↗</button>
-          {/if}
-          <button class="px-1 border-none bg-transparent text-inherit cursor-pointer opacity-60 hover:opacity-100"
-            title={item.pinned ? $_t('Unpin') : $_t('Pin')}
-            onclick={() => void togglePin(item.sessionId, !item.pinned)}>{item.pinned ? '★' : '☆'}</button>
-          <button class="hidden lg:block px-1 border-none bg-transparent text-inherit cursor-pointer opacity-0 group-hover:opacity-60 hover:!opacity-100"
-            title={$_t('Rename')} onclick={() => void rename(item.sessionId, item.title)}>✎</button>
-          <button class="px-1 pr-2 border-none bg-transparent text-inherit cursor-pointer opacity-0 group-hover:opacity-60 hover:!opacity-100"
-            title={$_t('Delete')} onclick={() => void remove(item.sessionId, item.title)}>×</button>
+
+          <!-- Hover overlay: floats above the row's right edge so the title text
+               can use the full width at rest. The row's controls (time, pin,
+               rename, delete) reveal only on hover or keyboard focus. -->
+          <div class="absolute inset-y-0 right-0 flex items-center gap-0.5 pl-8 pr-1 rounded-r-md
+            opacity-0 pointer-events-none transition-opacity
+            group-hover:opacity-100 group-hover:pointer-events-auto
+            group-focus-within:opacity-100 group-focus-within:pointer-events-auto
+            {currentTheme === 'modern'
+              ? 'bg-gradient-to-l from-chat-button-hover dark:from-chat-button-hover-dark via-chat-button-hover dark:via-chat-button-hover-dark via-60% to-transparent'
+              : 'bg-gradient-to-l from-term-bg via-term-bg via-60% to-transparent'}">
+            <span class="shrink-0 text-xs opacity-60">{formatTimeAgo(item.lastActiveAt)}</span>
+            {#if item.attentionRequest}
+              <button class="px-1 border-none bg-transparent text-inherit cursor-pointer opacity-70 hover:opacity-100"
+                title={$_t('Continue browser action')}
+                onclick={() => void resolveAttention(item.sessionId, item.attentionRequest!.requestId)}>↗</button>
+            {/if}
+            <button class="px-1 border-none bg-transparent text-inherit cursor-pointer opacity-70 hover:opacity-100"
+              title={item.pinned ? $_t('Unpin') : $_t('Pin')}
+              onclick={() => void togglePin(item.sessionId, !item.pinned)}>{item.pinned ? '★' : '☆'}</button>
+            <button class="px-1 border-none bg-transparent text-inherit cursor-pointer opacity-70 hover:opacity-100"
+              title={$_t('Rename')} onclick={() => void rename(item.sessionId, item.title)}>✎</button>
+            <button class="px-1 border-none bg-transparent text-inherit cursor-pointer opacity-70 hover:opacity-100"
+              title={$_t('Delete')} onclick={() => void remove(item.sessionId, item.title)}>×</button>
+          </div>
         </div>
       {/each}
     </div>

--- a/src/webfront/components/layout/ChatHistorySection.svelte
+++ b/src/webfront/components/layout/ChatHistorySection.svelte
@@ -287,18 +287,18 @@
               >
             {/if}
             <button
-              class="px-1 border-none bg-transparent text-inherit cursor-pointer opacity-70 hover:opacity-100"
+              class="px-1 border-none bg-transparent text-inherit text-[1.5em] leading-none cursor-pointer opacity-70 hover:opacity-100"
               title={item.pinned ? $_t('Unpin') : $_t('Pin')}
               onclick={() => void togglePin(item.sessionId, !item.pinned)}
               >{item.pinned ? '★' : '☆'}</button
             >
             <button
-              class="px-1 border-none bg-transparent text-inherit cursor-pointer opacity-70 hover:opacity-100"
+              class="px-1 border-none bg-transparent text-inherit text-[1.5em] leading-none cursor-pointer opacity-70 hover:opacity-100"
               title={$_t('Rename')}
               onclick={() => void rename(item.sessionId, item.title)}>✎</button
             >
             <button
-              class="px-1 border-none bg-transparent text-inherit cursor-pointer opacity-70 hover:opacity-100"
+              class="px-1 border-none bg-transparent text-inherit text-[1.5em] leading-none cursor-pointer opacity-70 hover:opacity-100"
               title={$_t('Delete')}
               onclick={() => void remove(item.sessionId, item.title)}>×</button
             >

--- a/src/webfront/components/layout/LeftPanel.svelte
+++ b/src/webfront/components/layout/LeftPanel.svelte
@@ -3,6 +3,7 @@
   import { location, push } from 'svelte-spa-router';
   import { uiTheme } from '../../stores/themeStore';
   import { userStore } from '../../stores/userStore';
+  import { overlayScroll } from '../../lib/actions/overlayScroll';
   import UserLoginStatus from '../common/UserLoginStatus.svelte';
   import NavTab from './NavTab.svelte';
   import LeftPanelSection from './LeftPanelSection.svelte';
@@ -39,7 +40,14 @@
   }
 </script>
 
-<div class="flex flex-col h-full w-full p-3 gap-2 overflow-y-auto
+<!-- Positioned, clipped host so the floating overlay scrollbar (see
+     lib/actions/overlayScroll.ts) can anchor to it without scrolling away or
+     reserving gutter width. The inner element is the sole scroll surface. -->
+<div class="relative h-full w-full overflow-hidden
+  {currentTheme === 'modern'
+    ? 'bg-chat-surface dark:bg-chat-surface-dark'
+    : 'bg-term-bg'}">
+<div use:overlayScroll class="flex flex-col h-full w-full p-3 gap-2 overflow-y-auto
   {currentTheme === 'modern'
     ? 'bg-chat-surface dark:bg-chat-surface-dark'
     : 'bg-term-bg'}">
@@ -71,4 +79,5 @@
     {/if}
     <UserLoginStatus />
   </div>
+</div>
 </div>

--- a/src/webfront/components/layout/__tests__/ChatHistorySection.test.ts
+++ b/src/webfront/components/layout/__tests__/ChatHistorySection.test.ts
@@ -83,7 +83,7 @@ describe('ChatHistorySection paging', () => {
     });
   });
 
-  it('loads ten rows at a time inside a fixed-height scroll container', async () => {
+  it('loads ten rows at a time appended into the panel, with no inner scroll container', async () => {
     mocks.serviceRequest
       .mockResolvedValueOnce({ entries: Array.from({ length: 10 }, (_, index) => item(index)), nextCursor: 'page-2' })
       .mockResolvedValueOnce({ entries: Array.from({ length: 10 }, (_, index) => item(index + 10)), nextCursor: null });
@@ -96,8 +96,10 @@ describe('ChatHistorySection paging', () => {
       cursor: undefined,
     }));
     expect(container.querySelectorAll('[data-thread-history-select]')).toHaveLength(10);
-    expect(container.querySelector('[data-thread-history-list]')?.className).toContain('max-h-80');
-    expect(container.querySelector('[data-thread-history-list]')?.className).toContain('overflow-y-auto');
+    // The chat-history list no longer owns a scrollbar; the whole left panel is
+    // the sole scroll surface, so the list must not clamp height or scroll.
+    expect(container.querySelector('[data-thread-history-list]')?.className).not.toContain('max-h-80');
+    expect(container.querySelector('[data-thread-history-list]')?.className).not.toContain('overflow-y-auto');
 
     await fireEvent.click(screen.getByRole('button', { name: 'Load More' }));
     await waitFor(() => {
@@ -108,6 +110,20 @@ describe('ChatHistorySection paging', () => {
       cursor: 'page-2',
     }));
     expect(screen.queryByRole('button', { name: 'Load More' })).toBeNull();
+  });
+
+  it('drops the header new-chat button and keeps per-row controls in the hover layer', async () => {
+    mocks.serviceRequest.mockResolvedValue({ entries: [item(0)], nextCursor: null });
+
+    render(ChatHistorySection);
+
+    await screen.findByText('Conversation 0');
+    expect(screen.queryByRole('button', { name: 'New Chat' })).toBeNull();
+    // Row controls still exist (rendered in the hover overlay), so pin/rename/
+    // delete remain reachable. They expose their label via `title`.
+    expect(screen.getByTitle('Pin')).toBeTruthy();
+    expect(screen.getByTitle('Rename')).toBeTruthy();
+    expect(screen.getByTitle('Delete')).toBeTruthy();
   });
 
   it('lets a newer search replace an in-flight result and ignores the stale response', async () => {

--- a/src/webfront/components/layout/__tests__/ChatHistorySection.test.ts
+++ b/src/webfront/components/layout/__tests__/ChatHistorySection.test.ts
@@ -152,9 +152,11 @@ describe('ChatHistorySection paging', () => {
     expect(screen.queryByRole('button', { name: 'New Chat' })).toBeNull();
     // Row controls still exist (rendered in the hover overlay), so pin/rename/
     // delete remain reachable. They expose their label via `title`.
-    expect(screen.getByTitle('Pin')).toBeTruthy();
-    expect(screen.getByTitle('Rename')).toBeTruthy();
-    expect(screen.getByTitle('Delete')).toBeTruthy();
+    for (const title of ['Pin', 'Rename', 'Delete']) {
+      const control = screen.getByTitle(title);
+      expect(control.classList.contains('text-[1.5em]')).toBe(true);
+      expect(control.classList.contains('leading-none')).toBe(true);
+    }
   });
 
   it('lets a newer search replace an in-flight result and ignores the stale response', async () => {

--- a/src/webfront/lib/actions/overlayScroll.ts
+++ b/src/webfront/lib/actions/overlayScroll.ts
@@ -1,0 +1,143 @@
+import type { Action } from 'svelte/action';
+
+/**
+ * Floating, auto-hiding scrollbar for a scroll container.
+ *
+ * The native scrollbar reserves gutter width and (cross-platform) either shows
+ * permanently or hides on OS-controlled timing. This action instead hides the
+ * native bar (`.no-native-scrollbar`) and draws a custom thumb that floats over
+ * the content: hidden at rest, revealed while the user scrolls, and auto-hidden
+ * a fixed delay after scrolling stops. The thumb is draggable.
+ *
+ * The thumb is appended to the node's parent (not the node itself) so it does
+ * not scroll away with the content — the parent must be positioned
+ * (`position: relative`).
+ */
+export interface OverlayScrollOptions {
+  /** Milliseconds to keep the thumb visible after the last scroll. */
+  hideDelayMs?: number;
+}
+
+const DEFAULT_HIDE_DELAY_MS = 3000;
+const MIN_THUMB_HEIGHT = 24;
+
+export const overlayScroll: Action<HTMLElement, OverlayScrollOptions | undefined> = (
+  node,
+  options,
+) => {
+  const parent = node.parentElement;
+  // No positioned host to anchor the thumb, or a non-DOM environment (SSR):
+  // degrade gracefully to the native scrollbar.
+  if (!parent || typeof document === 'undefined') return {};
+
+  node.classList.add('no-native-scrollbar');
+
+  const thumb = document.createElement('div');
+  thumb.className = 'overlay-scroll-thumb';
+  thumb.setAttribute('aria-hidden', 'true');
+  parent.appendChild(thumb);
+
+  let hideDelay = options?.hideDelayMs ?? DEFAULT_HIDE_DELAY_MS;
+  let hideTimer: ReturnType<typeof setTimeout> | null = null;
+  let dragging = false;
+  let dragStartY = 0;
+  let dragStartScrollTop = 0;
+
+  function scrollable(): boolean {
+    return node.scrollHeight - node.clientHeight > 1;
+  }
+
+  function layout(): void {
+    const { scrollHeight, clientHeight, scrollTop } = node;
+    if (!scrollable()) {
+      thumb.style.height = '0px';
+      thumb.classList.remove('is-visible');
+      return;
+    }
+    const track = clientHeight;
+    const thumbHeight = Math.max((clientHeight / scrollHeight) * track, MIN_THUMB_HEIGHT);
+    const maxScroll = scrollHeight - clientHeight;
+    const maxThumbTop = track - thumbHeight;
+    const thumbTop = maxScroll > 0 ? (scrollTop / maxScroll) * maxThumbTop : 0;
+    thumb.style.height = `${thumbHeight}px`;
+    thumb.style.transform = `translateY(${thumbTop}px)`;
+  }
+
+  function reveal(): void {
+    layout();
+    if (!scrollable()) return;
+    thumb.classList.add('is-visible');
+    if (hideTimer) clearTimeout(hideTimer);
+    hideTimer = setTimeout(() => {
+      if (!dragging) thumb.classList.remove('is-visible');
+    }, hideDelay);
+  }
+
+  function onScroll(): void {
+    reveal();
+  }
+
+  function onThumbPointerDown(event: PointerEvent): void {
+    if (!scrollable()) return;
+    event.preventDefault();
+    dragging = true;
+    dragStartY = event.clientY;
+    dragStartScrollTop = node.scrollTop;
+    thumb.classList.add('is-visible');
+    thumb.setPointerCapture(event.pointerId);
+    if (hideTimer) clearTimeout(hideTimer);
+  }
+
+  function onThumbPointerMove(event: PointerEvent): void {
+    if (!dragging) return;
+    const track = node.clientHeight;
+    const thumbHeight = thumb.offsetHeight;
+    const maxThumbTop = track - thumbHeight;
+    const maxScroll = node.scrollHeight - node.clientHeight;
+    if (maxThumbTop <= 0) return;
+    const deltaY = event.clientY - dragStartY;
+    node.scrollTop = dragStartScrollTop + (deltaY / maxThumbTop) * maxScroll;
+  }
+
+  function endDrag(event: PointerEvent): void {
+    if (!dragging) return;
+    dragging = false;
+    if (thumb.hasPointerCapture(event.pointerId)) thumb.releasePointerCapture(event.pointerId);
+    reveal();
+  }
+
+  node.addEventListener('scroll', onScroll, { passive: true });
+  thumb.addEventListener('pointerdown', onThumbPointerDown);
+  thumb.addEventListener('pointermove', onThumbPointerMove);
+  thumb.addEventListener('pointerup', endDrag);
+  thumb.addEventListener('pointercancel', endDrag);
+
+  // Keep the thumb sized correctly as the viewport or content (Load More) grows,
+  // without revealing it — layout() only repositions, reveal() shows.
+  const resizeObserver =
+    typeof ResizeObserver !== 'undefined' ? new ResizeObserver(() => layout()) : null;
+  resizeObserver?.observe(node);
+  const mutationObserver =
+    typeof MutationObserver !== 'undefined' ? new MutationObserver(() => layout()) : null;
+  mutationObserver?.observe(node, { childList: true, subtree: true });
+
+  layout();
+
+  return {
+    update(next) {
+      hideDelay = next?.hideDelayMs ?? DEFAULT_HIDE_DELAY_MS;
+    },
+    destroy() {
+      node.removeEventListener('scroll', onScroll);
+      thumb.removeEventListener('pointerdown', onThumbPointerDown);
+      thumb.removeEventListener('pointermove', onThumbPointerMove);
+      thumb.removeEventListener('pointerup', endDrag);
+      thumb.removeEventListener('pointercancel', endDrag);
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
+      if (hideTimer) clearTimeout(hideTimer);
+      node.classList.remove('no-native-scrollbar');
+      thumb.remove();
+    },
+  };
+};

--- a/src/webfront/styles.css
+++ b/src/webfront/styles.css
@@ -162,6 +162,43 @@ body.terminal-mode {
   background: var(--color-bx-text-secondary);
 }
 
+/* Overlay scrollbar (see lib/actions/overlayScroll.ts). The scroll container
+   hides its native bar; a custom thumb floats over the content and auto-hides. */
+.no-native-scrollbar {
+  scrollbar-width: none; /* Firefox */
+}
+.no-native-scrollbar::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+  display: none;
+}
+
+.overlay-scroll-thumb {
+  position: absolute;
+  top: 0;
+  right: 2px;
+  width: 6px;
+  border-radius: 3px;
+  background: var(--color-bx-border);
+  opacity: 0;
+  pointer-events: none;
+  cursor: grab;
+  transition: opacity 200ms ease;
+  will-change: transform;
+  z-index: 5;
+}
+.overlay-scroll-thumb.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+.overlay-scroll-thumb:hover,
+.overlay-scroll-thumb:active {
+  background: var(--color-bx-text-secondary);
+}
+.overlay-scroll-thumb:active {
+  cursor: grabbing;
+}
+
 /* Terminal component styles */
 .terminal-container {
   background-color: var(--color-term-bg);


### PR DESCRIPTION
## What & why

Optimizes the left-panel chat history (WORKXOS-14). Previously the chat-history list had its **own** scrollbar nested inside the left panel's scrollbar, and every row spent width on a time stamp plus pin/rename/delete buttons — squeezing the title text.

## Changes

- **Single scroll surface.** Removed the chat-history list's inner scroll container (`max-h-80 overflow-y-auto`). The left panel is now the only thing that scrolls; **Load More** just appends rows into it.
- **Floating auto-hide scrollbar.** New Svelte action `lib/actions/overlayScroll.ts` (+ CSS in `styles.css`) hides the native scrollbar and draws a custom thumb that:
  - is hidden at rest,
  - appears while the user scrolls,
  - auto-hides ~3s after scrolling stops,
  - floats over the content **without reserving gutter width**,
  - is draggable.

  Applied to `LeftPanel` via a positioned, clipped wrapper so the thumb can anchor without scrolling away.
- **Hover-only row controls.** Time / pin / rename / delete now live in an overlay layer that fades in on hover (and keyboard `focus-within`), so titles use the full width at rest. A persistent ★ marker is kept for pinned rows so pinned status still reads at a glance.
- **Removed** the `+` new-chat button beside the search box (and its now-unused handler).

## Validation

- `npx vitest run src/webfront/components/layout` — 5 tests pass (updated `ChatHistorySection` assertions for the no-inner-scroll behavior; added a test that the `+` button is gone and per-row controls still render).
- `npx eslint` on changed files — clean.
- `npx tsc --noEmit` — only pre-existing errors in unrelated files (missing optional native DB drivers `pg`/`mysql2`/`node-sql-parser`); none from changed files.
- `svelte/compiler` compile-check of both components — OK, no warnings.

## Notes

- Per-row controls are now hover/keyboard-focus gated (rename/delete already were; pin previously was always visible). On touch this narrows discoverability of those controls — an accepted tradeoff for the "maximize title width" goal; the persistent ★ preserves the pinned signal and `group-focus-within` preserves keyboard access.
- No i18n locale files were regenerated: the new "Pinned" string / removed "New Chat" string fall back to English literals at runtime exactly like the pre-existing unmapped "Pin"/"Rename"/"Search chats". Running the extractor would rewrite the entire stale 50-language corpus — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
