### PR TITLE
Align bundled OpenHub routes with the prod gateway catalog

### DIFF
--- a/src/config/__tests__/modelCatalog.test.ts
+++ b/src/config/__tests__/modelCatalog.test.ts
@@ -26,19 +26,37 @@ describe('OSS model catalog adapter', () => {
         model.openHubRoute,
       ]),
     ))).toEqual({
-      'xai:grok-4-1-fast-reasoning': {
-        modelSlug: 'x-ai/grok-4-1-fast-reasoning', providerSlug: 'xai',
-      },
-      'openai:gpt-5.5': { modelSlug: 'openai/gpt-5.5', providerSlug: 'azure' },
-      'openai:gpt-5.4': { modelSlug: 'openai/gpt-5.4', providerSlug: 'azure' },
+      // Every modelSlug below is a verified canonical llm.models.slug in the
+      // prod gateway catalog (2026-07-24); providerSlug is an active serving
+      // provider for that model. Some models are still status=draft upstream
+      // (gpt-5.6-*, claude-sonnet-5, gemini-3.1-pro-preview) — routed here so
+      // they start working the moment the catalog activates them.
+      'xai:grok-4.3': { modelSlug: 'x-ai/grok-4.3', providerSlug: 'xai' },
+      'xai:grok-4.5': { modelSlug: 'xai/grok-4.5', providerSlug: 'xai' },
+      'openai:gpt-5.6-sol': { modelSlug: 'openai/gpt-5.6-sol', providerSlug: 'openai' },
+      'openai:gpt-5.6-terra': { modelSlug: 'openai/gpt-5.6-terra', providerSlug: 'openai' },
+      'openai:gpt-5.6-luna': { modelSlug: 'openai/gpt-5.6-luna', providerSlug: 'openai' },
+      // Pinned to openai, not azure: the deployed gateway has no azure_openai
+      // adapter (azure endpoints are catalog rows the gateway cannot serve),
+      // so an azure pin can never route. The openai first-party endpoint is
+      // the only servable one for these models.
+      'openai:gpt-5.5': { modelSlug: 'openai/gpt-5.5', providerSlug: 'openai' },
+      'openai:gpt-5.4': { modelSlug: 'openai/gpt-5.4', providerSlug: 'openai' },
       'google-ai-studio:gemini-3.1-pro': {
-        modelSlug: 'google/gemini-3.1-pro', providerSlug: 'google-ai-studio',
+        modelSlug: 'google/gemini-3.1-pro-preview', providerSlug: 'google-ai-studio',
+      },
+      'google-ai-studio:gemini-3.5-flash': {
+        modelSlug: 'google/gemini-3.5-flash', providerSlug: 'google-ai-studio',
       },
       'deepseek:deepseek-v4-flash': {
         modelSlug: 'deepseek/deepseek-v4-flash', providerSlug: 'deepseek',
       },
+      'moonshot:kimi-k3': { modelSlug: 'kimi/kimi-k3', providerSlug: 'kimi' },
       'anthropic:claude-opus-4-8': {
         modelSlug: 'anthropic/claude-opus-4-8', providerSlug: 'deepinfra',
+      },
+      'anthropic:claude-sonnet-5': {
+        modelSlug: 'anthropic/claude-sonnet-5', providerSlug: 'anthropic',
       },
       'anthropic:claude-sonnet-4-6': {
         modelSlug: 'anthropic/claude-sonnet-4-6', providerSlug: 'deepinfra',

--- a/src/core/models/cost/modelCostTable.ts
+++ b/src/core/models/cost/modelCostTable.ts
@@ -36,9 +36,15 @@ export interface ModelRate {
  */
 export const MODEL_COST_TABLE: Record<string, ModelRate> = {
   // xai — flat, no cache discount
+  'xai:grok-4.3': { inputPer1M: 1.25, outputPer1M: 2.5, cachedInputPer1M: 1.25 },
+  'xai:grok-4.5': { inputPer1M: 2.0, outputPer1M: 6.0, cachedInputPer1M: 2.0 },
+  // legacy (retired from picker; retained so historical usage records cost correctly)
   'xai:grok-4-1-fast-reasoning': { inputPer1M: 0.2, outputPer1M: 0.5, cachedInputPer1M: 0.2 },
 
   // openai — Default tier (Priority tier intentionally not modeled)
+  'openai:gpt-5.6-sol': { inputPer1M: 5.0, outputPer1M: 30.0, cachedInputPer1M: 5.0 },
+  'openai:gpt-5.6-terra': { inputPer1M: 2.5, outputPer1M: 15.0, cachedInputPer1M: 2.5 },
+  'openai:gpt-5.6-luna': { inputPer1M: 1.0, outputPer1M: 6.0, cachedInputPer1M: 1.0 },
   'openai:gpt-5.5': { inputPer1M: 5.0, outputPer1M: 30.0, cachedInputPer1M: 0.5 },
   'openai:gpt-5.4': { inputPer1M: 2.5, outputPer1M: 15.0, cachedInputPer1M: 0.25 },
   // legacy (retired from picker; retained so historical usage records cost correctly)
@@ -47,6 +53,7 @@ export const MODEL_COST_TABLE: Record<string, ModelRate> = {
 
   // google-ai-studio — ≤200K base tier; client always reports cached=0
   'google-ai-studio:gemini-3.1-pro': { inputPer1M: 2.0, outputPer1M: 12.0, cachedInputPer1M: 0.2 },
+  'google-ai-studio:gemini-3.5-flash': { inputPer1M: 1.5, outputPer1M: 9.0, cachedInputPer1M: 0.15 },
   // legacy
   'google-ai-studio:gemini-3-pro-preview': { inputPer1M: 2.0, outputPer1M: 12.0, cachedInputPer1M: 2.0 },
   'google-ai-studio:gemini-2.5-pro': { inputPer1M: 1.25, outputPer1M: 10.0, cachedInputPer1M: 1.25 },
@@ -54,6 +61,8 @@ export const MODEL_COST_TABLE: Record<string, ModelRate> = {
   // deepseek — Cache Miss = input rate, Cache Hit = cached rate (free-tier default)
   'deepseek:deepseek-v4-flash': { inputPer1M: 0.14, outputPer1M: 0.28, cachedInputPer1M: 0.0028 },
 
+  // moonshot — Cache Miss = input rate, Cache Hit = cached rate
+  'moonshot:kimi-k3': { inputPer1M: 3.0, outputPer1M: 15.0, cachedInputPer1M: 0.3 },
   // legacy — Kimi (moonshot/fireworks/together) retired from the picker; rows
   // retained so historical usage records still cost correctly.
   'moonshot:kimi-k2.6': { inputPer1M: 0.95, outputPer1M: 4.0, cachedInputPer1M: 0.16 },
@@ -65,8 +74,10 @@ export const MODEL_COST_TABLE: Record<string, ModelRate> = {
   'together:moonshotai/Kimi-K2.6': { inputPer1M: 1.2, outputPer1M: 4.5, cachedInputPer1M: 0.2 },
   'together:moonshotai/Kimi-K2-Thinking': { inputPer1M: 1.2, outputPer1M: 4.0, cachedInputPer1M: 1.2 },
 
-  // anthropic — cache hit/refresh rate used for cached input
+  // anthropic — cache hit/refresh rate used for cached input; sonnet-5 priced
+  // at the standard (non-intro) rate so estimates stay valid past 2026-08-31
   'anthropic:claude-opus-4-8': { inputPer1M: 5.0, outputPer1M: 25.0, cachedInputPer1M: 0.5 },
+  'anthropic:claude-sonnet-5': { inputPer1M: 3.0, outputPer1M: 15.0, cachedInputPer1M: 0.3 },
   'anthropic:claude-sonnet-4-6': { inputPer1M: 3.0, outputPer1M: 15.0, cachedInputPer1M: 0.3 },
   'anthropic:claude-fable-5': { inputPer1M: 10.0, outputPer1M: 50.0, cachedInputPer1M: 1.0 },
   'anthropic:claude-haiku-4-5-20251001': { inputPer1M: 1.0, outputPer1M: 5.0, cachedInputPer1M: 0.1 },

--- a/src/core/models/providers/default.json
+++ b/src/core/models/providers/default.json
@@ -5,7 +5,7 @@
     "apiKey": "",
     "organization": null,
     "baseUrl": "https://api.x.ai/v1",
-    "defaultEfficientModelKey": "grok-4-1-fast-reasoning",
+    "defaultEfficientModelKey": "grok-4.3",
     "version": null,
     "headers": {},
     "timeout": 30000,
@@ -17,31 +17,57 @@
     },
     "models": [
       {
-        "name": "Grok 4.1 Fast Reasoning",
-        "modelKey": "grok-4-1-fast-reasoning",
+        "name": "Grok 4.3",
+        "modelKey": "grok-4.3",
         "openHubRoute": {
-          "modelSlug": "x-ai/grok-4-1-fast-reasoning",
+          "modelSlug": "x-ai/grok-4.3",
           "providerSlug": "xai"
         },
         "creator": "xAI",
-        "contextWindow": 2000000,
+        "contextWindow": 1000000,
         "maxOutputTokens": 16384,
         "supportsReasoning": true,
         "reasoningEfforts": [
-          "minimal",
           "low",
           "medium",
-          "high",
-          "ultra"
+          "high"
         ],
         "supportsReasoningSummaries": false,
         "supportsVerbosity": false,
         "supportsImage": true,
-        "releaseDate": "2024-11-15",
+        "releaseDate": "2026-05-15",
         "deprecated": false,
         "pricing": {
-          "inputToken": "$0.20 / 1M tokens",
-          "outputToken": "$0.50 / 1M tokens",
+          "inputToken": "$1.25 / 1M tokens",
+          "outputToken": "$2.50 / 1M tokens",
+          "link": "https://docs.x.ai/docs/models"
+        },
+        "supportBackendMode": 1
+      },
+      {
+        "name": "Grok 4.5",
+        "modelKey": "grok-4.5",
+        "openHubRoute": {
+          "modelSlug": "xai/grok-4.5",
+          "providerSlug": "xai"
+        },
+        "creator": "xAI",
+        "contextWindow": 500000,
+        "maxOutputTokens": 16384,
+        "supportsReasoning": true,
+        "reasoningEfforts": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "supportsReasoningSummaries": false,
+        "supportsVerbosity": false,
+        "supportsImage": true,
+        "releaseDate": "2026-07-08",
+        "deprecated": false,
+        "pricing": {
+          "inputToken": "$2.00 / 1M tokens",
+          "outputToken": "$6.00 / 1M tokens",
           "link": "https://docs.x.ai/docs/models"
         },
         "supportBackendMode": 1
@@ -66,11 +92,123 @@
     },
     "models": [
       {
+        "name": "GPT-5.6 Sol",
+        "modelKey": "gpt-5.6-sol",
+        "openHubRoute": {
+          "modelSlug": "openai/gpt-5.6-sol",
+          "providerSlug": "openai"
+        },
+        "creator": "OpenAI",
+        "contextWindow": 1050000,
+        "maxOutputTokens": 128000,
+        "fallbackModelKey": "openai:gpt-5.6-terra",
+        "supportsReasoning": true,
+        "reasoningEfforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "max"
+        ],
+        "supportsReasoningSummaries": true,
+        "supportsVerbosity": true,
+        "verbosityLevels": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "supportsImage": true,
+        "supportsWebSearch": true,
+        "releaseDate": "2026-07-09",
+        "deprecated": false,
+        "serviceTier": "default",
+        "pricing": {
+          "inputToken": "$5.00 / 1M tokens",
+          "outputToken": "$30.00 / 1M tokens",
+          "link": "https://openai.com/api/pricing/"
+        },
+        "supportBackendMode": 1
+      },
+      {
+        "name": "GPT-5.6 Terra",
+        "modelKey": "gpt-5.6-terra",
+        "openHubRoute": {
+          "modelSlug": "openai/gpt-5.6-terra",
+          "providerSlug": "openai"
+        },
+        "creator": "OpenAI",
+        "contextWindow": 1050000,
+        "maxOutputTokens": 128000,
+        "supportsReasoning": true,
+        "reasoningEfforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "max"
+        ],
+        "supportsReasoningSummaries": true,
+        "supportsVerbosity": true,
+        "verbosityLevels": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "supportsImage": true,
+        "supportsWebSearch": true,
+        "releaseDate": "2026-07-09",
+        "deprecated": false,
+        "serviceTier": "default",
+        "pricing": {
+          "inputToken": "$2.50 / 1M tokens",
+          "outputToken": "$15.00 / 1M tokens",
+          "link": "https://openai.com/api/pricing/"
+        },
+        "supportBackendMode": 1
+      },
+      {
+        "name": "GPT-5.6 Luna",
+        "modelKey": "gpt-5.6-luna",
+        "openHubRoute": {
+          "modelSlug": "openai/gpt-5.6-luna",
+          "providerSlug": "openai"
+        },
+        "creator": "OpenAI",
+        "contextWindow": 1050000,
+        "maxOutputTokens": 128000,
+        "supportsReasoning": true,
+        "reasoningEfforts": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "max"
+        ],
+        "supportsReasoningSummaries": true,
+        "supportsVerbosity": true,
+        "verbosityLevels": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "supportsImage": true,
+        "supportsWebSearch": true,
+        "releaseDate": "2026-07-09",
+        "deprecated": false,
+        "serviceTier": "default",
+        "pricing": {
+          "inputToken": "$1.00 / 1M tokens",
+          "outputToken": "$6.00 / 1M tokens",
+          "link": "https://openai.com/api/pricing/"
+        },
+        "supportBackendMode": 1
+      },
+      {
         "name": "GPT-5.5",
         "modelKey": "gpt-5.5",
         "openHubRoute": {
           "modelSlug": "openai/gpt-5.5",
-          "providerSlug": "azure"
+          "providerSlug": "openai"
         },
         "creator": "OpenAI",
         "contextWindow": 1050000,
@@ -96,7 +234,7 @@
         "deprecated": false,
         "serviceTier": "default",
         "pricing": {
-          "inputToken": "Default: $5.00 / 1M tokens, Cached: $0.50 / 1M tokens (\u2264272K tokens; 2x input above)",
+          "inputToken": "Default: $5.00 / 1M tokens, Cached: $0.50 / 1M tokens (≤272K tokens; 2x input above)",
           "outputToken": "Default: $30.00 / 1M tokens (1.5x above 272K tokens)",
           "link": "https://openai.com/api/pricing/"
         },
@@ -107,7 +245,7 @@
         "modelKey": "gpt-5.4",
         "openHubRoute": {
           "modelSlug": "openai/gpt-5.4",
-          "providerSlug": "azure"
+          "providerSlug": "openai"
         },
         "creator": "OpenAI",
         "contextWindow": 1000000,
@@ -146,7 +284,7 @@
     "apiKey": "",
     "organization": null,
     "baseUrl": "https://generativelanguage.googleapis.com",
-    "defaultEfficientModelKey": "gemini-3.1-pro",
+    "defaultEfficientModelKey": "gemini-3.5-flash",
     "version": null,
     "headers": {},
     "timeout": 30000,
@@ -161,7 +299,7 @@
         "name": "Gemini 3.1 Pro",
         "modelKey": "gemini-3.1-pro",
         "openHubRoute": {
-          "modelSlug": "google/gemini-3.1-pro",
+          "modelSlug": "google/gemini-3.1-pro-preview",
           "providerSlug": "google-ai-studio"
         },
         "creator": "Google",
@@ -176,8 +314,33 @@
         "releaseDate": "2026-05-01",
         "deprecated": false,
         "pricing": {
-          "inputToken": "\u2264200K tokens: $2.00 / 1M, >200K tokens: $4.00 / 1M, Cached: $0.20 / 1M",
-          "outputToken": "\u2264200K tokens: $12.00 / 1M, >200K tokens: $18.00 / 1M",
+          "inputToken": "≤200K tokens: $2.00 / 1M, >200K tokens: $4.00 / 1M, Cached: $0.20 / 1M",
+          "outputToken": "≤200K tokens: $12.00 / 1M, >200K tokens: $18.00 / 1M",
+          "link": "https://ai.google.dev/gemini-api/docs/pricing"
+        },
+        "supportBackendMode": 3
+      },
+      {
+        "name": "Gemini 3.5 Flash",
+        "modelKey": "gemini-3.5-flash",
+        "openHubRoute": {
+          "modelSlug": "google/gemini-3.5-flash",
+          "providerSlug": "google-ai-studio"
+        },
+        "creator": "Google",
+        "contextWindow": 1000000,
+        "maxOutputTokens": 16384,
+        "supportsReasoning": true,
+        "reasoningEfforts": [],
+        "supportsReasoningSummaries": false,
+        "supportsVerbosity": false,
+        "supportsImage": true,
+        "supportsWebSearch": true,
+        "releaseDate": "2026-05-19",
+        "deprecated": false,
+        "pricing": {
+          "inputToken": "$1.50 / 1M tokens, Cached: $0.15 / 1M tokens",
+          "outputToken": "$9.00 / 1M tokens",
           "link": "https://ai.google.dev/gemini-api/docs/pricing"
         },
         "supportBackendMode": 3
@@ -227,6 +390,53 @@
       }
     ]
   },
+  "moonshot": {
+    "id": "moonshot",
+    "name": "Kimi AI",
+    "apiKey": "",
+    "organization": null,
+    "baseUrl": "https://api.moonshot.ai/v1",
+    "defaultEfficientModelKey": "kimi-k3",
+    "version": null,
+    "headers": {},
+    "timeout": 30000,
+    "retryConfig": {
+      "maxRetries": 3,
+      "initialDelay": 1000,
+      "maxDelay": 10000,
+      "backoffMultiplier": 2
+    },
+    "models": [
+      {
+        "name": "Kimi K3",
+        "modelKey": "kimi-k3",
+        "openHubRoute": {
+          "modelSlug": "kimi/kimi-k3",
+          "providerSlug": "kimi"
+        },
+        "creator": "Kimi",
+        "contextWindow": 1048576,
+        "maxOutputTokens": 1048576,
+        "supportsReasoning": true,
+        "reasoningEfforts": [
+          "low",
+          "high",
+          "max"
+        ],
+        "supportsReasoningSummaries": false,
+        "supportsVerbosity": false,
+        "supportsImage": true,
+        "releaseDate": "2026-07-17",
+        "deprecated": false,
+        "pricing": {
+          "inputToken": "Cache Hit: $0.30 / 1M tokens, Cache Miss: $3.00 / 1M tokens",
+          "outputToken": "$15.00 / 1M tokens",
+          "link": "https://platform.kimi.ai/docs/pricing/chat-k3"
+        },
+        "supportBackendMode": 2
+      }
+    ]
+  },
   "anthropic": {
     "id": "anthropic",
     "name": "Anthropic",
@@ -268,6 +478,34 @@
         "pricing": {
           "inputToken": "$5.00 / 1M tokens, Cached: $0.50 / 1M tokens",
           "outputToken": "$25.00 / 1M tokens",
+          "link": "https://platform.claude.com/docs/en/about-claude/pricing"
+        },
+        "supportBackendMode": 0
+      },
+      {
+        "name": "Claude Sonnet 5",
+        "modelKey": "claude-sonnet-5",
+        "openHubRoute": {
+          "modelSlug": "anthropic/claude-sonnet-5",
+          "providerSlug": "anthropic"
+        },
+        "creator": "Anthropic",
+        "contextWindow": 1000000,
+        "maxOutputTokens": 128000,
+        "supportsReasoning": true,
+        "reasoningEfforts": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "supportsReasoningSummaries": false,
+        "supportsVerbosity": false,
+        "supportsImage": true,
+        "releaseDate": null,
+        "deprecated": false,
+        "pricing": {
+          "inputToken": "$3.00 / 1M tokens ($2.00 intro through 2026-08-31), Cached: $0.30 / 1M tokens",
+          "outputToken": "$15.00 / 1M tokens ($10.00 intro through 2026-08-31)",
           "link": "https://platform.claude.com/docs/en/about-claude/pricing"
         },
         "supportBackendMode": 0


### PR DESCRIPTION
## Summary
Audit of `src/core/models/providers/default.json` `openHubRoute` entries against the **prod gateway catalog** (queried `llm.models` / `llm.providers` / `llm.provider_model_endpoints` directly on 2026-07-24) and the helper remote catalog (`helper.airepublic.com/api/v1/workx/models`, which supplies the model picker; bundled entries supply the gateway route via the modelKey graft in `getDefaultProviders`). The gateway resolves model ids by exact string match against canonical `llm.models.slug` (plus explicit aliases — openhub#33 / data_store_lib#127), so every `modelSlug` here must match that column verbatim.

### Fixed (previously broken)
| Model | Was | Now | Why |
|---|---|---|---|
| xai grok | `x-ai/grok-4-1-fast-reasoning` | `grok-4.3` → `x-ai/grok-4.3`, `grok-4.5` → `xai/grok-4.5` | grok-4-1 was removed from prod and from the helper catalog |
| google gemini-3.1-pro | `google/gemini-3.1-pro` | `google/gemini-3.1-pro-preview` | old slug doesn't exist; preview row is the real one (draft upstream) |

### Added — helper-catalog models with **no** bundled route (selecting them threw "Gateway routing metadata is missing")
- `openai:gpt-5.6-sol/terra/luna` → `openai/gpt-5.6-*` (draft upstream)
- `google-ai-studio:gemini-3.5-flash` → `google/gemini-3.5-flash`
- `moonshot:kimi-k3` → `kimi/kimi-k3` (new provider block; serving provider `kimi`)
- `anthropic:claude-sonnet-5` → `anthropic/claude-sonnet-5` (draft upstream)

Draft-status upstream models are routed now so they start working the moment the catalog activates them; until then the gateway 400s them (same as today, minus the client-side metadata error).

`providerSlug` pins verified against **active** `llm.provider_model_endpoints` rows AND live-tested through the prod gateway (see below). One correction over the old file: **gpt-5.5/5.4 move from `azure` to `openai`** — the deployed gateway registers adapters only for `openai_chat_completions` (+ generic fallback) and `anthropic_messages`, so `azure_openai` endpoints can never be served; the openai first-party endpoint is the only servable one (currently health=unhealthy upstream, so these models 400 today regardless of pin — the openai pin makes them recover automatically when health does). opus-4-8/sonnet-4-6 stay on `deepinfra`. openai `defaultEfficientModelKey` stays `gpt-5.4`: the helper's pick (`gpt-5.6-luna`) is draft in prod and would break efficient-model fallback.

`modelCostTable.ts` gains hand-authored numeric rates for the 8 new keys (from their pricing prose; sonnet-5 at the standard non-intro rate); `grok-4-1-fast-reasoning` kept as a legacy row so historical usage records still cost correctly.

## Testing
- `npx vitest run src/config src/core/models` — **974 passed** (includes the updated route-map assertion listing every bundled route and the cost-table coverage test)
- `npx vitest run src/__tests__` — 100 passed
- `npm run type-check` — clean

## Live verification against prod gateway (2026-07-24)
Every route was also eligibility-checked in the prod DB (active endpoint + current price snapshot + provider secret_ref; enforcement mode = observe) and called end-to-end with the exact model+pin pair:

| Route | Result |
|---|---|
| `x-ai/grok-4.3` @ xai | ✅ 200 |
| `xai/grok-4.5` @ xai | ✅ 200 |
| `google/gemini-3.5-flash` @ google-ai-studio | ✅ 200 |
| `kimi/kimi-k3` @ kimi | ✅ 200 |
| `anthropic/claude-sonnet-4-6` @ deepinfra | ✅ 200 |
| `anthropic/claude-haiku-4.5` @ anthropic | ✅ 200 |
| `anthropic/claude-fable-5` @ anthropic | ✅ 200 |
| `deepseek/deepseek-v4-flash` @ deepseek | ✅ 200 |
| `openai/gpt-5.4` (either pin) | ⚠️ 400 today — openai endpoints unhealthy upstream; azure has no adapter (ops issue, not this PR) |
| draft models (gpt-5.6 trio, sonnet-5, gemini-3.1-pro-preview) | 400 until catalog activates them (expected) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
