### PR TITLE
Fix chat history persistence and ordering

### DIFF
--- a/src/desktop-runtime/storage/__tests__/pathSafety.test.ts
+++ b/src/desktop-runtime/storage/__tests__/pathSafety.test.ts
@@ -14,7 +14,11 @@ vi.mock('better-sqlite3', () => ({
   default: vi.fn((dbPath: string) => {
     openedDbPaths.push(dbPath);
     return {
-      pragma: vi.fn(),
+      pragma: vi.fn((statement: string) =>
+        statement === 'foreign_key_list(rollout_items)'
+          ? [{ table: 'rollout_metadata', from: 'rollout_id', on_delete: 'RESTRICT' }]
+          : undefined,
+      ),
       exec: vi.fn(),
       prepare: mockPrepare,
       close: vi.fn(),

--- a/src/storage/rollout/RolloutRecorder.ts
+++ b/src/storage/rollout/RolloutRecorder.ts
@@ -440,8 +440,7 @@ export class RolloutRecorder {
   /** Delete one complete rollout. Used only after the thread tombstone is due. */
   static async deleteSession(sessionId: ConversationId): Promise<void> {
     const provider = await RolloutRecorder.getProvider();
-    await provider.deleteItemsByRolloutIds([sessionId]);
-    await provider.deleteMetadata(sessionId);
+    await provider.deleteRollouts([sessionId]);
   }
 
   /**

--- a/src/storage/rollout/provider/IndexedDBRolloutStorageProvider.ts
+++ b/src/storage/rollout/provider/IndexedDBRolloutStorageProvider.ts
@@ -116,6 +116,35 @@ export class IndexedDBRolloutStorageProvider implements RolloutStorageProvider {
     });
   }
 
+  async deleteRollouts(rolloutIds: ConversationId[]): Promise<void> {
+    if (rolloutIds.length === 0) return;
+    const db = this.getDb();
+    return new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([STORE_ROLLOUTS, STORE_ROLLOUT_ITEMS], 'readwrite');
+      const rolloutsStore = tx.objectStore(STORE_ROLLOUTS);
+      const itemsStore = tx.objectStore(STORE_ROLLOUT_ITEMS);
+      const rolloutIdIndex = itemsStore.index('rolloutId');
+
+      for (const rolloutId of rolloutIds) {
+        rolloutsStore.delete(rolloutId);
+        const cursorRequest = rolloutIdIndex.openCursor(IDBKeyRange.only(rolloutId));
+        cursorRequest.onsuccess = (event) => {
+          const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
+          if (cursor) {
+            cursor.delete();
+            cursor.continue();
+          }
+        };
+      }
+
+      tx.oncomplete = () => resolve();
+      tx.onerror = () =>
+        reject(createDatabaseError('deleteRollouts', tx.error?.message || 'unknown error'));
+      tx.onabort = () =>
+        reject(createDatabaseError('deleteRollouts', 'Transaction aborted'));
+    });
+  }
+
   async getAllMetadata(): Promise<RolloutMetadataRecord[]> {
     const db = this.getDb();
     return new Promise<RolloutMetadataRecord[]>((resolve, reject) => {

--- a/src/storage/rollout/provider/RolloutStorageProvider.ts
+++ b/src/storage/rollout/provider/RolloutStorageProvider.ts
@@ -37,6 +37,9 @@ export interface RolloutStorageProvider {
     metadata: RolloutMetadataRecord,
     items: Array<{ timestamp: string; sequence: number; type: string; payload: unknown }>,
   ): Promise<boolean>;
+  /** Atomically remove complete rollouts, including all owned items. */
+  deleteRollouts(rolloutIds: ConversationId[]): Promise<void>;
+  /** Delete metadata only; implementations may reject while owned items exist. */
   deleteMetadata(rolloutId: ConversationId): Promise<void>;
   getAllMetadata(): Promise<RolloutMetadataRecord[]>;
   getRecoveryMetadata(rolloutId: ConversationId): Promise<RolloutRecoveryMetadata>;

--- a/src/storage/rollout/provider/TSRolloutStorageProvider.ts
+++ b/src/storage/rollout/provider/TSRolloutStorageProvider.ts
@@ -69,7 +69,7 @@ export class TSRolloutStorageProvider implements RolloutStorageProvider {
 
       CREATE TABLE IF NOT EXISTS rollout_items (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
-        rollout_id TEXT NOT NULL REFERENCES rollout_metadata(id) ON DELETE CASCADE,
+        rollout_id TEXT NOT NULL REFERENCES rollout_metadata(id) ON DELETE RESTRICT,
         timestamp TEXT NOT NULL,
         sequence INTEGER NOT NULL,
         type TEXT NOT NULL,
@@ -78,6 +78,7 @@ export class TSRolloutStorageProvider implements RolloutStorageProvider {
       );
       CREATE INDEX IF NOT EXISTS idx_items_rollout_seq ON rollout_items(rollout_id, sequence);
     `);
+    this.ensureRestrictiveItemForeignKey();
   }
 
   async close(): Promise<void> {
@@ -88,6 +89,48 @@ export class TSRolloutStorageProvider implements RolloutStorageProvider {
   private getDb(): import('better-sqlite3').Database {
     if (!this.db) throw new Error('TSRolloutStorageProvider not initialized. Call initialize() first.');
     return this.db;
+  }
+
+  /** Migrate legacy CASCADE schemas without changing or reordering item rows. */
+  private ensureRestrictiveItemForeignKey(): void {
+    const db = this.getDb();
+    const itemForeignKey = (db.pragma('foreign_key_list(rollout_items)') as RawForeignKeyRow[])
+      .find((row) => row.table === 'rollout_metadata' && row.from === 'rollout_id');
+    if (itemForeignKey?.on_delete.toUpperCase() === 'RESTRICT') return;
+
+    const orphan = db.prepare(
+      `SELECT rollout_items.rollout_id
+       FROM rollout_items
+       LEFT JOIN rollout_metadata ON rollout_metadata.id = rollout_items.rollout_id
+       WHERE rollout_metadata.id IS NULL
+       LIMIT 1`,
+    ).get() as { rollout_id: string } | undefined;
+    if (orphan) {
+      throw new Error(`Cannot migrate rollout item ownership: missing metadata for ${orphan.rollout_id}`);
+    }
+
+    const migrate = db.transaction(() => {
+      db.exec(`
+        DROP TABLE IF EXISTS rollout_items_restrict_migration;
+        CREATE TABLE rollout_items_restrict_migration (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          rollout_id TEXT NOT NULL REFERENCES rollout_metadata(id) ON DELETE RESTRICT,
+          timestamp TEXT NOT NULL,
+          sequence INTEGER NOT NULL,
+          type TEXT NOT NULL,
+          payload TEXT NOT NULL,
+          UNIQUE(rollout_id, sequence)
+        );
+        INSERT INTO rollout_items_restrict_migration
+          (id, rollout_id, timestamp, sequence, type, payload)
+        SELECT id, rollout_id, timestamp, sequence, type, payload
+        FROM rollout_items;
+        DROP TABLE rollout_items;
+        ALTER TABLE rollout_items_restrict_migration RENAME TO rollout_items;
+        CREATE INDEX idx_items_rollout_seq ON rollout_items(rollout_id, sequence);
+      `);
+    });
+    migrate();
   }
 
   // ==========================================================================
@@ -103,9 +146,20 @@ export class TSRolloutStorageProvider implements RolloutStorageProvider {
   }
 
   async putMetadata(metadata: RolloutMetadataRecord): Promise<void> {
-    this.getDb().prepare(
-      `INSERT OR REPLACE INTO rollout_metadata (id, created, updated, expires_at, session_meta, item_count, status)
-       VALUES (@id, @created, @updated, @expiresAt, @sessionMeta, @itemCount, @status)`
+    const db = this.getDb();
+    // This must be an in-place update. SQLite's INSERT OR REPLACE deletes the
+    // parent first: legacy schemas cascaded that deletion into rollout_items,
+    // while the restrictive schema correctly rejects it.
+    db.prepare(
+      `INSERT INTO rollout_metadata (id, created, updated, expires_at, session_meta, item_count, status)
+       VALUES (@id, @created, @updated, @expiresAt, @sessionMeta, @itemCount, @status)
+       ON CONFLICT(id) DO UPDATE SET
+         created = excluded.created,
+         updated = excluded.updated,
+         expires_at = excluded.expires_at,
+         session_meta = excluded.session_meta,
+         item_count = MAX(rollout_metadata.item_count, excluded.item_count),
+         status = excluded.status`
     ).run({
       id: metadata.id,
       created: metadata.created,
@@ -154,6 +208,19 @@ export class TSRolloutStorageProvider implements RolloutStorageProvider {
       return true;
     });
     return transaction();
+  }
+
+  async deleteRollouts(rolloutIds: ConversationId[]): Promise<void> {
+    if (rolloutIds.length === 0) return;
+    const db = this.getDb();
+    const placeholders = rolloutIds.map(() => '?').join(', ');
+    const transaction = db.transaction(() => {
+      db.prepare(`DELETE FROM rollout_items WHERE rollout_id IN (${placeholders})`)
+        .run(...rolloutIds);
+      db.prepare(`DELETE FROM rollout_metadata WHERE id IN (${placeholders})`)
+        .run(...rolloutIds);
+    });
+    transaction();
   }
 
   async deleteMetadata(rolloutId: ConversationId): Promise<void> {
@@ -427,4 +494,10 @@ interface RawItemRow {
   sequence: number;
   type: string;
   payload: string;
+}
+
+interface RawForeignKeyRow {
+  table: string;
+  from: string;
+  on_delete: string;
 }

--- a/src/storage/rollout/provider/__tests__/IndexedDBRolloutStorageProvider.test.ts
+++ b/src/storage/rollout/provider/__tests__/IndexedDBRolloutStorageProvider.test.ts
@@ -63,4 +63,18 @@ describe('IndexedDBRolloutStorageProvider.createRollout', () => {
       direction: 'desc',
     })).resolves.toMatchObject([{ sequence: 4 }, { sequence: 3 }]);
   });
+
+  it('atomically deletes complete rollouts', async () => {
+    await provider.createRollout(metadata('delete'), [{
+      timestamp: new Date(0).toISOString(),
+      sequence: 0,
+      type: 'response_item',
+      payload: { text: 'message' },
+    }]);
+
+    await provider.deleteRollouts(['delete']);
+
+    expect(await provider.getMetadata('delete')).toBeNull();
+    expect(await provider.getItemsByRolloutId('delete')).toHaveLength(0);
+  });
 });

--- a/src/storage/rollout/provider/__tests__/TSRolloutStorageProvider.test.ts
+++ b/src/storage/rollout/provider/__tests__/TSRolloutStorageProvider.test.ts
@@ -123,10 +123,109 @@ describe.skipIf(!hasBetterSqlite3)('TSRolloutStorageProvider', () => {
       expect(result!.status).toBe('archived');
     });
 
+    it('updates metadata without deleting existing rollout items', async () => {
+      const initial = makeMetadata('r-title-update');
+      await provider.putMetadata(initial);
+      await provider.addItems('r-title-update', [
+        { timestamp: '2024-01-01T00:00:00Z', sequence: 0, type: 'response_item', payload: { text: 'question' } },
+        { timestamp: '2024-01-01T00:00:01Z', sequence: 1, type: 'response_item', payload: { text: 'answer' } },
+      ]);
+
+      await provider.putMetadata({
+        ...initial,
+        updated: initial.updated + 1,
+        sessionMeta: { ...initial.sessionMeta, title: 'Generated title' },
+      });
+
+      expect((await provider.getMetadata('r-title-update'))?.sessionMeta.title)
+        .toBe('Generated title');
+      expect((await provider.getMetadata('r-title-update'))?.itemCount).toBe(2);
+      expect((await provider.getItemsByRolloutId('r-title-update')).map((item) => item.sequence))
+        .toEqual([0, 1]);
+    });
+
     it('deletes metadata', async () => {
       await provider.putMetadata(makeMetadata('r-3'));
       await provider.deleteMetadata('r-3');
       expect(await provider.getMetadata('r-3')).toBeNull();
+    });
+
+    it('rejects deleting metadata while it still owns rollout items', async () => {
+      await provider.putMetadata(makeMetadata('r-restrict'));
+      await provider.addItems('r-restrict', [
+        { timestamp: '2024-01-01T00:00:00Z', sequence: 0, type: 'response_item', payload: {} },
+      ]);
+
+      await expect(provider.deleteMetadata('r-restrict')).rejects.toThrow(/FOREIGN KEY/);
+      expect(await provider.getMetadata('r-restrict')).not.toBeNull();
+      expect(await provider.getItemsByRolloutId('r-restrict')).toHaveLength(1);
+    });
+
+    it('atomically deletes complete rollouts', async () => {
+      await provider.putMetadata(makeMetadata('r-complete-delete'));
+      await provider.addItems('r-complete-delete', [
+        { timestamp: '2024-01-01T00:00:00Z', sequence: 0, type: 'response_item', payload: {} },
+      ]);
+
+      await provider.deleteRollouts(['r-complete-delete']);
+
+      expect(await provider.getMetadata('r-complete-delete')).toBeNull();
+      expect(await provider.getItemsByRolloutId('r-complete-delete')).toHaveLength(0);
+    });
+
+    it('migrates legacy cascade ownership without losing rollout items', async () => {
+      await provider.close();
+      const dbPath = path.join(tmpDir, 'rollouts', 'rollouts.db');
+      const { default: Database } = await import('better-sqlite3');
+      const legacyDb = new Database(dbPath);
+      legacyDb.exec(`
+        DROP TABLE rollout_items;
+        DROP TABLE rollout_metadata;
+        CREATE TABLE rollout_metadata (
+          id TEXT PRIMARY KEY,
+          created INTEGER NOT NULL,
+          updated INTEGER NOT NULL,
+          expires_at INTEGER,
+          session_meta TEXT NOT NULL,
+          item_count INTEGER NOT NULL DEFAULT 0,
+          status TEXT NOT NULL DEFAULT 'active'
+        );
+        CREATE TABLE rollout_items (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          rollout_id TEXT NOT NULL REFERENCES rollout_metadata(id) ON DELETE CASCADE,
+          timestamp TEXT NOT NULL,
+          sequence INTEGER NOT NULL,
+          type TEXT NOT NULL,
+          payload TEXT NOT NULL,
+          UNIQUE(rollout_id, sequence)
+        );
+      `);
+      const legacyMetadata = makeMetadata('legacy-cascade', { itemCount: 1 });
+      legacyDb.prepare(
+        `INSERT INTO rollout_metadata
+          (id, created, updated, expires_at, session_meta, item_count, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        legacyMetadata.id,
+        legacyMetadata.created,
+        legacyMetadata.updated,
+        null,
+        JSON.stringify(legacyMetadata.sessionMeta),
+        legacyMetadata.itemCount,
+        legacyMetadata.status,
+      );
+      legacyDb.prepare(
+        `INSERT INTO rollout_items (rollout_id, timestamp, sequence, type, payload)
+         VALUES (?, ?, ?, ?, ?)`,
+      ).run('legacy-cascade', '2024-01-01T00:00:00Z', 0, 'response_item', '{}');
+      legacyDb.close();
+
+      provider = new TSRolloutStorageProvider(tmpDir);
+      await provider.initialize();
+
+      expect(await provider.getItemsByRolloutId('legacy-cascade')).toHaveLength(1);
+      await expect(provider.deleteMetadata('legacy-cascade')).rejects.toThrow(/FOREIGN KEY/);
+      expect(await provider.getItemsByRolloutId('legacy-cascade')).toHaveLength(1);
     });
 
     it('getAllMetadata returns all entries', async () => {
@@ -341,7 +440,7 @@ describe.skipIf(!hasBetterSqlite3)('TSRolloutStorageProvider', () => {
       expect(await provider.cleanupExpired()).toBe(0);
     });
 
-    it('cascade deletes items when metadata is deleted', async () => {
+    it('atomically deletes expired metadata and its items', async () => {
       const now = Date.now();
       await provider.putMetadata(makeMetadata('cascade', { expiresAt: now - 1000 }));
       await provider.addItems('cascade', [
@@ -349,7 +448,6 @@ describe.skipIf(!hasBetterSqlite3)('TSRolloutStorageProvider', () => {
       ]);
 
       await provider.cleanupExpired();
-      // Items should also be gone (via ON DELETE CASCADE)
       const items = await provider.getItemsByRolloutId('cascade');
       expect(items).toHaveLength(0);
     });

--- a/src/webfront/lib/__tests__/conversationTimeline.test.ts
+++ b/src/webfront/lib/__tests__/conversationTimeline.test.ts
@@ -12,11 +12,11 @@ import {
   upsertTimelineEvent,
 } from '../conversationTimeline';
 
-function event(id: string, content = id): ProcessedEvent {
+function event(id: string, content = id, timestamp = 0): ProcessedEvent {
   return {
     id,
     category: 'message',
-    timestamp: new Date(0),
+    timestamp: new Date(timestamp),
     title: 'user',
     content,
     style: { textColor: 'text-test' },
@@ -42,6 +42,36 @@ describe('conversation timeline reducer', () => {
     const timeline = upsertTimelineEvent(emptyTimeline(), event('user:m1'), 'optimistic');
     const attached = reconcileAttachedTimeline(timeline, [], [], new Set(['m1']));
     expect(attached.order).toEqual(['user:m1']);
+  });
+
+  it('places older retained optimistic messages before newer durable history', () => {
+    let timeline = upsertTimelineEvent(
+      emptyTimeline(),
+      event('user:old-1', 'old question one', 1_000),
+      'optimistic',
+    );
+    timeline = upsertTimelineEvent(
+      timeline,
+      event('user:old-2', 'old question two', 2_000),
+      'optimistic',
+    );
+
+    const attached = reconcileAttachedTimeline(
+      timeline,
+      [
+        event('user:new', 'new question', 3_000),
+        { ...event('response:new', 'new answer', 4_000), title: 'workx' },
+      ],
+      [],
+      new Set(['old-1', 'old-2']),
+    );
+
+    expect(attached.order).toEqual([
+      'user:old-1',
+      'user:old-2',
+      'user:new',
+      'response:new',
+    ]);
   });
 
   it('drops stale live rows on reattach but keeps local command output', () => {

--- a/src/webfront/lib/__tests__/conversationTimeline.test.ts
+++ b/src/webfront/lib/__tests__/conversationTimeline.test.ts
@@ -74,6 +74,40 @@ describe('conversation timeline reducer', () => {
     ]);
   });
 
+  it('falls back safely when retained or existing timestamps are malformed', () => {
+    const malformedRetained = {
+      ...event('user:malformed'),
+      timestamp: undefined,
+    } as unknown as ProcessedEvent;
+    const retainedTimeline = upsertTimelineEvent(
+      emptyTimeline(),
+      malformedRetained,
+      'optimistic',
+    );
+    expect(() => reconcileAttachedTimeline(
+      retainedTimeline,
+      [event('persisted', 'durable', 1_000)],
+      [],
+      new Set(['malformed']),
+    )).not.toThrow();
+
+    const malformedPersisted = {
+      ...event('persisted:malformed'),
+      timestamp: null,
+    } as unknown as ProcessedEvent;
+    const validRetained = upsertTimelineEvent(
+      emptyTimeline(),
+      event('user:valid', 'pending', 500),
+      'optimistic',
+    );
+    expect(() => reconcileAttachedTimeline(
+      validRetained,
+      [malformedPersisted],
+      [],
+      new Set(['valid']),
+    )).not.toThrow();
+  });
+
   it('drops stale live rows on reattach but keeps local command output', () => {
     let timeline = upsertTimelineEvent(emptyTimeline(), event('live-old'), 'live');
     timeline = upsertTimelineEvent(timeline, event('command'), 'local');

--- a/src/webfront/lib/conversationTimeline.ts
+++ b/src/webfront/lib/conversationTimeline.ts
@@ -110,12 +110,12 @@ function insertRetainedTimelineEvent(
   if (timeline.byId[event.id]) {
     return upsertTimelineEvent(timeline, event, source);
   }
-  const timestamp = event.timestamp.getTime();
+  const timestamp = event.timestamp?.getTime?.() ?? Number.NaN;
   if (!Number.isFinite(timestamp)) {
     return upsertTimelineEvent(timeline, event, source);
   }
   const insertionIndex = timeline.order.findIndex((id) => {
-    const existingTimestamp = timeline.byId[id]?.event.timestamp.getTime();
+    const existingTimestamp = timeline.byId[id]?.event.timestamp?.getTime?.();
     return existingTimestamp !== undefined
       && Number.isFinite(existingTimestamp)
       && existingTimestamp > timestamp;

--- a/src/webfront/lib/conversationTimeline.ts
+++ b/src/webfront/lib/conversationTimeline.ts
@@ -92,10 +92,46 @@ export function reconcileAttachedTimeline(
       !next.byId[id]
       && (entry.source === 'local' || (entry.source === 'optimistic' && pending))
     ) {
-      next = upsertTimelineEvent(next, entry.event, entry.source);
+      next = insertRetainedTimelineEvent(next, entry.event, entry.source);
     }
   }
   return next;
+}
+
+/**
+ * Attach history is already in durable sequence order. Insert retained local
+ * rows at their event time without re-sorting that authoritative projection.
+ */
+function insertRetainedTimelineEvent(
+  timeline: ConversationTimeline,
+  event: ProcessedEvent,
+  source: TimelineSource,
+): ConversationTimeline {
+  if (timeline.byId[event.id]) {
+    return upsertTimelineEvent(timeline, event, source);
+  }
+  const timestamp = event.timestamp.getTime();
+  if (!Number.isFinite(timestamp)) {
+    return upsertTimelineEvent(timeline, event, source);
+  }
+  const insertionIndex = timeline.order.findIndex((id) => {
+    const existingTimestamp = timeline.byId[id]?.event.timestamp.getTime();
+    return existingTimestamp !== undefined
+      && Number.isFinite(existingTimestamp)
+      && existingTimestamp > timestamp;
+  });
+  if (insertionIndex < 0) {
+    return upsertTimelineEvent(timeline, event, source);
+  }
+  return {
+    ...timeline,
+    order: [
+      ...timeline.order.slice(0, insertionIndex),
+      event.id,
+      ...timeline.order.slice(insertionIndex),
+    ],
+    byId: { ...timeline.byId, [event.id]: { event, source } },
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- replace the destructive SQLite metadata `INSERT OR REPLACE` with an in-place conflict update
- migrate rollout item ownership from `ON DELETE CASCADE` to `ON DELETE RESTRICT`
- delete complete rollouts atomically in both SQLite and IndexedDB
- restore retained optimistic UI messages at their original time instead of appending them after newer durable history
- defensively tolerate malformed timestamps during attach reconciliation
- add regressions for title updates, legacy schema migration, restrictive deletion, atomic deletion, attach ordering, and malformed timestamps

## Root cause

SQLite `INSERT OR REPLACE` does not update an existing row in place. It deletes the existing metadata row and inserts a new one. Because `rollout_items` used `ON DELETE CASCADE`, generated or manual title updates deleted the stored message rows.

After reattach, the UI projected the surviving durable suffix first and appended retained optimistic user messages afterward. That made older questions appear below newer question/answer pairs.

## Impact

Title updates no longer remove chat history. Accidental metadata deletion is rejected while owned messages exist, intentional rollout deletion is atomic, and attach reconciliation preserves chronological placement without re-sorting authoritative durable sequence order.

## Validation

- live Tauri test with seven completed turns, automatic title generation, and session switching; every user and assistant message survived in order
- `npx vitest run src/storage/rollout/provider/__tests__/TSRolloutStorageProvider.test.ts src/storage/rollout/provider/__tests__/IndexedDBRolloutStorageProvider.test.ts src/webfront/lib/__tests__/conversationTimeline.test.ts` (45 tests)
- `npx vitest run src/storage/rollout/__tests__/RolloutRecorder.test.ts` (41 tests)
- `npm run type-check`
- focused ESLint checks for changed storage/timeline files
- `npm run build:desktop`
- `npm run build:desktop-runtime-sidecar`
- migrated the active SQLite database and verified identical metadata/item counts and checksums with zero foreign-key violations