### PR TITLE
WORKXOS-12 Allow adjustable left panel width via splitter

### DIFF
--- a/src/webfront/components/layout/AppShell.svelte
+++ b/src/webfront/components/layout/AppShell.svelte
@@ -108,7 +108,10 @@
       <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
       <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
       <div
-        class="panel-splitter absolute inset-y-0 -right-1 w-2 z-10 cursor-col-resize"
+        class="panel-splitter absolute inset-y-0 -right-1 w-2 z-10 cursor-col-resize
+          {currentTheme === 'modern'
+            ? 'text-chat-text-muted dark:text-chat-text-muted-dark'
+            : 'text-term-green'}"
         use:resizeHandle={{
           onStart: () => (dragStartWidth = panelWidth),
           onMove: (deltaX) => (panelWidth = clampWidth(dragStartWidth + deltaX)),

--- a/src/webfront/components/layout/AppShell.svelte
+++ b/src/webfront/components/layout/AppShell.svelte
@@ -5,6 +5,7 @@
   import { isWideMode } from '../../stores/layoutStore';
   import { uiTheme } from '../../stores/themeStore';
   import { _t } from '../../lib/i18n';
+  import { resizeHandle } from '../../lib/actions/resizeHandle';
   import LeftPanel from './LeftPanel.svelte';
 
   let { children }: {
@@ -12,6 +13,47 @@
   } = $props();
 
   let currentTheme = $derived($uiTheme);
+
+  // Docked-panel resizing (wide mode only). The base width mirrors the
+  // `--left-panel-width` design token; the splitter lets the user drag the panel
+  // wider, clamped to [base, 2× base]. The chosen width is persisted so it
+  // survives reloads.
+  const BASE_PANEL_WIDTH = 220;
+  const MIN_PANEL_WIDTH = BASE_PANEL_WIDTH;
+  const MAX_PANEL_WIDTH = BASE_PANEL_WIDTH * 2;
+  const PANEL_WIDTH_STORAGE_KEY = 'workx.leftPanelWidth';
+
+  const clampWidth = (w: number) =>
+    Math.min(MAX_PANEL_WIDTH, Math.max(MIN_PANEL_WIDTH, w));
+
+  function loadStoredWidth(): number {
+    if (typeof localStorage === 'undefined') return BASE_PANEL_WIDTH;
+    const raw = Number(localStorage.getItem(PANEL_WIDTH_STORAGE_KEY));
+    return Number.isFinite(raw) && raw > 0 ? clampWidth(raw) : BASE_PANEL_WIDTH;
+  }
+
+  let panelWidth = $state(loadStoredWidth());
+  // Width captured at drag start; `onMove` deltas are applied relative to it.
+  let dragStartWidth = BASE_PANEL_WIDTH;
+
+  function persistWidth(): void {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(PANEL_WIDTH_STORAGE_KEY, String(panelWidth));
+  }
+
+  // Keyboard resize for the separator (a11y): arrows nudge, Home/End snap.
+  function handleSplitterKey(event: KeyboardEvent) {
+    const STEP = 16;
+    let next = panelWidth;
+    if (event.key === 'ArrowLeft') next = panelWidth - STEP;
+    else if (event.key === 'ArrowRight') next = panelWidth + STEP;
+    else if (event.key === 'Home') next = MIN_PANEL_WIDTH;
+    else if (event.key === 'End') next = MAX_PANEL_WIDTH;
+    else return;
+    event.preventDefault();
+    panelWidth = clampWidth(next);
+    persistWidth();
+  }
 
   // Narrow-mode slide-in drawer state. In wide mode the panel is docked and the
   // drawer is never used.
@@ -55,9 +97,32 @@
       {currentTheme === 'modern'
         ? 'border-r border-chat-border dark:border-chat-border-dark'
         : 'border-r border-term-dim-green'}"
-      style="width: var(--left-panel-width, 220px)"
+      style="width: {panelWidth}px"
     >
       <LeftPanel />
+      <!-- Splitter on the panel/main boundary. Drag to resize the left panel;
+           width is clamped to [BASE, 2×BASE]. Sits just past the right edge so
+           its hit area straddles the border. role="separator" + arrow keys make
+           it a focusable window-splitter (the a11y lint doesn't model that
+           pattern, hence the ignores). -->
+      <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+      <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+      <div
+        class="panel-splitter absolute inset-y-0 -right-1 w-2 z-10 cursor-col-resize"
+        use:resizeHandle={{
+          onStart: () => (dragStartWidth = panelWidth),
+          onMove: (deltaX) => (panelWidth = clampWidth(dragStartWidth + deltaX)),
+          onEnd: persistWidth,
+        }}
+        onkeydown={handleSplitterKey}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label={$_t('Resize sidebar')}
+        aria-valuenow={panelWidth}
+        aria-valuemin={MIN_PANEL_WIDTH}
+        aria-valuemax={MAX_PANEL_WIDTH}
+        tabindex="0"
+      ></div>
     </div>
   {/if}
   <div class="flex-1 flex flex-col min-h-0 overflow-hidden relative">
@@ -114,5 +179,26 @@
     flex: 1 1 0%;
     min-height: 0;
     overflow: hidden;
+  }
+
+  /* A thin, mostly-invisible grip that highlights on hover/drag so the
+     resize boundary is discoverable without adding a permanent visual seam. */
+  .panel-splitter::after {
+    content: '';
+    position: absolute;
+    inset-block: 0;
+    inset-inline: 50%;
+    width: 2px;
+    transform: translateX(-50%);
+    background: transparent;
+    transition: background-color 150ms ease;
+  }
+  .panel-splitter:hover::after,
+  .panel-splitter:focus-visible::after,
+  .panel-splitter:global(.is-dragging)::after {
+    background: color-mix(in srgb, currentColor 40%, transparent);
+  }
+  .panel-splitter:focus-visible {
+    outline: none;
   }
 </style>

--- a/src/webfront/lib/actions/__tests__/resizeHandle.test.ts
+++ b/src/webfront/lib/actions/__tests__/resizeHandle.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resizeHandle } from '../resizeHandle';
+
+/**
+ * jsdom has no PointerEvent constructor, so build a plain Event and graft on the
+ * pointer fields the action reads (clientX / button / pointerId).
+ */
+function firePointer(
+  node: HTMLElement,
+  type: string,
+  fields: { clientX?: number; button?: number; pointerId?: number } = {},
+) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(event, { clientX: 0, button: 0, pointerId: 1, ...fields });
+  node.dispatchEvent(event);
+  return event;
+}
+
+describe('resizeHandle action', () => {
+  afterEach(() => {
+    document.body.style.userSelect = '';
+    document.body.style.cursor = '';
+    document.body.innerHTML = '';
+  });
+
+  it('reports the horizontal offset from drag start via onMove', () => {
+    const node = document.createElement('div');
+    document.body.appendChild(node);
+    const onStart = vi.fn();
+    const onMove = vi.fn();
+    const onEnd = vi.fn();
+
+    const handle = resizeHandle(node, { onStart, onMove, onEnd });
+
+    firePointer(node, 'pointerdown', { clientX: 100 });
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(node.classList.contains('is-dragging')).toBe(true);
+
+    firePointer(node, 'pointermove', { clientX: 160 });
+    firePointer(node, 'pointermove', { clientX: 80 });
+    expect(onMove).toHaveBeenNthCalledWith(1, 60);
+    expect(onMove).toHaveBeenNthCalledWith(2, -20);
+
+    firePointer(node, 'pointerup', { clientX: 80 });
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(node.classList.contains('is-dragging')).toBe(false);
+
+    handle?.destroy?.();
+  });
+
+  it('ignores non-primary buttons and moves before a drag starts', () => {
+    const node = document.createElement('div');
+    document.body.appendChild(node);
+    const onStart = vi.fn();
+    const onMove = vi.fn();
+
+    const handle = resizeHandle(node, { onStart, onMove });
+
+    firePointer(node, 'pointermove', { clientX: 50 });
+    expect(onMove).not.toHaveBeenCalled();
+
+    firePointer(node, 'pointerdown', { clientX: 0, button: 2 });
+    expect(onStart).not.toHaveBeenCalled();
+
+    handle?.destroy?.();
+  });
+
+  it('suppresses text selection during a drag and restores it after', () => {
+    const node = document.createElement('div');
+    document.body.appendChild(node);
+
+    const handle = resizeHandle(node, {});
+
+    firePointer(node, 'pointerdown', { clientX: 0 });
+    expect(document.body.style.userSelect).toBe('none');
+    expect(document.body.style.cursor).toBe('col-resize');
+
+    firePointer(node, 'pointerup', { clientX: 0 });
+    expect(document.body.style.userSelect).toBe('');
+    expect(document.body.style.cursor).toBe('');
+
+    handle?.destroy?.();
+  });
+
+  it('detaches listeners on destroy', () => {
+    const node = document.createElement('div');
+    document.body.appendChild(node);
+    const onStart = vi.fn();
+
+    const handle = resizeHandle(node, { onStart });
+    handle?.destroy?.();
+
+    firePointer(node, 'pointerdown', { clientX: 0 });
+    expect(onStart).not.toHaveBeenCalled();
+  });
+});

