### PR TITLE
WORKXOS-14 Address overlay-scrollbar review feedback

### DIFF
--- a/src/webfront/lib/actions/overlayScroll.ts
+++ b/src/webfront/lib/actions/overlayScroll.ts
@@ -44,7 +44,9 @@ export const overlayScroll: Action<HTMLElement, OverlayScrollOptions | undefined
   let dragStartScrollTop = 0;
 
   function scrollable(): boolean {
-    return node.scrollHeight - node.clientHeight > 1;
+    // Require the container to be tall enough to host the minimum thumb height;
+    // otherwise maxThumbTop (track - thumbHeight) goes negative and the thumb overflows.
+    return node.scrollHeight - node.clientHeight > 1 && node.clientHeight >= MIN_THUMB_HEIGHT;
   }
 
   function layout(): void {

--- a/src/webfront/styles.css
+++ b/src/webfront/styles.css
@@ -180,6 +180,8 @@ body.terminal-mode {
   transition: opacity 200ms ease;
   will-change: transform;
   z-index: 5;
+  /* Let pointer-event listeners own drag gestures instead of native touch panning. */
+  touch-action: none;
 }
 .overlay-scroll-thumb.is-visible {
   opacity: 1;


### PR DESCRIPTION
Follow-up to merged #342 (WORKXOS-14). Applies the two medium-priority suggestions from the code review on #342 that weren't incorporated before it merged.

- **overlayScroll `scrollable()`**: now also requires `clientHeight >= MIN_THUMB_HEIGHT`. Without it, a container shorter than 24px with overflow made `maxThumbTop` (`track - thumbHeight`) negative, producing an oversized thumb that overflows the container.
- **`.overlay-scroll-thumb`**: added `touch-action: none` so the pointer-event drag handlers own the gesture instead of the browser intercepting it as native touch panning — fixes jittery/unresponsive dragging on touch devices.

Both are the exact changes gemini-code-assist proposed on #342.

Validation: `eslint` clean on changed files; `tsc --noEmit` reports no errors from the changed file (only pre-existing unrelated ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)