### PR TITLE
WORKXOS-12 Harden panel splitter per review feedback

### DIFF
--- a/src/webfront/components/layout/AppShell.svelte
+++ b/src/webfront/components/layout/AppShell.svelte
@@ -28,8 +28,13 @@
 
   function loadStoredWidth(): number {
     if (typeof localStorage === 'undefined') return BASE_PANEL_WIDTH;
-    const raw = Number(localStorage.getItem(PANEL_WIDTH_STORAGE_KEY));
-    return Number.isFinite(raw) && raw > 0 ? clampWidth(raw) : BASE_PANEL_WIDTH;
+    try {
+      const raw = Number(localStorage.getItem(PANEL_WIDTH_STORAGE_KEY));
+      return Number.isFinite(raw) && raw > 0 ? clampWidth(raw) : BASE_PANEL_WIDTH;
+    } catch {
+      // Storage access can throw (private mode / blocked by policy) — fall back.
+      return BASE_PANEL_WIDTH;
+    }
   }
 
   let panelWidth = $state(loadStoredWidth());
@@ -38,7 +43,11 @@
 
   function persistWidth(): void {
     if (typeof localStorage === 'undefined') return;
-    localStorage.setItem(PANEL_WIDTH_STORAGE_KEY, String(panelWidth));
+    try {
+      localStorage.setItem(PANEL_WIDTH_STORAGE_KEY, String(panelWidth));
+    } catch {
+      // Storage disabled/full (private mode / quota) — the width just won't persist.
+    }
   }
 
   // Keyboard resize for the separator (a11y): arrows nudge, Home/End snap.

--- a/src/webfront/lib/actions/__tests__/resizeHandle.test.ts
+++ b/src/webfront/lib/actions/__tests__/resizeHandle.test.ts
@@ -82,6 +82,24 @@ describe('resizeHandle action', () => {
     handle?.destroy?.();
   });
 
+  it('resets the drag when pointer capture is lost', () => {
+    const node = document.createElement('div');
+    document.body.appendChild(node);
+    const onEnd = vi.fn();
+
+    const handle = resizeHandle(node, { onEnd });
+
+    firePointer(node, 'pointerdown', { clientX: 0 });
+    expect(node.classList.contains('is-dragging')).toBe(true);
+
+    firePointer(node, 'lostpointercapture', { clientX: 0 });
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(node.classList.contains('is-dragging')).toBe(false);
+    expect(document.body.style.cursor).toBe('');
+
+    handle?.destroy?.();
+  });
+
   it('detaches listeners on destroy', () => {
     const node = document.createElement('div');
     document.body.appendChild(node);

--- a/src/webfront/lib/actions/resizeHandle.ts
+++ b/src/webfront/lib/actions/resizeHandle.ts
@@ -75,6 +75,9 @@ export const resizeHandle: Action<HTMLElement, ResizeHandleOptions | undefined> 
   node.addEventListener('pointermove', onPointerMove);
   node.addEventListener('pointerup', endDrag);
   node.addEventListener('pointercancel', endDrag);
+  // If capture is yanked away (element detached, browser reclaim), pointerup may
+  // never reach us — reset here so the drag state and body cursor don't stick.
+  node.addEventListener('lostpointercapture', endDrag);
 
   return {
     update(next) {
@@ -85,6 +88,7 @@ export const resizeHandle: Action<HTMLElement, ResizeHandleOptions | undefined> 
       node.removeEventListener('pointermove', onPointerMove);
       node.removeEventListener('pointerup', endDrag);
       node.removeEventListener('pointercancel', endDrag);
+      node.removeEventListener('lostpointercapture', endDrag);
       // Restore document styling if we're torn down mid-drag.
       if (dragging) setDragCursor(false);
     },


### PR DESCRIPTION
Follow-up to #343 (merged) addressing the Gemini Code Assist review, which had no human action before Gemini's consumer review sunset.

Both findings validated against the merged code and fixed:

- **`localStorage` can throw.** `loadStoredWidth`/`persistWidth` guarded only `typeof localStorage === 'undefined'`. In private mode or with storage blocked by policy (or on quota), `getItem`/`setItem` throw — the drag-end `onEnd` → `persistWidth` path would surface an uncaught error. Both are now wrapped in `try-catch`; the width silently falls back to base and just doesn't persist.
- **`lostpointercapture` not handled.** If capture is forcibly released (element detached, browser reclaim), `pointerup` may never reach the handle, leaving `dragging = true` and the body cursor stuck as `col-resize`. The action now resets on `lostpointercapture` (and cleans the listener up on destroy).

Adds a unit test for the lost-capture reset (`resizeHandle` suite now 5 tests). `vitest` green, `eslint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