--- a/src/webfront/lib/actions/resizeHandle.ts
+++ b/src/webfront/lib/actions/resizeHandle.ts
@@ -1,0 +1,92 @@
+import type { Action } from 'svelte/action';
+
+/**
+ * Horizontal drag-to-resize handle.
+ *
+ * Attach to a thin "splitter" element sitting on the boundary between two
+ * regions (e.g. the docked left panel and the main content). On pointer drag it
+ * reports the horizontal offset from where the drag started via `onMove`, so the
+ * host can translate that delta into a new width and clamp it however it likes —
+ * the action itself is layout-agnostic and owns no size state.
+ *
+ * During a drag the document's text selection and cursor are suppressed so the
+ * pointer reads as a resize everywhere, not just over the handle. Pointer
+ * capture keeps events flowing to the handle even when the cursor outruns it.
+ */
+export interface ResizeHandleOptions {
+  /** Called when a drag begins (pointer down on the handle). */
+  onStart?: () => void;
+  /** Called on every move with the signed horizontal offset (px) from drag start. */
+  onMove?: (deltaX: number) => void;
+  /** Called when the drag ends (pointer up / cancel). */
+  onEnd?: () => void;
+}
+
+export const resizeHandle: Action<HTMLElement, ResizeHandleOptions | undefined> = (
+  node,
+  options,
+) => {
+  // Non-DOM environment (SSR): nothing to wire up.
+  if (typeof document === 'undefined') return {};
+
+  let opts = options;
+  let dragging = false;
+  let startX = 0;
+
+  function setDragCursor(on: boolean): void {
+    document.body.style.userSelect = on ? 'none' : '';
+    document.body.style.cursor = on ? 'col-resize' : '';
+  }
+
+  function onPointerDown(event: PointerEvent): void {
+    // Primary button only; ignore right/middle clicks.
+    if (event.button !== 0) return;
+    event.preventDefault();
+    dragging = true;
+    startX = event.clientX;
+    // setPointerCapture is absent under jsdom — guard so tests don't throw.
+    if (typeof node.setPointerCapture === 'function') node.setPointerCapture(event.pointerId);
+    node.classList.add('is-dragging');
+    setDragCursor(true);
+    opts?.onStart?.();
+  }
+
+  function onPointerMove(event: PointerEvent): void {
+    if (!dragging) return;
+    opts?.onMove?.(event.clientX - startX);
+  }
+
+  function endDrag(event: PointerEvent): void {
+    if (!dragging) return;
+    dragging = false;
+    if (
+      typeof node.hasPointerCapture === 'function' &&
+      node.hasPointerCapture(event.pointerId) &&
+      typeof node.releasePointerCapture === 'function'
+    ) {
+      node.releasePointerCapture(event.pointerId);
+    }
+    node.classList.remove('is-dragging');
+    setDragCursor(false);
+    opts?.onEnd?.();
+  }
+
+  node.addEventListener('pointerdown', onPointerDown);
+  node.addEventListener('pointermove', onPointerMove);
+  node.addEventListener('pointerup', endDrag);
+  node.addEventListener('pointercancel', endDrag);
+
+  return {
+    update(next) {
+      opts = next;
+    },
+    destroy() {
+      node.removeEventListener('pointerdown', onPointerDown);
+      node.removeEventListener('pointermove', onPointerMove);
+      node.removeEventListener('pointerup', endDrag);
+      node.removeEventListener('pointercancel', endDrag);
+      // Restore document styling if we're torn down mid-drag.
+      if (dragging) setDragCursor(false);
+    },
+  };
+};


