### PR TITLE
Remove allowedAppIds from OpenHub apps credential handling

### DIFF
--- a/src/core/apps/AppsAccessController.ts
+++ b/src/core/apps/AppsAccessController.ts
@@ -49,12 +49,7 @@ export class AppsAccessController {
   }
 
   getState(): AppsAccessState {
-    return {
-      ...this.state,
-      allowedAppIds: this.state.allowedAppIds
-        ? [...this.state.allowedAppIds]
-        : this.state.allowedAppIds,
-    };
+    return { ...this.state };
   }
 
   async initialize(): Promise<AppsAccessState> {
@@ -113,9 +108,8 @@ export class AppsAccessController {
       const normalized = this.normalizeCandidate(candidate);
       if (!this.options.client)
         throw new AppsServiceError('APPS_NOT_CONFIGURED', 'The Apps catalog is not configured.');
-      let result: AppsCredentialValidationResult;
       try {
-        result = await this.options.client.validateCredential({
+        await this.options.client.validateCredential({
           method: 'api-key',
           token: normalized,
         });
@@ -130,7 +124,6 @@ export class AppsAccessController {
         capabilityStatus: 'supported',
         credentialSource: 'stored-api-key',
         hasCredential: true,
-        allowedAppIds: result.allowedAppIds,
         reason: undefined,
       });
       await this.reconnectMcpBestEffort();
@@ -171,7 +164,6 @@ export class AppsAccessController {
         credentialStatus: 'needs-api-key',
         credentialSource: 'none',
         hasCredential: false,
-        allowedAppIds: undefined,
         reason: 'api_key_missing',
       });
     }
@@ -185,14 +177,13 @@ export class AppsAccessController {
       });
     }
     try {
-      const result = await this.options.client.validateCredential(credential);
+      await this.options.client.validateCredential(credential);
       await this.commit({
         credentialStatus: 'ready',
         backendStatus: 'reachable',
         capabilityStatus: 'supported',
         credentialSource: credential.source,
         hasCredential: true,
-        allowedAppIds: result.allowedAppIds,
         reason: undefined,
       });
       if (!wasReady) await this.reconnectMcpBestEffort();

--- a/src/core/apps/OpenHubAppsClient.ts
+++ b/src/core/apps/OpenHubAppsClient.ts
@@ -220,13 +220,7 @@ export class OpenHubAppsClient {
         403
       );
     }
-    const allowedAppIds =
-      raw?.allowedAppIds === null
-        ? null
-        : Array.isArray(raw?.allowedAppIds)
-          ? raw.allowedAppIds.filter((v): v is string => typeof v === 'string').slice(0, 1000)
-          : null;
-    return { valid: true, credentialType, grantedScopes: scopes, allowedAppIds };
+    return { valid: true, credentialType, grantedScopes: scopes };
   }
 
   async marketplace(

--- a/src/core/apps/__tests__/OpenHubAppsClient.test.ts
+++ b/src/core/apps/__tests__/OpenHubAppsClient.test.ts
@@ -18,7 +18,6 @@ describe('OpenHubAppsClient OSS credentials', () => {
       capabilities: ['single-hub-apps-credential-v1'],
       credentialType: 'api-key',
       scopes: ['chat', 'models', 'apps'],
-      allowedAppIds: null,
     }), { headers: { 'content-type': 'application/json' } }));
     const client = new OpenHubAppsClient({
       catalogApiBaseUrl: 'https://hub.example/api/v1/apps',

--- a/src/core/apps/__tests__/createAppsRuntime.test.ts
+++ b/src/core/apps/__tests__/createAppsRuntime.test.ts
@@ -36,7 +36,6 @@ function credentialContract() {
       capabilities: ['single-hub-apps-credential-v1'],
       credentialType: 'api-key',
       scopes: ['chat', 'models', 'apps'],
-      allowedAppIds: null,
     }),
     { headers: { 'content-type': 'application/json' } }
   );
@@ -96,7 +95,6 @@ describe('createAppsRuntime', () => {
           capabilities: ['single-hub-apps-credential-v1'],
           credentialType: 'api-key',
           scopes: ['apps'],
-          allowedAppIds: null,
         }),
         { headers: { 'content-type': 'application/json' } }
       )

--- a/src/core/apps/types.ts
+++ b/src/core/apps/types.ts
@@ -41,7 +41,6 @@ export interface AppsAccessState {
   authMethod: AppsAuthMethod;
   credentialSource: AppsCredentialSource;
   hasCredential: boolean;
-  allowedAppIds?: string[] | null;
   reason?: AppsAccessReason;
   revision: number;
   updatedAt: number;
@@ -58,7 +57,6 @@ export interface AppsCredentialValidationResult {
   valid: true;
   credentialType: AppsAuthMethod;
   grantedScopes: string[];
-  allowedAppIds: string[] | null;
 }
 
 export interface ManualSetupField {


### PR DESCRIPTION
## What

Removes the `allowedAppIds` field from OpenHub apps credential handling: the `AppsAccessState` and `AppsCredentialValidationResult` types, the parse in `OpenHubAppsClient.validateCredential`, and the runtime state/snapshot carry-through in `AppsAccessController`. Test fixtures drop the field; no unrelated assertions were weakened.

## Why

OpenHub's Hub removed `allowedAppIds` from its `GET /apps/credentials/me` response — the per-key app allowlist is being deprecated platform-wide, with app access gated by user_type/quota rather than carried on the credential. WorkX only ever retained `allowedAppIds` as diagnostic-only state; it was never used in any access or gating decision (the backend remained authoritative). Removing it is behavior-preserving cleanup of dead state.

## Verification

- `tsc --noEmit`: clean (0 errors)
- `vitest run src/core/apps`: 5 files, 17 tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)