### PR DESCRIPTION
## WORKXOS-12 — Allow adjustable left panel width via splitter

Enables resizing the docked left panel (wide mode) by dragging a splitter on the boundary between the panel and the main window.

### Behavior
- A thin splitter sits on the panel/main boundary; hovering shows a `col-resize` cursor and highlights the grip.
- Dragging resizes the panel live.
- Width is clamped to **[220px, 440px]** — min = the current default width, max = 2× that (per the issue).
- The chosen width persists across reloads via `localStorage`.
- The splitter is keyboard-accessible (`role="separator"`, Arrow keys nudge, Home/End snap to min/max).
- Narrow-mode slide-in drawer is untouched (fixed-width overlay).

### Changes
- `src/webfront/lib/actions/resizeHandle.ts` — new generic horizontal drag-to-resize Svelte action (pointer-drag → signed deltaX callbacks), following the existing `overlayScroll.ts` action pattern. Guards `setPointerCapture`/SSR; suppresses text selection during drag.
- `src/webfront/components/layout/AppShell.svelte` — panel width is now `$state`, rendered inline; adds the splitter element + clamp + persistence.
- `src/webfront/lib/actions/__tests__/resizeHandle.test.ts` — unit tests for the action.

### Validation
- `tsc --noEmit`: no new errors (only pre-existing missing-optional-driver errors).
- `eslint` on changed files: clean.
- `vitest` (layout + actions suites): 8 tests pass, including 4 new for the action.
- Svelte compile check of `AppShell.svelte`: no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
